### PR TITLE
Chains new

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -17,7 +17,7 @@
 		},
 		{
 			"ImportPath": "github.com/ebuchman/go-shell-pipes",
-			"Rev": "83e1324808622485314bff0fd97b8b944200a7a4"
+			"Rev": "2b9ded3b4c5b2b156a970522c2a820ab9afe628c"
 		},
 		{
 			"ImportPath": "github.com/eris-ltd/common/go/common",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -21,11 +21,11 @@
 		},
 		{
 			"ImportPath": "github.com/eris-ltd/common/go/common",
-			"Rev": "aa66cb878cf35cc51d2c80a6ea3943870dc550d9"
+			"Rev": "f1266fd4cc903e0dbbc10fc69c3ded903f4530f9"
 		},
 		{
 			"ImportPath": "github.com/eris-ltd/common/go/log",
-			"Rev": "aa66cb878cf35cc51d2c80a6ea3943870dc550d9"
+			"Rev": "f1266fd4cc903e0dbbc10fc69c3ded903f4530f9"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient",

--- a/Godeps/_workspace/src/github.com/ebuchman/go-shell-pipes/exec.go
+++ b/Godeps/_workspace/src/github.com/ebuchman/go-shell-pipes/exec.go
@@ -69,17 +69,18 @@ func RunStrings(tokens ...string) (string, error) {
 }
 
 // Pipe stdout of each command into stdin of next
+// XXX: writing all the sterrs to the same writer causes race condition ... duh!
 func AssemblePipes(cmds []*exec.Cmd, stdin io.Reader, stdout io.Writer) []*exec.Cmd {
 	cmds[0].Stdin = stdin
-	cmds[0].Stderr = stdout
+	//cmds[0].Stderr = stdout
 	// assemble pipes
 	for i, c := range cmds {
 		if i < len(cmds)-1 {
 			cmds[i+1].Stdin, _ = c.StdoutPipe()
-			cmds[i+1].Stderr = stdout
+			//		cmds[i+1].Stderr = stdout
 		} else {
 			c.Stdout = stdout
-			c.Stderr = stdout
+			//		c.Stderr = stdout
 		}
 	}
 	return cmds
@@ -88,17 +89,13 @@ func AssemblePipes(cmds []*exec.Cmd, stdin io.Reader, stdout io.Writer) []*exec.
 // Run series of piped commands
 func RunCmds(cmds []*exec.Cmd) error {
 	// start processes in descending order
-	for i := len(cmds) - 1; i > 0; i-- {
+	for i := len(cmds) - 1; i >= 0; i-- {
 		if err := cmds[i].Start(); err != nil {
 			return err
 		}
 	}
-	// run the first process
-	if err := cmds[0].Run(); err != nil {
-		return err
-	}
-	// wait on processes in ascending order
-	for i := 1; i < len(cmds); i++ {
+	// wait on processes in descending order
+	for i := len(cmds) - 1; i >= 0; i-- {
 		if err := cmds[i].Wait(); err != nil {
 			return err
 		}

--- a/Godeps/_workspace/src/github.com/eris-ltd/common/go/common/dirs_and_files.go
+++ b/Godeps/_workspace/src/github.com/eris-ltd/common/go/common/dirs_and_files.go
@@ -160,7 +160,18 @@ func Copy(src, dst string) error {
 		return err
 	}
 	if f.IsDir() {
-		return copyDir(src, dst)
+		tmpDir, err := ioutil.TempDir(os.TempDir(), "golang-copy")
+		if err != nil {
+			return err
+		}
+		if err := copyDir(src, tmpDir); err != nil {
+			return err
+		}
+		fi, err := os.Stat(src)
+		if err := os.MkdirAll(dst, fi.Mode()); err != nil {
+			return err
+		}
+		return os.Rename(tmpDir, dst)
 	}
 	return copyFile(src, dst)
 }

--- a/Godeps/_workspace/src/github.com/eris-ltd/common/go/common/numbers.go
+++ b/Godeps/_workspace/src/github.com/eris-ltd/common/go/common/numbers.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"math/big"
+)
+
+var tt256 = new(big.Int).Lsh(big.NewInt(1), 256)
+var tt256m1 = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
+var tt255 = new(big.Int).Lsh(big.NewInt(1), 255)
+
+func U256(x *big.Int) *big.Int {
+	//if x.Cmp(Big0) < 0 {
+	//		return new(big.Int).Add(tt256, x)
+	//	}
+
+	x.And(x, tt256m1)
+
+	return x
+}
+
+func S256(x *big.Int) *big.Int {
+	if x.Cmp(tt255) < 0 {
+		return x
+	} else {
+		// We don't want to modify x, ever
+		return new(big.Int).Sub(x, tt256)
+	}
+}

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -38,9 +38,9 @@ func TestMain(m *testing.M) {
 	var logLevel log.LogLevel
 	var err error
 
-	//logLevel = 0
+	logLevel = 0
 	// logLevel = 1
-	logLevel = 3
+	// logLevel = 3
 
 	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
 

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -108,7 +108,7 @@ func TestChainGraduate(t *testing.T) {
 		t.Fail()
 	}
 
-	if len(srvDef.ServiceDeps) != 1 {
+	if len(srvDef.ServiceDeps.Dependencies) != 1 {
 		logger.Errorf("FAILURE: improper service deps on GRADUATE. expected: [\"keys\"]\tgot: %s\n", srvDef.ServiceDeps)
 		t.Fail()
 	}

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
+	"github.com/eris-ltd/eris-cli/data"
 	def "github.com/eris-ltd/eris-cli/definitions"
 	ini "github.com/eris-ltd/eris-cli/initialize"
 	"github.com/eris-ltd/eris-cli/loaders"
@@ -16,34 +16,44 @@ import (
 	"github.com/eris-ltd/eris-cli/version"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
 )
 
 var erisDir string = path.Join(os.TempDir(), "eris")
-var chainName string = "testchain"
+var chainName string = "my_tests" // :(
 var hash string
+
+var DEAD bool // XXX: don't double panic (TODO: Flushing twice blocks)
+
+func fatal(t *testing.T, err error) {
+	if !DEAD {
+		log.Flush()
+		testsTearDown()
+		DEAD = true
+		panic(err)
+	}
+}
 
 func TestMain(m *testing.M) {
 	var logLevel log.LogLevel
 	var err error
 
-	logLevel = 0
+	//logLevel = 0
 	// logLevel = 1
-	// logLevel = 2
+	logLevel = 3
 
 	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
 
 	testsInit()
-	logger.Infoln("Test init completed. Starting main test sequence now.")
+	logger.Infoln("Test init completed. Starting main test sequence now.\n")
 
 	exitCode := m.Run()
 
 	logger.Infoln("Commensing with Tests Tear Down.")
-	if os.Getenv("TEST_IN_CIRCLE") != "true" {
-		err = testsTearDown()
-		if err != nil {
-			logger.Errorln(err)
-			os.Exit(1)
-		}
+	err = testsTearDown()
+	if err != nil {
+		logger.Errorln(err)
+		os.Exit(1)
 	}
 
 	os.Exit(exitCode)
@@ -55,65 +65,42 @@ func TestKnownChain(t *testing.T) {
 
 	k := strings.Split(do.Result, "\n") // tests output formatting.
 
-	if k[0] != "" {
+	if k[0] != chainName {
 		logger.Debugf("Result =>\t\t%s\n", do.Result)
 		ifExit(fmt.Errorf("Found a chain definition file. Something is wrong."))
 	}
 }
 
-func TestNewChain(t *testing.T) {
-	do := def.NowDo()
-	do.GenesisFile = path.Join(common.BlockchainsPath, "config", "default", "genesis.json")
-	do.Name = chainName
-	do.Operations.ContainerNumber = 1
-	logger.Infof("Creating chain (from tests) =>\t%s\n", do.Name)
-	e := NewChain(do) // configFile and dir are not needed for the tests.
-	if e != nil {
-		fmt.Println(e)
-		t.Fail()
-	}
-}
-
 func TestChainGraduate(t *testing.T) {
-
 	do := def.NowDo()
 	do.Name = chainName
 	logger.Infof("Graduating chain (from tests) ==>\t%s\n", do.Name)
-	g := GraduateChain(do)
-	if g != nil {
-		fmt.Println(g)
-		t.FailNow()
+	if err := GraduateChain(do); err != nil {
+		fatal(t, err)
 	}
 
-	srvDef, err := loaders.LoadServiceDefinition("my_tests", false, 1)
+	srvDef, err := loaders.LoadServiceDefinition(chainName, false, 1)
 	if err != nil {
-		logger.Errorln(err)
-		t.Fail()
+		fatal(t, err)
 	}
 
 	vers := strings.Join(strings.Split(version.VERSION, ".")[0:2], ".")
 	image := "eris/erisdb:" + vers
 	if srvDef.Service.Image != image {
-		logger.Errorf("FAILURE: improper service image on GRADUATE. expected: %s\tgot: %s\n", image, srvDef.Service.Image)
-		t.Fail()
+		fatal(t, fmt.Errorf("FAILURE: improper service image on GRADUATE. expected: %s\tgot: %s\n", image, srvDef.Service.Image))
 	}
 
 	if srvDef.Service.Command != loaders.ErisChainStart {
-		logger.Errorf("FAILURE: improper service command on GRADUATE. expected: %s\tgot: %s\n", loaders.ErisChainStart, srvDef.Service.Command)
-		t.Fail()
+		fatal(t, fmt.Errorf("FAILURE: improper service command on GRADUATE. expected: %s\tgot: %s\n", loaders.ErisChainStart, srvDef.Service.Command))
 	}
 
 	if !srvDef.Service.AutoData {
-		logger.Errorf("FAILURE: improper service autodata on GRADUATE. expected: %t\tgot: %t\n", true, srvDef.Service.AutoData)
-		t.Fail()
+		fatal(t, fmt.Errorf("FAILURE: improper service autodata on GRADUATE. expected: %t\tgot: %t\n", true, srvDef.Service.AutoData))
 	}
 
 	if len(srvDef.ServiceDeps.Dependencies) != 1 {
-		logger.Errorf("FAILURE: improper service deps on GRADUATE. expected: [\"keys\"]\tgot: %s\n", srvDef.ServiceDeps)
-		t.Fail()
+		fatal(t, fmt.Errorf("FAILURE: improper service deps on GRADUATE. expected: [\"keys\"]\tgot: %s\n", srvDef.ServiceDeps))
 	}
-
-	//	testExistAndRun(t, chainName, true, true)
 }
 
 func TestLoadChainDefinition(t *testing.T) {
@@ -121,41 +108,31 @@ func TestLoadChainDefinition(t *testing.T) {
 	logger.Infof("Load chain def (from tests) =>\t%s\n", chainName)
 	chn, e := loaders.LoadChainDefinition(chainName, false, 1)
 	if e != nil {
-		logger.Errorln(e)
-		t.FailNow()
+		fatal(t, e)
 	}
 
 	if chn.Service.Name != chainName {
-		logger.Errorln("FAILURE: improper service name on LOAD. expected: %s\tgot: %s", chainName, chn.Service.Name)
-		t.FailNow()
+		fatal(t, fmt.Errorf("FAILURE: improper service name on LOAD. expected: %s\tgot: %s", chainName, chn.Service.Name))
 	}
 
 	if !chn.Service.AutoData {
-		logger.Errorln("FAILURE: data_container not properly read on LOAD.")
-		t.FailNow()
+		fatal(t, fmt.Errorf("FAILURE: data_container not properly read on LOAD."))
 	}
 
 	if chn.Operations.DataContainerName == "" {
-		logger.Errorln("FAILURE: data_container_name not set.")
-		t.Fail()
+		fatal(t, fmt.Errorf("FAILURE: data_container_name not set."))
 	}
 }
 
-func TestStartChain(t *testing.T) {
-	do := def.NowDo()
-	do.Name = chainName
-	do.Operations.ContainerNumber = 1
-	logger.Infof("Starting chain (from tests) =>\t%s\n", do.Name)
-	e := StartChain(do)
-	if e != nil {
-		logger.Errorln(e)
-		t.Fail()
-	}
-
-	testExistAndRun(t, chainName, true, true)
+func TestStartKillChain(t *testing.T) {
+	testStartChain(t, chainName)
+	testKillChain(t, chainName)
 }
 
 func TestLogsChain(t *testing.T) {
+	testStartChain(t, chainName)
+	defer testKillChain(t, chainName)
+
 	do := def.NowDo()
 	do.Name = chainName
 	do.Follow = false
@@ -163,16 +140,13 @@ func TestLogsChain(t *testing.T) {
 	logger.Infof("Get chain logs (from tests) =>\t%s:%s\n", do.Name, do.Tail)
 	e := LogsChain(do)
 	if e != nil {
-		logger.Errorln(e)
-		t.Fail()
+		fatal(t, e)
 	}
 }
 
 func TestUpdateChain(t *testing.T) {
-	if os.Getenv("TEST_IN_CIRCLE") == "true" {
-		logger.Println("Testing in Circle. Where we don't have rm privileges (due to their driver). Skipping test.")
-		return
-	}
+	testStartChain(t, chainName)
+	defer testKillChain(t, chainName)
 
 	do := def.NowDo()
 	do.Name = chainName
@@ -180,19 +154,15 @@ func TestUpdateChain(t *testing.T) {
 	logger.Infof("Updating chain (from tests) =>\t%s\n", do.Name)
 	e := UpdateChain(do)
 	if e != nil {
-		logger.Errorln(e)
-		t.Fail()
+		fatal(t, e)
 	}
 
 	testExistAndRun(t, chainName, true, true)
 }
 
 func TestInspectChain(t *testing.T) {
-	// log.SetLoggers(3, os.Stdout, os.Stderr)
-	if os.Getenv("TEST_IN_CIRCLE") == "true" {
-		logger.Println("Testing in Circle. Where we don't have rm privileges (due to their driver). Skipping test.")
-		return
-	}
+	testStartChain(t, chainName)
+	defer testKillChain(t, chainName)
 
 	do := def.NowDo()
 	do.Name = chainName
@@ -201,73 +171,38 @@ func TestInspectChain(t *testing.T) {
 	logger.Debugf("Inspect chain (via tests) =>\t%s:%v\n", chainName, do.Args)
 	e := InspectChain(do)
 	if e != nil {
-		logger.Infof("Error inspecting chain =>\t%v\n", e)
-		t.FailNow()
+		fatal(t, fmt.Errorf("Error inspecting chain =>\t%v\n", e))
 	}
 	// log.SetLoggers(0, os.Stdout, os.Stderr)
 }
 
 func TestRenameChain(t *testing.T) {
+	oldName := chainName
+	newName := "niahctset"
+	testStartChain(t, oldName)
+	defer testKillChain(t, oldName)
+
 	do := def.NowDo()
-	do.Name = chainName
-	do.NewName = "niahctset"
+	do.Name = oldName
+	do.NewName = newName
 	logger.Infof("Renaming chain (from tests) =>\t%s:%s\n", do.Name, do.NewName)
 	e := RenameChain(do)
 	if e != nil {
-		logger.Errorln(e)
-		t.Fail()
+		fatal(t, e)
 	}
 
-	testExistAndRun(t, "niahctset", true, true)
+	testExistAndRun(t, newName, true, true)
 
 	do = def.NowDo()
-	do.Name = "niahctset"
+	do.Name = newName
 	do.NewName = chainName
 	logger.Infof("Renaming chain (from tests) =>\t%s:%s\n", do.Name, do.NewName)
 	e = RenameChain(do)
 	if e != nil {
-		logger.Errorln(e)
-		t.Fail()
+		fatal(t, e)
 	}
 
 	testExistAndRun(t, chainName, true, true)
-}
-
-func TestKillChain(t *testing.T) {
-	// log.SetLoggers(2, os.Stdout, os.Stderr)
-	testExistAndRun(t, chainName, true, true)
-
-	do := def.NowDo()
-	do.Args = []string{"keys"}
-	if os.Getenv("TEST_IN_CIRCLE") != "true" {
-		do.Rm = true
-		do.RmD = true
-	}
-	logger.Infof("Removing keys (from tests) =>\n%s\n", do.Name)
-	e := services.KillService(do)
-	if e != nil {
-		logger.Errorln(e)
-		t.Fail()
-	}
-
-	do = def.NowDo()
-	do.Name = chainName
-	if os.Getenv("TEST_IN_CIRCLE") != "true" {
-		do.Rm = true
-		do.RmD = true
-	}
-	logger.Infof("Stopping chain (from tests) =>\t%s\n", do.Name)
-	e = KillChain(do)
-	if e != nil {
-		logger.Errorln(e)
-		t.Fail()
-	}
-	if os.Getenv("TEST_IN_CIRCLE") != "true" {
-		testExistAndRun(t, chainName, false, false)
-	} else {
-		testExistAndRun(t, chainName, true, false)
-	}
-	// log.SetLoggers(0, os.Stdout, os.Stderr)
 }
 
 // TODO: finish this....
@@ -286,22 +221,69 @@ func TestKillChain(t *testing.T) {
 // }
 
 func TestRmChain(t *testing.T) {
-	if os.Getenv("TEST_IN_CIRCLE") == "true" {
-		logger.Println("Testing in Circle. Where we don't have rm privileges (due to their driver). Skipping test.")
-		return
-	}
+	testStartChain(t, chainName)
 
 	do := def.NowDo()
+	do.Args, do.Rm, do.RmD = []string{"keys"}, true, true
+	logger.Infof("Removing keys (from tests) =>\n%s\n", do.Name)
+	if e := services.KillService(do); e != nil {
+		fatal(t, e)
+	}
+
+	do = def.NowDo()
+	do.Name, do.Rm, do.RmD = chainName, false, false
+	logger.Infof("Stopping chain (from tests) =>\t%s\n", do.Name)
+	if e := KillChain(do); e != nil {
+		fatal(t, e)
+	}
+	testExistAndRun(t, chainName, true, false)
+
+	do = def.NowDo()
 	do.Name = chainName
 	do.RmD = true
 	logger.Infof("Removing chain (from tests) =>\n%s\n", do.Name)
 	e := RmChain(do)
 	if e != nil {
-		logger.Errorln(e)
-		t.Fail()
+		fatal(t, e)
 	}
 
 	testExistAndRun(t, chainName, false, false)
+}
+
+//------------------------------------------------------------------
+// testing utils
+
+func testStartChain(t *testing.T, chain string) {
+	do := def.NowDo()
+	do.Name = chain
+	do.Operations.ContainerNumber = 1
+	logger.Infof("Starting chain (from tests) =>\t%s\n", do.Name)
+	e := StartChain(do)
+	if e != nil {
+		logger.Errorln(e)
+		fatal(t, nil)
+	}
+	testExistAndRun(t, chain, true, true)
+}
+
+func testKillChain(t *testing.T, chain string) {
+	// log.SetLoggers(2, os.Stdout, os.Stderr)
+	testExistAndRun(t, chain, true, true)
+
+	do := def.NowDo()
+	do.Args, do.Rm, do.RmD = []string{"keys"}, true, true
+	logger.Infof("Removing keys (from tests) =>\n%s\n", do.Name)
+	if e := services.KillService(do); e != nil {
+		fatal(t, e)
+	}
+
+	do = def.NowDo()
+	do.Name, do.Rm, do.RmD = chain, true, true
+	logger.Infof("Stopping chain (from tests) =>\t%s\n", do.Name)
+	if e := KillChain(do); e != nil {
+		fatal(t, e)
+	}
+	testExistAndRun(t, chain, false, false)
 }
 
 func testExistAndRun(t *testing.T, chainName string, toExist, toRun bool) {
@@ -313,8 +295,7 @@ func testExistAndRun(t *testing.T, chainName string, toExist, toRun bool) {
 	do.Quiet = true
 	do.Args = []string{"testing"}
 	if err := ListExisting(do); err != nil {
-		logger.Errorln(err)
-		t.FailNow()
+		fatal(t, err)
 	}
 	res := strings.Split(do.Result, "\n")
 	for _, r := range res {
@@ -328,8 +309,7 @@ func testExistAndRun(t *testing.T, chainName string, toExist, toRun bool) {
 	do.Quiet = true
 	do.Args = []string{"testing"}
 	if err := ListRunning(do); err != nil {
-		logger.Errorln(err)
-		t.FailNow()
+		fatal(t, err)
 	}
 	res = strings.Split(do.Result, "\n")
 	for _, r := range res {
@@ -345,7 +325,7 @@ func testExistAndRun(t *testing.T, chainName string, toExist, toRun bool) {
 		} else {
 			logger.Infof("Found an existing instance of %s when I shouldn't have\n", chainName)
 		}
-		t.Fail()
+		fatal(t, nil)
 	}
 
 	if toRun != run {
@@ -354,7 +334,7 @@ func testExistAndRun(t *testing.T, chainName string, toExist, toRun bool) {
 		} else {
 			logger.Infof("Found a running instance of %s when I shouldn't have\n", chainName)
 		}
-		t.Fail()
+		fatal(t, nil)
 	}
 
 	logger.Debugln("")
@@ -383,7 +363,22 @@ func testsInit() error {
 		ifExit(fmt.Errorf("TRAGIC. Could not initialize the eris dir.\n"))
 	}
 
+	// lay a chain service def
+	testNewChain(chainName)
+
 	return nil
+}
+
+func testNewChain(chain string) {
+	do := def.NowDo()
+	do.GenesisFile = path.Join(common.BlockchainsPath, "config", "default", "genesis.json")
+	do.Name = chain
+	do.Operations.ContainerNumber = 1
+	logger.Infof("Creating chain (from tests) =>\t%s\n", do.Name)
+	ifExit(NewChain(do)) // configFile and dir are not needed for the tests.
+
+	// remove the data container
+	ifExit(data.RmData(do))
 }
 
 func testsTearDown() error {

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -265,10 +265,12 @@ func UpdateChain(do *definitions.Do) error {
 		return err
 	}
 
-	// DockerRebuild is built for services, adding false to the final
-	//   variable will mean it pulls. But we want the opposite default
-	//   behaviour for chains as we do for services in this regard
-	//   so we flip the variable.
+	// if the chain is already running we need to set the right env vars and command
+	if IsChainRunning(chain) {
+		chain.Service.Environment = []string{fmt.Sprintf("CHAIN_ID=%s", do.Name)}
+		chain.Service.Command = loaders.ErisChainStart
+	}
+
 	err = perform.DockerRebuild(chain.Service, chain.Operations, do.SkipPull, do.Timeout)
 	if err != nil {
 		return err

--- a/chains/operate.go
+++ b/chains/operate.go
@@ -24,7 +24,7 @@ import (
 func NewChain(do *definitions.Do) error {
 	// read chainID from genesis. genesis may be in dir
 	// if no genesis or no genesis.chain_id, chainID = name
-	var err error
+	/*var err error
 	if do.GenesisFile = resolveGenesisFile(do.GenesisFile, do.Path); do.GenesisFile == "" {
 		do.ChainID = do.Name
 	} else {
@@ -32,7 +32,10 @@ func NewChain(do *definitions.Do) error {
 		if err != nil {
 			return err
 		}
-	}
+	}*/
+
+	// for now we just let setupChain force do.ChainID = do.Name
+	// and we overwrite using jq in the container
 	logger.Debugf("Starting Setup for ChnID =>\t%s\n", do.ChainID)
 	return setupChain(do, loaders.ErisChainNew)
 }
@@ -264,7 +267,7 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 		fmt.Sprintf("CONTAINER_NAME=%s", containerName),
 		fmt.Sprintf("RUN=%v", do.Run),
 		fmt.Sprintf("GENERATE_GENESIS=%v", genGen),
-		fmt.Sprintf("CSV=%v", csvFile),
+		fmt.Sprintf("CSV=/home/eris/.eris/blockchains/%s/%s", do.ChainID, csvFile),
 		fmt.Sprintf("CONFIG_OPTS=%s", configOpts),
 	}
 

--- a/chains/operate.go
+++ b/chains/operate.go
@@ -184,6 +184,9 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 	// TODO: deal with do.Operations.ContainerNumbers ....!
 	// we probably need to update Import
 
+	logger.Debugln("container destination:", containerDst)
+	logger.Debugln("local destination:", dst)
+
 	if err = os.MkdirAll(dst, 0700); err != nil {
 		return fmt.Errorf("Error making data directory: %v", err)
 	}
@@ -328,6 +331,7 @@ type stringPair struct {
 func copyFiles(dst string, files []stringPair) error {
 	for _, f := range files {
 		if f.key != "" {
+			logger.Debugf("copying files from %s to %s\n", f.key, path.Join(dst, f.value))
 			if err := Copy(f.key, path.Join(dst, f.value)); err != nil {
 				return err
 			}

--- a/chains/operate.go
+++ b/chains/operate.go
@@ -1,6 +1,7 @@
 package chains
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -18,7 +19,6 @@ import (
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid"
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/tcnksm/go-gitconfig"
 )
 
 func NewChain(do *definitions.Do) error {
@@ -44,6 +44,8 @@ func InstallChain(do *definitions.Do) error {
 func StartChain(do *definitions.Do) error {
 	logger.Infoln("Ensuring Key Server is Started.")
 	//should it take a flag? keys server may be running another cNum
+	// XXX: currently we don't use or need a key server.
+	// plus this should be specified in a service def anyways
 	keysService, err := loaders.LoadServiceDefinition("keys", false, 1)
 	if err != nil {
 		return err
@@ -115,6 +117,7 @@ func KillChain(do *definitions.Do) error {
 	return nil
 }
 
+// Throw away chains are used for eris contracts
 func ThrowAwayChain(do *definitions.Do) error {
 	do.Name = do.Name + "_" + strings.Split(uuid.New(), "-")[0]
 	do.Path = filepath.Join(ChainsConfigPath, "default")
@@ -154,7 +157,7 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 		do.ChainID = do.Name
 	}
 
-	// do.Run containers and exit (creates data container)
+	// ensure/create data container
 	if !data.IsKnown(containerName) {
 		if err := perform.DockerCreateDataContainer(do.Name, do.Operations.ContainerNumber); err != nil {
 			return fmt.Errorf("Error creating data containr =>\t%v", err)
@@ -169,12 +172,13 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 			logger.Infof("Error on setupChain =>\t\t%v\n", err)
 			logger.Infoln("Cleaning up...")
 			if err2 := RmChain(do); err2 != nil {
+				// maybe be less dramatic
 				err = fmt.Errorf("Tragic! Our marmots encountered an error during setupChain for %s.\nThey also failed to cleanup after themselves (remove containers) due to another error.\nFirst error =>\t\t\t%v\nCleanup error =>\t\t%v\n", containerName, err, err2)
 			}
 		}
 	}()
 
-	// copy do.Path, do.GenesisFile, config into container
+	// copy do.Path, do.GenesisFile, do.ConfigFile, do.Priv, do.CSV into container
 	containerDst := path.Join("blockchains", do.Name)           // path in container
 	dst := path.Join(DataContainersPath, do.Name, containerDst) // path on host
 	// TODO: deal with do.Operations.ContainerNumbers ....!
@@ -184,23 +188,19 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 		return fmt.Errorf("Error making data directory: %v", err)
 	}
 
-	if do.Path != "" {
-		if err = Copy(do.Path, dst); err != nil {
-			return err
-		}
-	}
-	if do.GenesisFile != "" {
-		if err = Copy(do.GenesisFile, path.Join(dst, "genesis.json")); err != nil {
-			return err
-		}
-	} else {
-		// TODO: do.Run mintgen and open the do.GenesisFile in editor
+	var csvFile string
+	if do.CSV != "" {
+		csvFile = "genesis.csv"
 	}
 
-	if do.ConfigFile != "" {
-		if err = Copy(do.ConfigFile, path.Join(dst, "config."+path.Ext(do.ConfigFile))); err != nil {
-			return err
-		}
+	if err := copyFiles(dst, []stringPair{
+		stringPair{do.Path, ""},
+		stringPair{do.GenesisFile, "genesis.json"},
+		stringPair{do.ConfigFile, "config.toml"},
+		stringPair{do.Priv, "priv_validator.json"},
+		stringPair{do.CSV, csvFile},
+	}); err != nil {
+		return err
 	}
 
 	// copy from host to container
@@ -214,20 +214,11 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 
 	chain := loaders.MockChainDefinition(do.Name, do.ChainID, false, do.Operations.ContainerNumber)
 
-	//get maintainer info
-	uName, err := gitconfig.Username()
+	//set maintainer info
+	chain.Maintainer.Name, chain.Maintainer.Email, err = util.GitConfigUser()
 	if err != nil {
-		logger.Debugf("Could not find git user.name, setting chain.Maintainer.Name = \"\"")
-		uName = ""
+		logger.Debugf(err.Error())
 	}
-	email, err := gitconfig.Email()
-	if err != nil {
-		logger.Debugf("Could not find git user.email, setting chain.Maintainer.Email = \"\"")
-		email = ""
-	}
-
-	chain.Maintainer.Name = uName
-	chain.Maintainer.Email = email
 
 	// write the chain definition file ...
 	fileName := filepath.Join(BlockchainsPath, do.Name) + ".toml"
@@ -253,19 +244,33 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 		genGen = true
 	}
 
+	// write the list of <key>:<value> config options as flags
+	buf := new(bytes.Buffer)
+	for _, cv := range do.ConfigOpts {
+		spl := strings.Split(cv, ":")
+		if len(spl) != 2 {
+			return fmt.Errorf("Config options should be <key>:<value> pairs. Got %s", cv)
+		}
+		buf.WriteString(fmt.Sprintf(" --%s=%s", spl[0], spl[1]))
+	}
+	configOpts := string(buf.Bytes())
+
 	// set chainid and other vars
 	envVars := []string{
-		"CHAIN_ID=" + do.ChainID,
-		"CONTAINER_NAME=" + containerName,
+		fmt.Sprintf("CHAIN_ID=%s", do.ChainID),
+		fmt.Sprintf("CONTAINER_NAME=%s", containerName),
 		fmt.Sprintf("RUN=%v", do.Run),
 		fmt.Sprintf("GENERATE_GENESIS=%v", genGen),
+		fmt.Sprintf("CSV=%v", csvFile),
+		fmt.Sprintf("CONFIG_OPTS=%s", configOpts),
 	}
 
 	logger.Debugf("Set env vars from setupChain =>\t%v\n", envVars)
 	for _, eV := range envVars {
 		chain.Service.Environment = append(chain.Service.Environment, eV)
 	}
-	// TODO mint vs. erisdb (in terms of rpc)
+
+	// TODO: if do.N > 1 ...
 
 	chain.Operations.DataContainerName = util.DataContainersName(do.Name, do.Operations.ContainerNumber)
 
@@ -313,4 +318,20 @@ func getChainIDFromGenesis(genesis, name string) (string, error) {
 		chainID = name
 	}
 	return chainID, nil
+}
+
+type stringPair struct {
+	key   string
+	value string
+}
+
+func copyFiles(dst string, files []stringPair) error {
+	for _, f := range files {
+		if f.key != "" {
+			if err := Copy(f.key, path.Join(dst, f.value)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/commands/chains.go
+++ b/commands/chains.go
@@ -327,7 +327,7 @@ Command will cat local chains definition file.`,
 func addChainsFlags() {
 	chainsNew.PersistentFlags().StringVarP(&do.GenesisFile, "genesis", "g", "", "genesis.json file")
 	chainsNew.PersistentFlags().StringVarP(&do.ConfigFile, "config", "c", "", "config.toml file")
-	chainsNew.PersistentFlags().StringSliceVarP(&do.ConfigOpts, "options", "", nil, "space separated <key>:<value> pairs to set in config.toml")
+	chainsNew.PersistentFlags().StringSliceVarP(&do.ConfigOpts, "options", "", nil, "space separated <key>=<value> pairs to set in config.toml")
 	chainsNew.PersistentFlags().StringVarP(&do.Path, "dir", "", "", "a directory whose contents should be copied into the chain's main dir")
 	chainsNew.PersistentFlags().StringVarP(&do.CSV, "csv", "", "", "render a genesis.json from a csv file")
 	chainsNew.PersistentFlags().StringVarP(&do.Priv, "priv", "", "", "pass in a priv_validator.json file (dev-only!)")

--- a/commands/chains.go
+++ b/commands/chains.go
@@ -326,8 +326,12 @@ Command will cat local chains definition file.`,
 
 func addChainsFlags() {
 	chainsNew.PersistentFlags().StringVarP(&do.GenesisFile, "genesis", "g", "", "genesis.json file")
-	chainsNew.PersistentFlags().StringVarP(&do.ConfigFile, "config", "c", "", "main config file for the chain")
+	chainsNew.PersistentFlags().StringVarP(&do.ConfigFile, "config", "c", "", "config.toml file")
+	chainsNew.PersistentFlags().StringSliceVarP(&do.ConfigOpts, "options", "", nil, "space separated <key>:<value> pairs to set in config.toml")
 	chainsNew.PersistentFlags().StringVarP(&do.Path, "dir", "", "", "a directory whose contents should be copied into the chain's main dir")
+	chainsNew.PersistentFlags().StringVarP(&do.CSV, "csv", "", "", "render a genesis.json from a csv file")
+	chainsNew.PersistentFlags().StringVarP(&do.Priv, "priv", "", "", "pass in a priv_validator.json file (dev-only!)")
+	chainsNew.PersistentFlags().UintVarP(&do.N, "N", "", 1, "make a new genesis.json with this many validators and create data containers for each")
 	chainsNew.PersistentFlags().BoolVarP(&do.Run, "run", "r", false, "run the chain after creating")
 
 	chainsInstall.PersistentFlags().StringVarP(&do.ConfigFile, "config", "c", "", "main config file for the chain")

--- a/commands/data.go
+++ b/commands/data.go
@@ -173,7 +173,7 @@ func InspectData(cmd *cobra.Command, args []string) {
 
 func RmData(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "ge", cmd, args))
-	do.Name = args[0]
+	do.Args = args
 	IfExit(data.RmData(do))
 }
 

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -23,7 +23,7 @@ func TestMain(m *testing.M) {
 
 	logLevel = 0
 	// logLevel = 1
-	// logLevel = 2
+	logLevel = 3
 
 	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
 

--- a/data/manage.go
+++ b/data/manage.go
@@ -49,32 +49,35 @@ func InspectData(do *definitions.Do) error {
 	return nil
 }
 
-func RmData(do *definitions.Do) error {
-	if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
-		logger.Infoln("Removing data container " + do.Name)
+// XXX: what to do with error if only some (not all) are removed
+func RmData(do *definitions.Do) (err error) {
+	for _, name := range do.Args {
+		do.Name = name
+		if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
+			logger.Infoln("Removing data container " + do.Name)
 
-		srv := definitions.BlankServiceDefinition()
-		srv.Operations.SrvContainerName = util.ContainersName("data", do.Name, do.Operations.ContainerNumber)
+			srv := definitions.BlankServiceDefinition()
+			srv.Operations.SrvContainerName = util.ContainersName("data", do.Name, do.Operations.ContainerNumber)
 
-		err := perform.DockerRemove(srv.Service, srv.Operations, false)
-		if err != nil {
-			return err
+			if err = perform.DockerRemove(srv.Service, srv.Operations, false); err != nil {
+				logger.Errorf("Error removing %s: %v", do.Name, err)
+			}
+
+		} else {
+			err = fmt.Errorf("I cannot find that data container for %s. Please check the data container name you sent me.", do.Name)
+			logger.Errorln(err)
 		}
 
-	} else {
-		return fmt.Errorf("I cannot find that data container. Please check the data container name you sent me.")
-	}
-
-	if do.RmHF {
-		logger.Println("Removing host folder " + do.Name)
-		err := os.RemoveAll(path.Join(DataContainersPath, do.Name))
-		if err != nil {
-			return err
+		if do.RmHF {
+			logger.Println("Removing host folder " + do.Name)
+			if err = os.RemoveAll(path.Join(DataContainersPath, do.Name)); err != nil {
+				return err
+			}
 		}
 	}
 
 	do.Result = "success"
-	return nil
+	return err
 }
 
 func ListKnown(do *definitions.Do) error {

--- a/data/manage.go
+++ b/data/manage.go
@@ -49,8 +49,11 @@ func InspectData(do *definitions.Do) error {
 	return nil
 }
 
-// XXX: what to do with error if only some (not all) are removed
+// TODO: skip errors flag
 func RmData(do *definitions.Do) (err error) {
+	if len(do.Args) == 0 {
+		do.Args = []string{do.Name}
+	}
 	for _, name := range do.Args {
 		do.Name = name
 		if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
@@ -61,11 +64,13 @@ func RmData(do *definitions.Do) (err error) {
 
 			if err = perform.DockerRemove(srv.Service, srv.Operations, false); err != nil {
 				logger.Errorf("Error removing %s: %v", do.Name, err)
+				return err
 			}
 
 		} else {
 			err = fmt.Errorf("I cannot find that data container for %s. Please check the data container name you sent me.", do.Name)
 			logger.Errorln(err)
+			return err
 		}
 
 		if do.RmHF {

--- a/data/operate.go
+++ b/data/operate.go
@@ -63,7 +63,7 @@ func ExecData(do *definitions.Do) error {
 	if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
 		do.Name = util.DataContainersName(do.Name, do.Operations.ContainerNumber)
 		logger.Infoln("Running exec on container with volumes from data container " + do.Name)
-		if err := perform.DockerRunVolumesFromContainer(do.Name, do.Interactive, do.Args); err != nil {
+		if _, err := perform.DockerRunVolumesFromContainer(do.Name, do.Interactive, do.Args); err != nil {
 			return err
 		}
 	} else {

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -1,7 +1,7 @@
 package definitions
 
 type Do struct {
-	Dev           bool     `mapstructure:"," json:"," yaml:"," toml:","`
+	Dev           bool     `mapstructure:"," json:"," yaml:"," toml:","` // ?
 	Force         bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	File          bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Interactive   bool     `mapstructure:"," json:"," yaml:"," toml:","`
@@ -18,8 +18,9 @@ type Do struct {
 	RmHF          bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Verbose       bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Debug         bool     `mapstructure:"," json:"," yaml:"," toml:","`
-	Lines         int      `mapstructure:"," json:"," yaml:"," toml:","`
+	Lines         int      `mapstructure:"," json:"," yaml:"," toml:","` // ?
 	Timeout       uint     `mapstructure:"," json:"," yaml:"," toml:","`
+	N             uint     `mapstructure:"," json:"," yaml:"," toml:","`
 	Type          string   `mapstructure:"," json:"," yaml:"," toml:","`
 	Task          string   `mapstructure:"," json:"," yaml:"," toml:","`
 	Tail          string   `mapstructure:"," json:"," yaml:"," toml:","`
@@ -32,7 +33,10 @@ type Do struct {
 	Path          string   `mapstructure:"," json:"," yaml:"," toml:","`
 	NewName       string   `mapstructure:"," json:"," yaml:"," toml:","`
 	ResultFormt   string   `mapstructure:"," json:"," yaml:"," toml:","`
+	CSV           string   `mapstructure:"," json:"," yaml:"," toml:","`
+	Priv          string   `mapstructure:"," json:"," yaml:"," toml:","`
 	ServicesSlice []string `mapstructure:"," json:"," yaml:"," toml:","`
+	ConfigOpts    []string `mapstructure:"," json:"," yaml:"," toml:","`
 
 	// Generalized string slice
 	Args []string `mapstructure:"," json:"," yaml:"," toml:","`

--- a/definitions/service_definition.go
+++ b/definitions/service_definition.go
@@ -5,18 +5,21 @@ type ServiceDefinition struct {
 	Name string `json:"name" yaml:"name" toml:"name"`
 	// id of the service
 	ServiceID string `mapstructure:"service_id,omitempty" json:"service_id,omitempty" yaml:"service_id,omitempty" toml:"service_id,omitempty"`
-	// array of strings of other services which should be started prior to this service starting
-	ServiceDeps []string `mapstructure:"services" json:"services,omitempty", yaml:"services,omitempty" toml:"services,omitempty"`
 	// a chain which must be started prior to this service starting. can take a `$chain` string
 	// which would then be passed in via a command line flag
 	Chain string `json:"chain,omitempty" yaml:"chain,omitempty" toml:"chain,omitempty"`
 
-	Service    *Service    `json:"service" yaml:"service" toml:"service"`
-	Maintainer *Maintainer `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
-	Location   *Location   `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
-	Machine    *Machine    `json:"machine,omitempty" yaml:"machine,omitempty" toml:"machine,omitempty"`
-	Srvs       []*Service
-	Operations *Operation
+	Service     *Service     `json:"service" yaml:"service" toml:"service"`
+	ServiceDeps *ServiceDeps `mapstructure:"services" json:"services,omitempty", yaml:"services,omitempty" toml:"services,omitempty"`
+	Maintainer  *Maintainer  `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
+	Location    *Location    `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
+	Machine     *Machine     `json:"machine,omitempty" yaml:"machine,omitempty" toml:"machine,omitempty"`
+	Srvs        []*Service
+	Operations  *Operation
+}
+
+type ServiceDeps struct {
+	Dependencies []string `mapstructure:"dependencies" json:"dependencies,omitempty" yaml:"dependencies,omitempty" toml:"dependencies,omitempty"`
 }
 
 func BlankServiceDefinition() *ServiceDefinition {

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
 	"github.com/eris-ltd/eris-cli/definitions"
 	ini "github.com/eris-ltd/eris-cli/initialize"
+	"github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/util"
 )
 
@@ -19,12 +20,23 @@ var file string
 var content string = "test content\n"
 var hash string
 
+var DEAD bool // XXX: don't double panic (TODO: Flushing twice blocks)
+func fatal(t *testing.T, err error) {
+	if !DEAD {
+		log.Flush()
+		testKillIPFS(t)
+		testsTearDown()
+		DEAD = true
+		panic(err)
+	}
+}
+
 func TestMain(m *testing.M) {
 	var logLevel log.LogLevel
 
-	logLevel = 0
+	//	logLevel = 0
 	// logLevel = 1
-	// logLevel = 2
+	logLevel = 3
 
 	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
 
@@ -39,6 +51,7 @@ func TestMain(m *testing.M) {
 	exitCode := m.Run()
 
 	if os.Getenv("TEST_IN_CIRCLE") != "true" {
+		testKillIPFS(nil)
 		ifExit(testsTearDown())
 	}
 
@@ -50,8 +63,7 @@ func TestPutFiles(t *testing.T) {
 	do.Name = file
 	logger.Infof("Putting File =>\t\t\t%s\n", do.Name)
 	if err := PutFiles(do); err != nil {
-		logger.Errorln(err)
-		t.Fail()
+		fatal(t, err)
 	}
 	hash = do.Result
 	logger.Debugf("My Result =>\t\t\t%s\n", do.Result)
@@ -63,25 +75,21 @@ func TestGetFiles(t *testing.T) {
 	do.Name = hash
 	do.Path = fileName
 	if err := GetFiles(do); err != nil {
-		logger.Errorln(err)
-		t.FailNow()
+		fatal(t, err)
 	}
 
 	f, err := os.Open(fileName)
 	if err != nil {
-		logger.Errorln(err)
-		t.FailNow()
+		fatal(t, err)
 	}
 
 	contentPuted, err := ioutil.ReadAll(f)
 	if err != nil {
-		logger.Errorln(err)
-		t.FailNow()
+		fatal(t, err)
 	}
 
 	if string(contentPuted) != content {
-		fmt.Printf("ERROR: Content Put into IPFS and Pulled out to not match.\nExpected:\t%s\nReceived:\t%s\n", content, string(contentPuted))
-		t.Fail()
+		fatal(t, fmt.Errorf("ERROR: Content Put into IPFS and Pulled out to not match.\nExpected:\t%s\nReceived:\t%s\n", content, string(contentPuted)))
 	}
 }
 
@@ -121,6 +129,20 @@ func testsTearDown() error {
 	}
 
 	return nil
+}
+
+func testKillIPFS(t *testing.T) {
+	serviceName := "ipfs"
+	logger.Debugf("Stopping serv (via tests) =>\t%s\n", serviceName)
+
+	do := definitions.NowDo()
+	do.Name = serviceName
+	do.Args = []string{serviceName}
+	do.Rm = true
+	do.RmD = true
+	if e := services.KillService(do); e != nil {
+		t.Fatal(e)
+	}
 }
 
 func ifExit(err error) {

--- a/initialize/defaults.go
+++ b/initialize/defaults.go
@@ -1,7 +1,7 @@
 package initialize
 
 func defKeys() string {
-  return `[service]
+	return `[service]
 name = "keys"
 
 image = "eris/keys"
@@ -10,7 +10,32 @@ data_container = true
 }
 
 func defIpfs() string {
-  return `name = "ipfs"
+	return `name = "ipfs"
+
+[service]
+name = "ipfs"
+image = "eris/ipfs"
+data_container = true
+ports = ["4001:4001", "5001:5001", "8080:8080"]
+user = "root"
+
+[maintainer]
+name = "Eris Industries"
+email = "support@erisindustries.com"
+
+[location]
+repository = "github.com/eris-ltd/eris-services"
+
+[machine]
+include = ["docker"]
+requires = [""]
+`
+}
+
+func defIpfs2() string {
+	return `name = "ipfs"
+
+  services = ["keys"]
 
 [service]
 name = "ipfs"
@@ -33,7 +58,7 @@ requires = [""]
 }
 
 func defAct() string {
-  return `name = "do not use"
+	return `name = "do not use"
 services = [ "ipfs" ]
 chain = ""
 steps = [
@@ -59,7 +84,7 @@ requires = [""]
 }
 
 func defChainConfig() string {
-  return `
+	return `
 # This is a TOML config file.
 # For more information, see https://github.com/toml-lang/toml
 
@@ -74,7 +99,7 @@ rpc_laddr = ""
 }
 
 func defChainGen() string {
-  return `
+	return `
 {
   "chain_id": "my_tests",
   "accounts": [
@@ -119,7 +144,7 @@ func defChainGen() string {
 }
 
 func defChainKeys() string {
-  return `
+	return `
 {
   "address": "37236DF251AB70022B1DA351F08A20FB52443E37",
   "pub_key": [
@@ -138,7 +163,7 @@ func defChainKeys() string {
 }
 
 func defChainServConfig() string {
-  return `
+	return `
 # This is a TOML config file.
 # For more information, see https://github.com/toml-lang/toml
 

--- a/initialize/defaults.go
+++ b/initialize/defaults.go
@@ -1,5 +1,9 @@
 package initialize
 
+import (
+	"fmt"
+)
+
 func DefaultKeys() string {
 	return `[service]
 name = "keys"
@@ -84,7 +88,7 @@ requires = [""]
 `
 }
 
-func defChainConfig() string {
+func DefChainConfig() string {
 	return `
 # This is a TOML config file.
 # For more information, see https://github.com/toml-lang/toml
@@ -94,12 +98,12 @@ seeds = ""
 fast_sync = false
 db_backend = "leveldb"
 log_level = "debug"
-node_laddr = ""
-rpc_laddr = ""
+node_laddr = "0.0.0.0:46656"
+rpc_laddr = "0.0.0.0:46657"
 `
 }
 
-func defChainGen() string {
+func DefChainGen() string {
 	return `
 {
   "chain_id": "my_tests",
@@ -144,7 +148,14 @@ func defChainGen() string {
 `
 }
 
-func defChainKeys() string {
+// different from genesis above!
+var DefaultPubKeys = []string{"BB3688B7561D488A2A4834E1AEE9398BEF94844D8BDBBCA980C11E3654A45906"}
+
+func DefChainCSV() string {
+	return fmt.Sprintf("%s,", DefaultPubKeys[0])
+}
+
+func DefChainKeys() string {
 	return `
 {
   "address": "37236DF251AB70022B1DA351F08A20FB52443E37",
@@ -163,7 +174,7 @@ func defChainKeys() string {
 `
 }
 
-func defChainServConfig() string {
+func DefChainServConfig() string {
 	return `
 # This is a TOML config file.
 # For more information, see https://github.com/toml-lang/toml

--- a/initialize/defaults.go
+++ b/initialize/defaults.go
@@ -1,6 +1,6 @@
 package initialize
 
-func defKeys() string {
+func DefaultKeys() string {
 	return `[service]
 name = "keys"
 
@@ -9,7 +9,7 @@ data_container = true
 `
 }
 
-func defIpfs() string {
+func DefaultIpfs() string {
 	return `name = "ipfs"
 
 [service]
@@ -32,10 +32,8 @@ requires = [""]
 `
 }
 
-func defIpfs2() string {
+func DefaultIpfs2() string {
 	return `name = "ipfs"
-
-  services = ["keys"]
 
 [service]
 name = "ipfs"
@@ -43,6 +41,9 @@ image = "eris/ipfs"
 data_container = true
 ports = ["4001:4001", "5001:5001", "8080:8080"]
 user = "root"
+
+[services]
+dependencies = ["keys"]
 
 [maintainer]
 name = "Eris Industries"

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -29,6 +29,9 @@ func dropDefaults() error {
 	if err := writeDefaultFile(common.ServicesPath, "ipfs.toml", defIpfs); err != nil {
 		return fmt.Errorf("Cannot add ipfs: %s.\n", err)
 	}
+	if err := writeDefaultFile(common.ServicesPath, "do_not_use.toml", defIpfs2); err != nil {
+		return fmt.Errorf("Cannot add ipfs: %s.\n", err)
+	}
 	if err := writeDefaultFile(common.ActionsPath, "do_not_use.toml", defAct); err != nil {
 		return fmt.Errorf("Cannot add default action: %s.\n", err)
 	}

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -40,17 +40,20 @@ func dropDefaults() error {
 
 func dropChainDefaults() error {
 	defChainDir := filepath.Join(common.BlockchainsPath, "config", "default")
-	if err := writeDefaultFile(defChainDir, "config.toml", defChainConfig); err != nil {
+	if err := writeDefaultFile(defChainDir, "config.toml", DefChainConfig); err != nil {
 		return fmt.Errorf("Cannot add default config.toml: %s.\n", err)
 	}
-	if err := writeDefaultFile(defChainDir, "genesis.json", defChainGen); err != nil {
+	if err := writeDefaultFile(defChainDir, "genesis.json", DefChainGen); err != nil {
 		return fmt.Errorf("Cannot add default genesis.json: %s.\n", err)
 	}
-	if err := writeDefaultFile(defChainDir, "priv_validator.json", defChainKeys); err != nil {
+	if err := writeDefaultFile(defChainDir, "priv_validator.json", DefChainKeys); err != nil {
 		return fmt.Errorf("Cannot add default priv_validator.json: %s.\n", err)
 	}
-	if err := writeDefaultFile(defChainDir, "server_conf.toml", defChainServConfig); err != nil {
+	if err := writeDefaultFile(defChainDir, "server_conf.toml", DefChainServConfig); err != nil {
 		return fmt.Errorf("Cannot add default server_conf.toml: %s.\n", err)
+	}
+	if err := writeDefaultFile(defChainDir, "genesis.csv", DefChainCSV); err != nil {
+		return fmt.Errorf("Cannot add default genesis.csv: %s.\n", err)
 	}
 	return nil
 }

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -23,13 +23,13 @@ func pullRepo(name, location string, verbose bool) error {
 }
 
 func dropDefaults() error {
-	if err := writeDefaultFile(common.ServicesPath, "keys.toml", defKeys); err != nil {
+	if err := writeDefaultFile(common.ServicesPath, "keys.toml", DefaultKeys); err != nil {
 		return fmt.Errorf("Cannot add keys: %s.\n", err)
 	}
-	if err := writeDefaultFile(common.ServicesPath, "ipfs.toml", defIpfs); err != nil {
+	if err := writeDefaultFile(common.ServicesPath, "ipfs.toml", DefaultIpfs); err != nil {
 		return fmt.Errorf("Cannot add ipfs: %s.\n", err)
 	}
-	if err := writeDefaultFile(common.ServicesPath, "do_not_use.toml", defIpfs2); err != nil {
+	if err := writeDefaultFile(common.ServicesPath, "do_not_use.toml", DefaultIpfs2); err != nil {
 		return fmt.Errorf("Cannot add ipfs: %s.\n", err)
 	}
 	if err := writeDefaultFile(common.ActionsPath, "do_not_use.toml", defAct); err != nil {

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -78,7 +78,7 @@ func ServiceDefFromChain(chain *definitions.Chain, cmd string) *definitions.Serv
 	srv := &definitions.ServiceDefinition{
 		Name:        chain.Name,
 		ServiceID:   chain.ChainID,
-		ServiceDeps: []string{"keys"},
+		ServiceDeps: &definitions.ServiceDeps{[]string{"keys"}},
 		Service:     chain.Service,
 		Operations:  chain.Operations,
 		Maintainer:  chain.Maintainer,

--- a/loaders/services.go
+++ b/loaders/services.go
@@ -156,7 +156,9 @@ func checkImage(srv *definitions.Service) error {
 }
 
 func addDependencyVolumesAndLinks(srv *definitions.ServiceDefinition) {
-	for _, dep := range srv.ServiceDeps {
-		ConnectToAService(srv, dep)
+	if srv.ServiceDeps != nil {
+		for _, dep := range srv.ServiceDeps.Dependencies {
+			ConnectToAService(srv, dep)
+		}
 	}
 }

--- a/services/load.go
+++ b/services/load.go
@@ -6,7 +6,6 @@ import (
 	"github.com/eris-ltd/eris-cli/perform"
 	"github.com/eris-ltd/eris-cli/util"
 	"strings"
-	"time"
 )
 
 func EnsureRunning(do *definitions.Do) error {
@@ -16,8 +15,8 @@ func EnsureRunning(do *definitions.Do) error {
 	}
 
 	if !IsServiceRunning(srv.Service, srv.Operations) {
-		logger.Infof("%s is not running. Starting now. Waiting for %s to become available \n", strings.ToUpper(do.Name))
-		time.Sleep(time.Second * 5) // this is dirty
+		name := strings.ToUpper(do.Name)
+		logger.Infof("%s is not running. Starting now. Waiting for %s to become available \n", name, name)
 		err := perform.DockerRun(srv.Service, srv.Operations)
 		if err != nil {
 			return err

--- a/services/load.go
+++ b/services/load.go
@@ -23,7 +23,7 @@ func EnsureRunning(do *definitions.Do) error {
 		if err != nil {
 			return err
 		}
-		time.Sleep(time.Second * 5)
+		time.Sleep(time.Second * 5) // TODO: ping container until ready: issue #149
 	} else {
 		logger.Infof("%s is running.\n", strings.ToUpper(do.Name))
 	}

--- a/services/load.go
+++ b/services/load.go
@@ -1,11 +1,13 @@
 package services
 
 import (
+	"strings"
+	"time"
+
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/loaders"
 	"github.com/eris-ltd/eris-cli/perform"
 	"github.com/eris-ltd/eris-cli/util"
-	"strings"
 )
 
 func EnsureRunning(do *definitions.Do) error {
@@ -21,6 +23,7 @@ func EnsureRunning(do *definitions.Do) error {
 		if err != nil {
 			return err
 		}
+		time.Sleep(time.Second * 5)
 	} else {
 		logger.Infof("%s is running.\n", strings.ToUpper(do.Name))
 	}

--- a/services/operate.go
+++ b/services/operate.go
@@ -101,13 +101,15 @@ func BuildServicesGroup(srvName string, cNum int, services ...*definitions.Servi
 	if err != nil {
 		return nil, err
 	}
-	for _, sName := range srv.ServiceDeps {
-		logger.Debugf("Found service dependency =>\t%s\n", sName)
-		s, e := BuildServicesGroup(sName, cNum)
-		if e != nil {
-			return nil, e
+	if srv.ServiceDeps != nil {
+		for _, sName := range srv.ServiceDeps.Dependencies {
+			logger.Debugf("Found service dependency =>\t%s\n", sName)
+			s, e := BuildServicesGroup(sName, cNum)
+			if e != nil {
+				return nil, e
+			}
+			services = append(services, s...)
 		}
-		services = append(services, s...)
 	}
 	services = append(services, srv)
 	return services, nil

--- a/services/operate.go
+++ b/services/operate.go
@@ -38,11 +38,13 @@ func StartService(do *definitions.Do) (err error) {
 	}
 
 	// TODO: move this wg, ch logic into func StartGroup([]*definitions.ServiceDefinition) error {}
-	wg, ch := new(sync.WaitGroup), make(chan error, 1)
+	wg, ch := new(sync.WaitGroup), make(chan error)
 	StartGroup(ch, wg, services)
 	go func() {
 		wg.Wait()
-		ch <- nil
+		select {
+		case ch <- nil:
+		}
 	}()
 	if err := <-ch; err != nil {
 		return err

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -58,7 +58,7 @@ func TestKnownService(t *testing.T) {
 	k := strings.Split(do.Result, "\n") // tests output formatting.
 
 	if len(k) != 3 {
-		ifExit(fmt.Errorf("More than two service definitions found. Something is wrong.\n"))
+		ifExit(fmt.Errorf("Did not find exactly 3 service definitions files. Something is wrong.\n"))
 	}
 
 	if k[1] != "ipfs" {

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -35,8 +35,8 @@ func TestMain(m *testing.M) {
 	var logLevel log.LogLevel
 
 	logLevel = 0
-	// logLevel = 1
-	logLevel = 2
+	//logLevel = 1
+	//logLevel = 2
 
 	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
 

--- a/services/writer.go
+++ b/services/writer.go
@@ -50,8 +50,8 @@ func WriteServiceDefinitionFile(serviceDef *def.ServiceDefinition, fileName stri
 		enc := toml.NewEncoder(writer)
 		enc.Indent = ""
 		writer.Write([]byte("name = \"" + serviceDef.Name + "\"\n\n"))
-		if len(serviceDef.ServiceDeps) != 0 {
-			writer.Write([]byte("services = [ \"" + strings.Join(serviceDef.ServiceDeps, "\",\"") + "\" ]\n"))
+		if serviceDef.ServiceDeps != nil && len(serviceDef.ServiceDeps.Dependencies) != 0 {
+			writer.Write([]byte("services = [ \"" + strings.Join(serviceDef.ServiceDeps.Dependencies, "\",\"") + "\" ]\n"))
 		}
 		if serviceDef.ServiceID != "" {
 			writer.Write([]byte("service_id = \"" + serviceDef.ServiceID + "\"\n"))

--- a/services/writer.go
+++ b/services/writer.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 
 	def "github.com/eris-ltd/eris-cli/definitions"
 
@@ -50,9 +49,6 @@ func WriteServiceDefinitionFile(serviceDef *def.ServiceDefinition, fileName stri
 		enc := toml.NewEncoder(writer)
 		enc.Indent = ""
 		writer.Write([]byte("name = \"" + serviceDef.Name + "\"\n\n"))
-		if serviceDef.ServiceDeps != nil && len(serviceDef.ServiceDeps.Dependencies) != 0 {
-			writer.Write([]byte("services = [ \"" + strings.Join(serviceDef.ServiceDeps.Dependencies, "\",\"") + "\" ]\n"))
-		}
 		if serviceDef.ServiceID != "" {
 			writer.Write([]byte("service_id = \"" + serviceDef.ServiceID + "\"\n"))
 		}
@@ -61,6 +57,10 @@ func WriteServiceDefinitionFile(serviceDef *def.ServiceDefinition, fileName stri
 		}
 		writer.Write([]byte("[service]\n"))
 		enc.Encode(serviceDef.Service)
+		writer.Write([]byte("[services]\n"))
+		if serviceDef.ServiceDeps != nil && len(serviceDef.ServiceDeps.Dependencies) != 0 {
+			enc.Encode(serviceDef.ServiceDeps)
+		}
 		writer.Write([]byte("\n[maintainer]\n"))
 		enc.Encode(serviceDef.Maintainer)
 		writer.Write([]byte("\n[location]\n"))

--- a/util/config.go
+++ b/util/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/BurntSushi/toml"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/viper"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/tcnksm/go-gitconfig"
 )
 
 // Properly scope the globalConfig
@@ -148,4 +149,24 @@ func marshallGlobalConfig(globalConfig *viper.Viper, config *ErisConfig) error {
 	}
 
 	return nil
+}
+
+func GitConfigUser() (uName string, email string, err error) {
+	uName, err = gitconfig.Username()
+	if err != nil {
+		uName = ""
+	}
+	email, err = gitconfig.Email()
+	if err != nil {
+		email = ""
+	}
+
+	if uName == "" && email == "" {
+		err = fmt.Errorf("Can not find username or email in git config. Using \"\" for both")
+	} else if uName == "" {
+		err = fmt.Errorf("Can not find username in git config. Using \"\"")
+	} else if email == "" {
+		err = fmt.Errorf("Can not find email in git config. Using \"\"")
+	}
+	return
 }


### PR DESCRIPTION
- various code cleanups
- `chains new` upgrades:
    - actually works
    -  `--csv` to pass validators to `mintgen`
    -  `--options` for `mintconfig`. eg `eris chains new --csv=validators.csv --options="moniker:bob fast-sync:false" mychainid`
    - chain_id of `-g genesis.json` is overwritten by jq in erisdb (replaced with argument to `chains new`)
- tests for chains and services can all standalone and cleanup nicely
    - NOTE: I gutted all the `TEST_IN_CIRCLE` crud. This will fail on circle until we get a better CI solution ala @NodeGuy 
- remove multiple data containers at once

Note these updates depend on an updated `erisdb`. Let's call it 0.10.1? How do we manage what revision `0.10` actually points to?