### PR TITLE
chains checkout feature

### DIFF
--- a/chains/load.go
+++ b/chains/load.go
@@ -24,16 +24,3 @@ func IsChainRunning(chain *definitions.Chain) bool {
 	return true
 
 }
-
-// check if given chain is known
-func isKnownChain(name string) bool {
-	known := util.GetGlobalLevelConfigFilesByType("chains", false)
-	if len(known) != 0 {
-		for _, srv := range known {
-			if srv == name {
-				return true
-			}
-		}
-	}
-	return false
-}

--- a/commands/chains.go
+++ b/commands/chains.go
@@ -49,6 +49,8 @@ func buildChainsCommand() {
 	Chains.AddCommand(chainsImport)
 	Chains.AddCommand(chainsListKnown)
 	Chains.AddCommand(chainsList)
+	Chains.AddCommand(chainsCheckout)
+	Chains.AddCommand(chainsHead)
 	Chains.AddCommand(chainsEdit)
 	Chains.AddCommand(chainsStart)
 	Chains.AddCommand(chainsLogs)
@@ -138,6 +140,38 @@ To start a chain use: [eris chains start chainName].
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		ListChains()
+	},
+}
+
+var chainsCheckout = &cobra.Command{
+	Use:   "checkout",
+	Short: "Checks out a chain.",
+	Long: `Checks out a chain.
+
+Checkout if a convenience features. For any eris command
+which accepts a --chain or $chain variable, the checked
+out chain can replace manually passing in a --chain flag.
+If a --chain is passed to any command accepting --chain,
+the --chain which is passed will overwrite any checked
+out chain.
+
+If command is given without arguments it will clear the
+head and there will be no chain checked out.
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		CheckoutChain(cmd, args)
+	},
+}
+
+var chainsHead = &cobra.Command{
+	Use:   "current",
+	Short: "The currently checked out chain.",
+	Long: `The currently checked out chain.
+
+To checkout a new chain use eris chains checkout
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		CurrentChain()
 	},
 }
 
@@ -370,6 +404,20 @@ func ImportChain(cmd *cobra.Command, args []string) {
 	do.Name = args[0]
 	do.Path = args[1]
 	IfExit(chns.ImportChain(do))
+}
+
+// checkout a chain
+func CheckoutChain(cmd *cobra.Command, args []string) {
+	if len(args) >= 1 {
+		do.Name = args[0]
+	} else {
+		do.Name = ""
+	}
+	IfExit(chns.CheckoutChain(do))
+}
+
+func CurrentChain() {
+	IfExit(chns.CurrentChain(do))
 }
 
 // edit a chain definition file

--- a/commands/eris.go
+++ b/commands/eris.go
@@ -40,6 +40,7 @@ Complete documentation is available at https://docs.erisindustries.com
 
 		common.InitErisDir()
 		util.DockerConnect(do.Verbose, do.MachineName)
+		do.ChainName, _ = util.GetHead()
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		err := util.SaveGlobalConfig(util.GlobalConfig.Config)

--- a/perform/docker_stats.go
+++ b/perform/docker_stats.go
@@ -47,10 +47,20 @@ func PrintTableReport(typ string, running bool) error {
 		return nil
 	}
 
+	var head string
+	if typ == "chain" {
+		head, _ = util.GetHead()
+	}
+
 	table := tablewriter.NewWriter(util.GlobalConfig.Writer)
 	table.SetHeader([]string{"SERVICE NAME", "CONTAINER NAME", "TYPE", "CONTAINER #", "PORTS"})
 	for _, c := range conts {
 		n, _ := PrintLineByContainerName(c.FullName)
+		if typ == "chain" {
+			if n[0] == head {
+				n[0] = fmt.Sprintf("**  %s", n[0]) // TODO: colorize this when we settle on a lib
+			}
+		}
 		table.Append(n)
 	}
 

--- a/util/chains_info.go
+++ b/util/chains_info.go
@@ -1,0 +1,85 @@
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
+)
+
+// Maximum entries in the HEAD file
+var MaxHead = 100
+
+// check if given chain is known
+func IsKnownChain(name string) bool {
+	known := GetGlobalLevelConfigFilesByType("chains", false)
+	if len(known) != 0 {
+		for _, srv := range known {
+			if srv == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Change the head to null (no head)
+func NullHead() error {
+	return ChangeHead("")
+}
+
+// Get the current active chain (top of the HEAD file)
+// Returns chain name
+func GetHead() (string, error) {
+	// TODO: only read the one line!
+	f, err := ioutil.ReadFile(common.HEAD)
+	if err != nil {
+		return "", err
+	}
+
+	fspl := strings.Split(string(f), "\n")
+	head := fspl[0]
+
+	if head == "" {
+		return "", fmt.Errorf("There is no chain checked out")
+	}
+
+	return head, nil
+}
+
+// Add a new entry (name) to the top of the HEAD file
+// Expects the chain type and head (id) to be full (already resolved)
+func ChangeHead(name string) error {
+	if !IsKnownChain(name) && name != "" {
+		logger.Debugf("Chain name not known. Not saving.\n")
+		return nil
+	}
+
+	logger.Debugf("Chain name known (or blank). Saving to head file.\n")
+	// read in the entire head file and clip
+	// if we have reached the max length
+	b, err := ioutil.ReadFile(common.HEAD)
+	if err != nil {
+		return err
+	}
+	bspl := strings.Split(string(b), "\n")
+	var bsp string
+	if len(bspl) >= MaxHead {
+		bsp = strings.Join(bspl[:MaxHead-1], "\n")
+	} else {
+		bsp = string(b)
+	}
+
+	// add the new head
+	var s string
+	// handle empty head
+	s = name + "\n" + bsp
+	err = ioutil.WriteFile(common.HEAD, []byte(s), 0666)
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("Head file saved.\n")
+	return nil
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const VERSION = "0.10.0"
+const VERSION = "0.10.1"


### PR DESCRIPTION
this pr closes #71. It pulls in the checkout work from EPM along
with the head work. it builds on that effort by adding an ability
for the checkout chain to populate the default of the --chain flag.

* adds `eris chains current` for current chain
* adds `eris chains checkout` to change the current chain
* modifies printers to account for the checked out chain (TODO:
* colorize)