### PR TITLE
Exec is back

### DIFF
--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -140,10 +140,14 @@ func TestStartKillChain(t *testing.T) {
 }
 
 func TestExecChain(t *testing.T) {
-	if os.Getenv("TEST_IN_CIRCLE") == "true" {
+	/*	if os.Getenv("TEST_IN_CIRCLE") == "true" {
 		logger.Println("Testing in Circle. Where we don't have exec privileges (due to their driver). Skipping test.")
 		return
-	}
+	}*/
+
+	testStartChain(t, chainName)
+	defer testKillChain(t, chainName)
+
 	do := def.NowDo()
 	do.Name = chainName
 	do.Args = strings.Fields("ls -la /home/eris/.eris/blockchains")

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -139,6 +139,23 @@ func TestStartKillChain(t *testing.T) {
 	testKillChain(t, chainName)
 }
 
+func TestExecChain(t *testing.T) {
+	if os.Getenv("TEST_IN_CIRCLE") == "true" {
+		logger.Println("Testing in Circle. Where we don't have exec privileges (due to their driver). Skipping test.")
+		return
+	}
+	do := def.NowDo()
+	do.Name = chainName
+	do.Args = strings.Fields("ls -la /home/eris/.eris/blockchains")
+	do.Interactive = false
+	logger.Infof("Exec-ing chain (from tests) =>\t%s\n", do.Name)
+	e := ExecChain(do)
+	if e != nil {
+		logger.Errorln(e)
+		t.Fail()
+	}
+}
+
 // eris chains new --dir _ -g _
 // the default chain_id is my_tests, so should be overwritten
 func TestChainsNewDirGen(t *testing.T) {

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -82,6 +82,22 @@ func LogsChain(do *definitions.Do) error {
 	return nil
 }
 
+func ExecChain(do *definitions.Do) error {
+	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)
+	if err != nil {
+		return err
+	}
+
+	if IsChainExisting(chain) {
+		logger.Infoln("Chain exists.")
+		return perform.DockerExec(chain.Service, chain.Operations, do.Args, do.Interactive)
+	} else {
+		return fmt.Errorf("Chain does not exist. Please start the chain container with eris chains start %s.\n", do.Name)
+	}
+
+	return nil
+}
+
 // export a chain definition file
 func ExportChain(do *definitions.Do) error {
 	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)

--- a/commands/services.go
+++ b/commands/services.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"strings"
 
 	srv "github.com/eris-ltd/eris-cli/services"
 
@@ -34,6 +35,7 @@ func buildServicesCommand() {
 	Services.AddCommand(servicesLogs)
 	Services.AddCommand(servicesListRunning)
 	Services.AddCommand(servicesInspect)
+	Services.AddCommand(servicesExec)
 	Services.AddCommand(servicesStop)
 	Services.AddCommand(servicesExport)
 	Services.AddCommand(servicesRename)
@@ -183,6 +185,15 @@ var servicesLogs = &cobra.Command{
 	},
 }
 
+var servicesExec = &cobra.Command{
+	Use:   "exec [serviceName]",
+	Short: "Run a command or interactive shell",
+	Long:  "Run a command or interactive shell in a container with volumes-from the data container",
+	Run: func(cmd *cobra.Command, args []string) {
+		ExecService(cmd, args)
+	},
+}
+
 // stop stops a running service
 var servicesStop = &cobra.Command{
 	Use:   "stop [name]",
@@ -255,6 +266,8 @@ func addServicesFlags() {
 	servicesLogs.Flags().BoolVarP(&do.Follow, "follow", "f", false, "follow logs")
 	servicesLogs.Flags().StringVarP(&do.Tail, "tail", "t", "all", "number of lines to show from end of logs")
 
+	servicesExec.Flags().BoolVarP(&do.Interactive, "interactive", "i", false, "interactive shell")
+
 	servicesUpdate.Flags().BoolVarP(&do.Pull, "pull", "p", false, "skip the pulling feature and simply rebuild the service container")
 	servicesUpdate.Flags().UintVarP(&do.Timeout, "timeout", "t", 10, "manually set the timeout; overridden by --force")
 
@@ -287,6 +300,19 @@ func LogService(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "ge", cmd, args))
 	do.Name = args[0]
 	IfExit(srv.LogsService(do))
+}
+
+func ExecService(cmd *cobra.Command, args []string) {
+	IfExit(ArgCheck(1, "ge", cmd, args))
+
+	do.Name = args[0]
+	args = args[1:]
+	if len(args) == 1 {
+		args = strings.Split(args[0], " ")
+	}
+	do.Args = args
+
+	IfExit(srv.ExecService(do))
 }
 
 func KillService(cmd *cobra.Command, args []string) {

--- a/services/manage.go
+++ b/services/manage.go
@@ -173,6 +173,21 @@ func LogsService(do *definitions.Do) error {
 	return LogsServiceByService(service.Service, service.Operations, do.Follow, do.Tail)
 }
 
+func ExecService(do *definitions.Do) error {
+	service, err := loaders.LoadServiceDefinition(do.Name, false, do.Operations.ContainerNumber)
+	if err != nil {
+		return err
+	}
+
+	if IsServiceExisting(service.Service, service.Operations) {
+		return ExecServiceByService(service.Service, service.Operations, do.Args, do.Interactive)
+	} else {
+		return fmt.Errorf("Services does not exist. Please start the service container with eris services start %s.\n", do.Name)
+	}
+
+	return nil
+}
+
 func ExportService(do *definitions.Do) error {
 	if parseKnown(do.Name) {
 		doNow := definitions.NowDo()

--- a/services/operate.go
+++ b/services/operate.go
@@ -172,6 +172,10 @@ func LogsServiceByService(srv *definitions.Service, ops *definitions.Operation, 
 	return perform.DockerLogs(srv, ops, follow, tail)
 }
 
+func ExecServiceByService(srvMain *definitions.Service, ops *definitions.Operation, cmd []string, attach bool) error {
+	return perform.DockerExec(srvMain, ops, cmd, attach)
+}
+
 func KillServiceByService(srvMain *definitions.Service, ops *definitions.Operation, timeout uint) error {
 	return perform.DockerStop(srvMain, ops, timeout)
 }

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -142,6 +142,27 @@ func TestLogsService(t *testing.T) {
 	}
 }
 
+func TestExecService(t *testing.T) {
+	if os.Getenv("TEST_IN_CIRCLE") == "true" {
+		logger.Println("Testing in Circle. Where we don't have exec privileges (due to their driver). Skipping test.")
+		return
+	}
+
+	testStartService(t, servName)
+	defer testKillService(t, servName, true)
+
+	do := def.NowDo()
+	do.Name = servName
+	do.Interactive = false
+	do.Args = strings.Fields("ls -la /root/")
+	logger.Debugf("Exec-ing serv (via tests) =>\t%s:%v\n", servName, strings.Join(do.Args, " "))
+	e := ExecService(do)
+	if e != nil {
+		logger.Errorln(e)
+		t.Fail()
+	}
+}
+
 func TestUpdateService(t *testing.T) {
 	testStartService(t, servName)
 	defer testKillService(t, servName, true)

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -143,10 +143,10 @@ func TestLogsService(t *testing.T) {
 }
 
 func TestExecService(t *testing.T) {
-	if os.Getenv("TEST_IN_CIRCLE") == "true" {
+	/*if os.Getenv("TEST_IN_CIRCLE") == "true" {
 		logger.Println("Testing in Circle. Where we don't have exec privileges (due to their driver). Skipping test.")
 		return
-	}
+	}*/
 
 	testStartService(t, servName)
 	defer testKillService(t, servName, true)


### PR DESCRIPTION
tests 
- pass on linux box, 
- pass then fail after package level tests on circle: `Get http:///var/run/docker.sock/v1.20/version: dial unix /var/run/docker.sock: no such file or directory.`
- chains_test fails on OSX because `index.docker.io` is down