### PR TITLE
add verbosity to init sequence. add more friendly error mgs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,11 @@ RUN curl -sSL -o $INSTALL_BASE/go-wrapper https://raw.githubusercontent.com/dock
 RUN chmod +x $INSTALL_BASE/go-wrapper
 
 # DOCKER
-RUN mkdir -p /var/log/supervisor
 RUN mkdir -p /var/log/docker
-COPY ./agent/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-RUN echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list \
-  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9 \
+RUN echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list \
+  && apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D \
   && apt-get update -qq \
-  && apt-get install -qqy lxc-docker
+  && apt-get install -qqy docker-engine
 
 # DOCKER WRAPPER
 RUN curl -sSL -o $INSTALL_BASE/wrapdocker https://raw.githubusercontent.com/jpetazzo/dind/master/wrapdocker

--- a/commands/eris.go
+++ b/commands/eris.go
@@ -96,7 +96,7 @@ func AddGlobalFlags() {
 	ErisCmd.PersistentFlags().BoolVarP(&do.Debug, "debug", "d", false, "debug level output")
 	ErisCmd.PersistentFlags().IntVarP(&do.Operations.ContainerNumber, "num", "n", 1, "container number")
 	ErisCmd.PersistentFlags().StringVarP(&do.MachineName, "machine", "", "eris", "machine name for docker-machine that is running VM")
-	Init.Flags().BoolVarP(&do.SkipPull, "skip-pull", "p", false, "skip the pulling feature; for when git is not installed")
+	Init.Flags().BoolVarP(&do.Pull, "pull", "p", true, "git clone the default services and actions; use the flag for when git is not installed")
 	// Init.Flags().BoolVarP(&do.Dev, "dev", "", false, "pull development images")
 	// Init.Flags().BoolVarP(&do.SkipImages, "no-pull", "", false, "skip pulling default images")
 }

--- a/commands/init.go
+++ b/commands/init.go
@@ -13,6 +13,6 @@ var Init = &cobra.Command{
 and clone eris-ltd/eris-actions eris-ltd/eris-services into them, respectively.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		ini.Initialize(do.SkipPull, do.Verbose)
+		ini.Initialize(do.Pull, do.Verbose)
 	},
 }

--- a/initialize/init.go
+++ b/initialize/init.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/eris-ltd/eris-cli/util"
-
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 )
 
 func Initialize(skipPull, verbose bool) error { // todo: remove the verbose here
+	logger.Printf("The marmots have connected to Docker successfully.\nThey will now will install a few default services and actions for your use.\n\n")
 
 	if _, err := os.Stat(common.ErisRoot); err != nil {
 		if err := common.InitErisDir(); err != nil {
@@ -19,11 +18,16 @@ func Initialize(skipPull, verbose bool) error { // todo: remove the verbose here
 		logger.Infof("Root eris directory (%s) already exists. Please type `eris` to see the help.\n", common.ErisRoot)
 	}
 
-	logger.Debugf("Checking connection to Docker....\n")
-	if err := util.CheckDockerClient(); err != nil {
-		return err
-	}
-	logger.Infof("Docker Connection OK.\n")
+	// XXX: [csk] The below is redunant. DockerConnect() is a PersistentPreRun
+	//   command and if it cannot connect to the "default" or "eris" docker-machines
+	//   then it will call CheckDockerClient() to perform the functionality
+	//   envisioned by the below. Going to leave this in case we want to change
+	//   that functionality in the future.
+	// logger.Debugf("Checking connection to Docker....\n")
+	// if err := util.CheckDockerClient(); err != nil {
+	// 	return err
+	// }
+	// logger.Infof("Docker Connection OK.\n")
 
 	if err := InitDefaultServices(skipPull); err != nil {
 		return fmt.Errorf("Could not instantiate default services.\n%s\n", err)
@@ -31,7 +35,7 @@ func Initialize(skipPull, verbose bool) error { // todo: remove the verbose here
 	logger.Infof("Initialized eris root directory (%s) with default actions and service files.\n", common.ErisRoot)
 
 	// todo: when called from cli provide option to go on tour, like `ipfs tour`
-	logger.Printf("The marmots have everything set up for you.\n")
+	logger.Printf("\nThe marmots have everything set up for you.\nIf you are just getting started please type [eris] to get an overview of the tool.\n")
 
 	return nil
 }
@@ -44,14 +48,14 @@ func InitDefaultServices(skipPull bool) error {
 	logger.Debugf("Chain defaults written.\n")
 
 	if !skipPull {
-		if err := pullRepo("eris-services", common.ServicesPath); err != nil {
-			logger.Debugf("Using default defs.")
+		if err := cloneRepo("eris-services", common.ServicesPath); err != nil {
+			logger.Debugf("Using default defs.\n")
 			if err2 := dropDefaults(); err2 != nil {
-				return fmt.Errorf("Cannot pull: %s. %s.\n", err, err2)
+				return fmt.Errorf("Cannot clone: %s. %s.\n", err, err2)
 			}
 		} else {
-			if err2 := pullRepo("eris-actions", common.ActionsPath); err2 != nil {
-				return fmt.Errorf("Cannot pull actions: %s.\n", err2)
+			if err2 := cloneRepo("eris-actions", common.ActionsPath); err2 != nil {
+				return fmt.Errorf("Cannot clone actions: %s.\n", err2)
 			}
 		}
 	} else {

--- a/tests/build_tool.sh
+++ b/tests/build_tool.sh
@@ -4,6 +4,8 @@ release_maj="0.10"
 release_min="0.10.1"
 branch=${CIRCLE_BRANCH:=master}
 branch=${branch/-/_}
+testimage=${testimage:="eris/eris"}
+repo=${repo:=$GOPATH/src/github.com/eris-ltd/eris-cli}
 
 start=`pwd`
 cd $repo

--- a/tests/test_tool.sh
+++ b/tests/test_tool.sh
@@ -150,9 +150,9 @@ echo "Checking the Eris <-> Docker Connection"
 echo ""
 if [[ $machine == "eris-test-local" ]]
 then
-  eris init -d
+  eris init -dp
 else
-  eris init -d --machine $machine
+  eris init -dp --machine $machine
 fi
 passed Setup
 

--- a/util/docker_client.go
+++ b/util/docker_client.go
@@ -26,6 +26,13 @@ func DockerConnect(verbose bool, machName string) { // TODO: return an error...?
 		if os.Getenv("DOCKER_HOST") == "" && os.Getenv("DOCKER_CERT_PATH") == "" { // this means we aren't gonna use docker-machine
 			endpoint := "unix:///var/run/docker.sock"
 
+			u, _ := url.Parse(endpoint)
+			_, err := net.Dial(u.Scheme, u.Path)
+			if err != nil {
+				logger.Printf("%v\n", mustInstallError())
+				os.Exit(1)
+			}
+
 			logger.Debugln("Connecting to the Docker Client via:", endpoint)
 			DockerClient, err = docker.NewClient(endpoint)
 			if err != nil {
@@ -53,19 +60,22 @@ func DockerConnect(verbose bool, machName string) { // TODO: return an error...?
 		logger.Debugln("Successfully connected to Docker daemon.")
 
 	} else {
-		dockerHost, dockerCertPath, err = getMachineDeets(machName)
+		dockerHost, dockerCertPath, err = getMachineDeets(machName) // machName is "eris" by default
 
 		if err != nil {
-			logger.Debugf("Could not connect to the eris docker-machine.\nError:\t%v\nTrying default docker-machine.\n", err)
+
+			logger.Debugf("Could not connect to the eris docker-machine.\nError:\t%vTrying \"default\" docker-machine.\n", err)
 			dockerHost, dockerCertPath, err = getMachineDeets("default") // during toolbox setup this is the machine that is created
 			if err != nil {
-				logger.Debugf("Could not connect to the default docker-machine.\nError:\t%v\nTrying to set up a new machine.\n", err)
+
+				logger.Debugf("Could not connect to the \"default\" docker-machine.\nError:\t%vTrying to set up a new machine.\n", err)
 				if e2 := CheckDockerClient(); e2 != nil {
 					logger.Printf("%v\n", e2)
 					os.Exit(1)
 				}
 				dockerHost, dockerCertPath, _ = getMachineDeets("eris")
 			}
+
 		}
 
 		if err := connectDockerTLS(dockerHost, dockerCertPath); err != nil {
@@ -81,45 +91,28 @@ func DockerConnect(verbose bool, machName string) { // TODO: return an error...?
 
 func CheckDockerClient() error {
 	if runtime.GOOS == "linux" {
-		// _, err := net.Dial("unix", "/var/run/docker.sock")
-		// if err != nil {
-		// 	return mustInstallError()
-		// }
 		return nil
-	} else {
-		dockerHost, dockerCertPath := popPathAndHost()
+	}
 
-		if dockerCertPath == "" || dockerHost == "" {
-			driver := "virtualbox" // when we use agents we'll wanna turn this driver into a flag
+	var input string
+	dockerHost, dockerCertPath := popPathAndHost()
 
-			if runtime.GOOS == "windows" {
-				if err := prepWin(); err != nil {
-					return fmt.Errorf("Could not add ssh.exe to PATH.\nError:%v\n", err)
-				}
+	if dockerCertPath == "" || dockerHost == "" {
+		driver := "virtualbox" // when we use agents we'll wanna turn this driver into a flag
+
+		if runtime.GOOS == "windows" {
+			if err := prepWin(); err != nil {
+				return fmt.Errorf("Could not add ssh.exe to PATH.\nError:%v\n", err)
 			}
+		}
 
-			if _, _, err := getMachineDeets("default"); err == nil {
+		if _, _, err := getMachineDeets("default"); err == nil {
 
-				var input string
-				fmt.Print("A docker-machine exists, which eris can use.\nHowever, our marmots recommend that you have a vm dedicated to eris dev-ing.\nWould you like the marmots to create a machine for you? (Y/n): ")
-				fmt.Scanln(&input)
+			fmt.Print("A docker-machine virtual machine exists, which eris can use.\nHowever, our marmots recommend that you have a vm dedicated to eris dev-ing.\nWould you like the marmots to create a machine for you? (Y/n): ")
+			fmt.Scanln(&input)
 
-				if input == "Y" || input == "y" || input == "YES" || input == "Yes" || input == "yes" {
-					logger.Infof("The marmots will create an eris machine.\n")
-					if err := setupErisMachine(driver); err != nil {
-						return err
-					}
-
-					logger.Debugf("New docker machine created using %s driver. Getting the proper environment variables.\n", driver)
-					if _, _, err := getMachineDeets("eris"); err != nil {
-						return err
-					}
-				} else {
-					logger.Infof("No eris docker-machine will be created.")
-				}
-
-			} else {
-				logger.Debugf("The marmots will create an eris machine.\n")
+			if input == "Y" || input == "y" || input == "YES" || input == "Yes" || input == "yes" {
+				logger.Infof("The marmots will create an eris machine.\n")
 				if err := setupErisMachine(driver); err != nil {
 					return err
 				}
@@ -128,7 +121,27 @@ func CheckDockerClient() error {
 				if _, _, err := getMachineDeets("eris"); err != nil {
 					return err
 				}
+			} else {
+				logger.Infof("No eris docker-machine will be created.")
 			}
+
+		} else {
+
+			fmt.Print("The marmots could not find a docker-machine virtual machine they could connect to.\nOur marmots recommend that you have a vm dedicated to eris dev-ing.\nWould you like the marmots to create a machine for you? (Y/n): ")
+			fmt.Scanln(&input)
+
+			if input == "Y" || input == "y" || input == "YES" || input == "Yes" || input == "yes" {
+				logger.Printf("The marmots will create an eris machine.\n")
+				if err := setupErisMachine(driver); err != nil {
+					return err
+				}
+
+				logger.Infof("New docker machine created using %s driver.\nGetting the proper environment variables.\n", driver)
+				if _, _, err := getMachineDeets("eris"); err != nil {
+					return err
+				}
+			}
+
 		}
 	}
 
@@ -173,11 +186,11 @@ func getMachineDeets(machName string) (string, string, error) {
 		return "", "", noConnectError
 	}
 
-	logger.Debugf("Querying whether the host and user have access to the right files for TLS connection to docker.\n")
+	logger.Infof("Querying whether the host and user have access to the right files for TLS connection to docker.\n")
 	if err := checkKeysAndCerts(dPath); err != nil {
 		return "", "", err
 	}
-	logger.Debugf("\tCerts files look good.\n")
+	logger.Debugf("\tCertificate files look good.\n")
 
 	// technically, do not *have* to do this, but it will make repetitive tasks faster
 	logger.Debugf("Setting the environment variables for quick future development.\n")
@@ -186,12 +199,12 @@ func getMachineDeets(machName string) (string, string, error) {
 	os.Setenv("DOCKER_TLS_VERIFY", "1")
 	os.Setenv("DOCKER_MACHINE_NAME", machName)
 
-	logger.Debugf("Finished getting machine details for =>\t%s\n", machName)
+	logger.Debugf("Finished getting machine details =>\t%s\n", machName)
 	return dPath, dHost, nil
 }
 
 func setupErisMachine(driver string) error {
-	logger.Debugf("Creating the eris docker-machine.\n")
+	logger.Printf("Creating the eris docker-machine.\nThis will take some time, please feel free to go feed your marmot.\n")
 	cmd := exec.Command("docker-machine", "create", "--driver", driver, "eris")
 	if err := cmd.Run(); err != nil {
 		logger.Debugf("There was an error creating the eris docker-machine.\nError:\t%v\n", err)
@@ -199,12 +212,12 @@ func setupErisMachine(driver string) error {
 	}
 	logger.Debugf("Eris docker-machine created.\n")
 
-	logger.Debugf("Starting eris docker-machine.\n")
+	logger.Infof("Starting eris docker-machine.\n")
 	cmd = exec.Command("docker-machine", "start", "eris")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("There was an error starting the newly created docker-machine.\nError:\t%v\n", err)
 	}
-	logger.Debugf("Eris docker-machine started.\n")
+	logger.Infof("Eris docker-machine started.\n")
 
 	return nil
 }
@@ -212,14 +225,16 @@ func setupErisMachine(driver string) error {
 func connectDockerTLS(dockerHost, dockerCertPath string) error {
 	var err error
 
-	logger.Debugln("Connecting to the Docker Client via:", dockerHost)
-	logger.Debugln("Docker Certificate Path:", dockerCertPath)
+	logger.Debugf("Connecting to the Docker Client via TLS.\n")
+	logger.Debugf("\tURL =>\t\t\t%s\n", dockerHost)
+	logger.Debugf("\tDocker Certificate Path =>\t%s\n", dockerCertPath)
 
 	DockerClient, err = docker.NewTLSClient(dockerHost, path.Join(dockerCertPath, "cert.pem"), path.Join(dockerCertPath, "key.pem"), path.Join(dockerCertPath, "ca.pem"))
 	if err != nil {
 		return err
 	}
 
+	logger.Debugf("Connected over TLS.")
 	return nil
 }
 
@@ -250,7 +265,7 @@ func mustInstallError() error {
 
 	switch runtime.GOOS {
 	case "linux":
-		return fmt.Errorf("%s%s\nDo you have docker running?\nIf not please [sudo services start docker] on Ubuntu.\n", errBase, dInst)
+		return fmt.Errorf("%s%s\nDo you have docker installed and running?\nIf not please [sudo services start docker] on Ubuntu.\n", errBase, dInst)
 	case "darwin":
 		return fmt.Errorf("%s%s\n", errBase, (dInst + "mac/"))
 	case "windows":
@@ -276,12 +291,12 @@ func prepWin() error {
 func setIPFSHostViaDockerHost(dockerHost string) {
 	u, err := url.Parse(dockerHost)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Println("The marmots could not parse the URL for the DockerHost to populate the IPFS Host.\nPlease check that your docker-machine VM is running with [docker-machine ls]\nError:\t%v\n", err)
 		os.Exit(1)
 	}
 	dIP, _, err := net.SplitHostPort(u.Host)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Println("The marmots could not split the host and port for the DockerHost to populate the IPFS Host.\nPlease check that your docker-machine VM is running with [docker-machine ls]\nError:\t%v\n", err)
 		os.Exit(1)
 	}
 	dockerIP := fmt.Sprintf("%s%s", "http://", dIP)


### PR DESCRIPTION
Changes:

* updates to docker 1.8.1 (current default)
* changes skipPull to Pull so init works correctly. (eris init will pull service def files eris init -p will not)
* commented out DockerClientCheck function during init sequence as redundant with the DockerConnect function which is called during PreRun sequence.
* separated cloneRepo and pullRepo for more resiliency. when init called if cloneRepo sees a dir it will call pullRepo instead of flaming out with a dir not empty error (will check with user first before doing so in case they do not want to do this)
* DockerConnect sequence will query the /var/run/docker.sock (on linux) to see if its open and if it is not, will send back a better error message to the user. 
* Asks user before actually creating that eris VM. Also advises user that it will take a moment to create.

Closes #174 