### PR TITLE
Ports, links

### DIFF
--- a/actions/perform.go
+++ b/actions/perform.go
@@ -41,10 +41,10 @@ func Do(do *definitions.Do) error {
 func StartServicesAndChains(do *definitions.Do) error {
 	// start the services and chains
 	doSrvs := definitions.NowDo()
-	doSrvs.Args = do.Action.ServiceDeps
-	if len(doSrvs.Args) == 0 {
+	if do.Action.Dependencies == nil || len(do.Action.Dependencies.Services) == 0 {
 		logger.Debugf("No services to start.\n")
 	} else {
+		doSrvs.Args = do.Action.Dependencies.Services
 		logger.Debugf("Starting Services. Args =>\t%v\n", doSrvs.Args)
 		if err := services.StartService(doSrvs); err != nil {
 			return err
@@ -126,6 +126,8 @@ func resolveChain(do *definitions.Do) {
 }
 
 func resolveServices(do *definitions.Do) {
-	do.Action.ServiceDeps = append(do.Action.ServiceDeps, do.ServicesSlice...)
+	if do.Action.Dependencies != nil {
+		do.Action.Dependencies.Services = append(do.Action.Dependencies.Services, do.ServicesSlice...)
+	}
 	logger.Debugf("Services to start =>\t\t%v\n", do.Args)
 }

--- a/actions/writer.go
+++ b/actions/writer.go
@@ -50,7 +50,6 @@ func WriteActionDefinitionFile(actDef *def.Action, fileName string) error {
 		enc := toml.NewEncoder(writer)
 		enc.Indent = ""
 		writer.Write([]byte("name = \"" + actDef.Name + "\"\n"))
-		writer.Write([]byte("services = [ \"" + strings.Join(actDef.ServiceDeps, "\",\"") + "\" ]\n"))
 		writer.Write([]byte("chain = \"" + actDef.Chain + "\"\n"))
 		writer.Write([]byte("steps = [ \n"))
 		for _, s := range actDef.Steps {
@@ -62,6 +61,12 @@ func WriteActionDefinitionFile(actDef *def.Action, fileName string) error {
 		writer.Write([]byte("] \n"))
 		writer.Write([]byte("\n[environment]\n"))
 		enc.Encode(actDef.Environment)
+		writer.Write([]byte("[dependencies]\n"))
+		if actDef.Dependencies != nil {
+			if len(actDef.Dependencies.Services) != 0 || len(actDef.Dependencies.Chains) != 0 {
+				enc.Encode(actDef.Dependencies)
+			}
+		}
 		writer.Write([]byte("\n[maintainer]\n"))
 		enc.Encode(actDef.Maintainer)
 		writer.Write([]byte("\n[location]\n"))

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -107,8 +107,8 @@ func TestChainGraduate(t *testing.T) {
 		fatal(t, fmt.Errorf("FAILURE: improper service autodata on GRADUATE. expected: %t\tgot: %t\n", true, srvDef.Service.AutoData))
 	}
 
-	if len(srvDef.ServiceDeps.Dependencies) != 1 {
-		fatal(t, fmt.Errorf("FAILURE: improper service deps on GRADUATE. expected: [\"keys\"]\tgot: %s\n", srvDef.ServiceDeps))
+	if len(srvDef.Dependencies.Services) != 1 {
+		fatal(t, fmt.Errorf("FAILURE: improper service deps on GRADUATE. expected: [\"keys\"]\tgot: %s\n", srvDef.Dependencies.Services))
 	}
 }
 
@@ -357,8 +357,7 @@ func TestUpdateChain(t *testing.T) {
 	do.Name = chainName
 	do.SkipPull = true
 	logger.Infof("Updating chain (from tests) =>\t%s\n", do.Name)
-	e := UpdateChain(do)
-	if e != nil {
+	if e := UpdateChain(do); e != nil {
 		fatal(t, e)
 	}
 
@@ -374,8 +373,7 @@ func TestInspectChain(t *testing.T) {
 	do.Args = []string{"name"}
 	do.Operations.ContainerNumber = 1
 	logger.Debugf("Inspect chain (via tests) =>\t%s:%v\n", chainName, do.Args)
-	e := InspectChain(do)
-	if e != nil {
+	if e := InspectChain(do); e != nil {
 		fatal(t, fmt.Errorf("Error inspecting chain =>\t%v\n", e))
 	}
 	// log.SetLoggers(0, os.Stdout, os.Stderr)
@@ -391,8 +389,7 @@ func TestRenameChain(t *testing.T) {
 	do.Name = oldName
 	do.NewName = newName
 	logger.Infof("Renaming chain (from tests) =>\t%s:%s\n", do.Name, do.NewName)
-	e := RenameChain(do)
-	if e != nil {
+	if e := RenameChain(do); e != nil {
 		fatal(t, e)
 	}
 
@@ -402,8 +399,7 @@ func TestRenameChain(t *testing.T) {
 	do.Name = newName
 	do.NewName = chainName
 	logger.Infof("Renaming chain (from tests) =>\t%s:%s\n", do.Name, do.NewName)
-	e = RenameChain(do)
-	if e != nil {
+	if e := RenameChain(do); e != nil {
 		fatal(t, e)
 	}
 
@@ -447,8 +443,7 @@ func TestRmChain(t *testing.T) {
 	do.Name = chainName
 	do.RmD = true
 	logger.Infof("Removing chain (from tests) =>\n%s\n", do.Name)
-	e := RmChain(do)
-	if e != nil {
+	if e := RmChain(do); e != nil {
 		fatal(t, e)
 	}
 
@@ -463,8 +458,7 @@ func testStartChain(t *testing.T, chain string) {
 	do.Name = chain
 	do.Operations.ContainerNumber = 1
 	logger.Infof("Starting chain (from tests) =>\t%s\n", do.Name)
-	e := StartChain(do)
-	if e != nil {
+	if e := StartChain(do); e != nil {
 		logger.Errorln(e)
 		fatal(t, nil)
 	}
@@ -599,7 +593,21 @@ func removeChainContainer(t *testing.T, chainID string, cNum int) {
 }
 
 func testsTearDown() error {
+	killService("keys")
 	return os.RemoveAll(erisDir)
+}
+
+func killService(name string) {
+	do := def.NowDo()
+	do.Name = name
+	do.Args = []string{name}
+	do.Rm = true
+	do.RmD = true
+	e := services.KillService(do)
+	if e != nil {
+		logger.Errorln(e)
+		fatal(nil, e)
+	}
 }
 
 func ifExit(err error) {

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -303,10 +303,11 @@ func UpdateChain(do *definitions.Do) error {
 		return err
 	}
 
-	// if the chain is already running we need to set the right env vars and command
+	// set the right env vars and command
 	if IsChainRunning(chain) {
 		chain.Service.Environment = []string{fmt.Sprintf("CHAIN_ID=%s", do.Name)}
 		chain.Service.Environment = append(chain.Service.Environment, do.Env...)
+		chain.Service.Links = append(chain.Service.Links, do.Links...)
 		chain.Service.Command = loaders.ErisChainStart
 	}
 

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -151,6 +151,20 @@ func PlopChain(do *definitions.Do) error {
 	return ExecChain(do)
 }
 
+func PortsChain(do *definitions.Do) error {
+	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)
+	if err != nil {
+		return err
+	}
+
+	if IsChainExisting(chain) {
+		logger.Debugf("Chain exists, getting port mapping.\n")
+		return perform.PrintPortMappings(chain.Operations.SrvContainerID, do.Args)
+	}
+
+	return nil
+}
+
 func EditChain(do *definitions.Do) error {
 	chainConf, err := config.LoadViperConfig(path.Join(BlockchainsPath), do.Name, "chain")
 	if err != nil {

--- a/commands/chains.go
+++ b/commands/chains.go
@@ -320,9 +320,11 @@ func addChainsFlags() {
 	chainsNew.PersistentFlags().StringVarP(&do.ServerConf, "serverconf", "", "", "pass in a server_conf.toml file")
 	chainsNew.PersistentFlags().StringVarP(&do.CSV, "csv", "", "", "render a genesis.json from a csv file")
 	chainsNew.PersistentFlags().StringVarP(&do.Priv, "priv", "", "", "pass in a priv_validator.json file (dev-only!)")
+	chainsNew.PersistentFlags().StringVarP(&do.Address, "register", "r", "", "pubkey to use for registering the chain on etcb")
 	chainsNew.PersistentFlags().UintVarP(&do.N, "N", "", 1, "make a new genesis.json with this many validators and create data containers for each")
 	chainsNew.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish all ports")
 	chainsNew.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val1 syntax")
+	chainsNew.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val1 syntax")
 
 	chainsInstall.PersistentFlags().StringVarP(&do.ConfigFile, "config", "c", "", "main config file for the chain")
 	chainsInstall.PersistentFlags().StringVarP(&do.ServerConf, "serverconf", "", "", "pass in a server_conf.toml file")
@@ -330,10 +332,12 @@ func addChainsFlags() {
 	chainsInstall.PersistentFlags().StringVarP(&do.ChainID, "id", "", "", "id of the chain to fetch")
 	chainsInstall.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish all ports")
 	chainsInstall.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val1 syntax")
+	chainsInstall.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val1 syntax")
 
 	chainsStart.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish all ports")
 	chainsStart.PersistentFlags().BoolVarP(&do.Run, "api", "a", false, "turn the chain on using erisdb's api")
 	chainsStart.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val1 syntax")
+	chainsStart.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val1 syntax")
 
 	chainsLogs.Flags().BoolVarP(&do.Follow, "follow", "f", false, "follow logs, like tail -f")
 	chainsLogs.Flags().StringVarP(&do.Tail, "tail", "t", "all", "number of lines to show from end of logs")
@@ -346,6 +350,7 @@ func addChainsFlags() {
 	chainsUpdate.Flags().BoolVarP(&do.SkipPull, "pull", "p", true, "pull an updated version of the chain's base service image from docker hub")
 	chainsUpdate.Flags().UintVarP(&do.Timeout, "timeout", "t", 10, "manually set the timeout; overridden by --force")
 	chainsUpdate.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val1 syntax")
+	chainsUpdate.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val1 syntax")
 
 	chainsStop.Flags().BoolVarP(&do.Rm, "rm", "r", false, "remove containers after stopping")
 	chainsStop.Flags().BoolVarP(&do.RmD, "data", "x", false, "remove data containers after stopping")

--- a/commands/chains.go
+++ b/commands/chains.go
@@ -53,6 +53,7 @@ func buildChainsCommand() {
 	Chains.AddCommand(chainsCheckout)
 	Chains.AddCommand(chainsHead)
 	Chains.AddCommand(chainsPlop)
+	Chains.AddCommand(chainsPorts)
 	Chains.AddCommand(chainsEdit)
 	Chains.AddCommand(chainsExec)
 	Chains.AddCommand(chainsStart)
@@ -159,6 +160,13 @@ var chainsPlop = &cobra.Command{
 	Short: "Plop the genesis or config file",
 	Long:  "Plop the genesis or config file",
 	Run:   PlopChain,
+}
+
+var chainsPorts = &cobra.Command{
+	Use:   "ports",
+	Short: "Print the port mapping",
+	Long:  "Print the port mapping",
+	Run:   PortsChain,
 }
 
 var chainsHead = &cobra.Command{
@@ -437,7 +445,17 @@ func PlopChain(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(2, "eq", cmd, args))
 	do.ChainID = args[0]
 	do.Type = args[1]
+	if len(args) > 2 {
+		do.Args = args[2:]
+	}
 	IfExit(chns.PlopChain(do))
+}
+
+func PortsChain(cmd *cobra.Command, args []string) {
+	IfExit(ArgCheck(2, "ge", cmd, args))
+	do.Name = args[0]
+	do.Args = args[1:]
+	IfExit(chns.PortsChain(do))
 }
 
 // edit a chain definition file

--- a/commands/services.go
+++ b/commands/services.go
@@ -246,10 +246,12 @@ func addServicesFlags() {
 	servicesUpdate.Flags().BoolVarP(&do.Pull, "pull", "p", false, "skip the pulling feature and simply rebuild the service container")
 	servicesUpdate.Flags().UintVarP(&do.Timeout, "timeout", "t", 10, "manually set the timeout; overridden by --force")
 	servicesUpdate.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val1 syntax")
+	servicesUpdate.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val1 syntax")
 
+	servicesStart.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish all ports")
 	servicesStart.Flags().StringVarP(&do.ChainName, "chain", "c", "", "specify a chain the service depends on")
 	servicesStart.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val1 syntax")
-	servicesStart.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish all ports")
+	servicesStart.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val1 syntax")
 
 	servicesStop.Flags().BoolVarP(&do.All, "all", "a", false, "stop the primary service and its dependent services")
 	servicesStop.Flags().StringVarP(&do.ChainName, "chain", "c", "", "specify a chain the service should also stop")

--- a/commands/services.go
+++ b/commands/services.go
@@ -35,6 +35,7 @@ func buildServicesCommand() {
 	Services.AddCommand(servicesLogs)
 	Services.AddCommand(servicesListRunning)
 	Services.AddCommand(servicesInspect)
+	Services.AddCommand(servicesPorts)
 	Services.AddCommand(servicesExec)
 	Services.AddCommand(servicesStop)
 	Services.AddCommand(servicesExport)
@@ -147,6 +148,13 @@ see: https://github.com/fsouza/go-dockerclient/blob/master/container.go#L235`,
 	Run: InspectService,
 }
 
+var servicesPorts = &cobra.Command{
+	Use:   "ports [port]",
+	Short: "Print port mapping",
+	Long:  "Print port mapping",
+	Run:   PortsService,
+}
+
 var servicesExport = &cobra.Command{
 	Use:   "export [serviceName]",
 	Short: "Export a service definition file to IPFS.",
@@ -241,6 +249,7 @@ func addServicesFlags() {
 
 	servicesStart.Flags().StringVarP(&do.ChainName, "chain", "c", "", "specify a chain the service depends on")
 	servicesStart.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val1 syntax")
+	servicesStart.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish all ports")
 
 	servicesStop.Flags().BoolVarP(&do.All, "all", "a", false, "stop the primary service and its dependent services")
 	servicesStop.Flags().StringVarP(&do.ChainName, "chain", "c", "", "specify a chain the service should also stop")
@@ -329,6 +338,13 @@ func InspectService(cmd *cobra.Command, args []string) {
 	}
 
 	IfExit(srv.InspectService(do))
+}
+
+func PortsService(cmd *cobra.Command, args []string) {
+	IfExit(ArgCheck(2, "ge", cmd, args))
+	do.Name = args[0]
+	do.Args = args[1:]
+	IfExit(srv.PortsService(do))
 }
 
 func ExportService(cmd *cobra.Command, args []string) {

--- a/definitions/actions.go
+++ b/definitions/actions.go
@@ -5,7 +5,7 @@ type Action struct {
 	Name string `json:"name" yaml:"name" toml:"name"`
 	// an array of strings listing the services which eris should start prior
 	// to running the steps required for the action
-	ServiceDeps []string `json:"services" yaml:"services" toml:"services"`
+	Dependencies *Dependencies `json:"dependencies" yaml:"dependencies" toml:"dependencies"`
 	// a chain which should be started by eris prior to running the steps
 	// required for the action. can take a `$chain` string which would then
 	// be passed in via a command line flag

--- a/definitions/chains.go
+++ b/definitions/chains.go
@@ -9,11 +9,12 @@ type Chain struct {
 	ChainType string `mapstructure:"chain_type" json:"chain_type" yaml:"chain_type" toml:"chain_type"`
 
 	// same fields as in the Service Struct/Service Specification
-	Service    *Service    `json:"service,omitempty" yaml:"service,omitempty" toml:"service,omitempty"`
-	Maintainer *Maintainer `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
-	Location   *Location   `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
-	Machine    *Machine    `json:"machine,omitempty" yaml:"machine,omitempty" toml:"machine,omitempty"`
-	Operations *Operation
+	Service      *Service      `json:"service,omitempty" yaml:"service,omitempty" toml:"service,omitempty"`
+	Dependencies *Dependencies `json:"dependencies,omitempty" yaml:"dependencies,omitempty" toml:"dependencies,omitempty"`
+	Maintainer   *Maintainer   `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
+	Location     *Location     `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
+	Machine      *Machine      `json:"machine,omitempty" yaml:"machine,omitempty" toml:"machine,omitempty"`
+	Operations   *Operation
 }
 
 func BlankChain() *Chain {

--- a/definitions/contracts.go
+++ b/definitions/contracts.go
@@ -7,17 +7,17 @@ type Package struct {
 
 type Contracts struct {
 	// TODO: harmonize with dapps_definition_spec.md
-	Name        string            `json:"name" yaml:"name" toml:"name"`
-	PackageID   string            `json:"package_id" yaml:"package_id" toml:"package_id"`
-	Environment map[string]string `json:"environment" yaml:"environment" toml:"environment"`
-	ServiceDeps []string          `mapstructure:"services" json:"services" yaml:"services" toml:"services"`
-	ChainName   string            `json:"chain_name" yaml:"chain_name" toml:"chain_name"`
-	ChainID     string            `mapstructure:"chain_id" json:"chain_id" yaml:"chain_id" toml:"chain_id"`
-	ChainTypes  []string          `mapstructure:"chain_types" json:"chain_types" yaml:"chain_types" toml:"chain_types"`
-	TestType    string            `mapstructure:"test_type" json:"test_type" yaml:"test_type" toml:"test_type"`
-	DeployType  string            `mapstructure:"deploy_type" json:"deploy_type" yaml:"deploy_type" toml:"deploy_type"`
-	TestTask    string            `mapstructure:"test_task" json:"test_task" yaml:"test_task" toml:"test_task"`
-	DeployTask  string            `mapstructure:"deploy_task" json:"deploy_task" yaml:"deploy_task" toml:"deploy_task"`
+	Name         string            `json:"name" yaml:"name" toml:"name"`
+	PackageID    string            `json:"package_id" yaml:"package_id" toml:"package_id"`
+	Environment  map[string]string `json:"environment" yaml:"environment" toml:"environment"`
+	Dependencies *Dependencies     `json:"dependencies" yaml:"dependencies" toml:"dependencies"`
+	ChainName    string            `json:"chain_name" yaml:"chain_name" toml:"chain_name"`
+	ChainID      string            `mapstructure:"chain_id" json:"chain_id" yaml:"chain_id" toml:"chain_id"`
+	ChainTypes   []string          `mapstructure:"chain_types" json:"chain_types" yaml:"chain_types" toml:"chain_types"`
+	TestType     string            `mapstructure:"test_type" json:"test_type" yaml:"test_type" toml:"test_type"`
+	DeployType   string            `mapstructure:"deploy_type" json:"deploy_type" yaml:"deploy_type" toml:"deploy_type"`
+	TestTask     string            `mapstructure:"test_task" json:"test_task" yaml:"test_task" toml:"test_task"`
+	DeployTask   string            `mapstructure:"deploy_task" json:"deploy_task" yaml:"deploy_task" toml:"deploy_task"`
 
 	Maintainer *Maintainer `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
 	Location   *Location   `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -47,6 +47,9 @@ type Do struct {
 	// <key>=<value> pairs
 	Env []string `mapstructure:"," json:"," yaml:"," toml:","`
 
+	// <container_name>:<internal_name> pairs
+	Links []string `mapstructure:"," json:"," yaml:"," toml:","`
+
 	// Objects
 	Action            *Action
 	Chain             *Chain

--- a/definitions/service_definition.go
+++ b/definitions/service_definition.go
@@ -9,17 +9,18 @@ type ServiceDefinition struct {
 	// which would then be passed in via a command line flag
 	Chain string `json:"chain,omitempty" yaml:"chain,omitempty" toml:"chain,omitempty"`
 
-	Service     *Service     `json:"service" yaml:"service" toml:"service"`
-	ServiceDeps *ServiceDeps `mapstructure:"services" json:"services,omitempty", yaml:"services,omitempty" toml:"services,omitempty"`
-	Maintainer  *Maintainer  `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
-	Location    *Location    `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
-	Machine     *Machine     `json:"machine,omitempty" yaml:"machine,omitempty" toml:"machine,omitempty"`
-	Srvs        []*Service
-	Operations  *Operation
+	Service      *Service      `json:"service" yaml:"service" toml:"service"`
+	Dependencies *Dependencies `json:"dependencies,omitempty", yaml:"dependencies,omitempty" toml:"dependencies,omitempty"`
+	Maintainer   *Maintainer   `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
+	Location     *Location     `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
+	Machine      *Machine      `json:"machine,omitempty" yaml:"machine,omitempty" toml:"machine,omitempty"`
+	Srvs         []*Service
+	Operations   *Operation
 }
 
-type ServiceDeps struct {
-	Dependencies []string `mapstructure:"dependencies" json:"dependencies,omitempty" yaml:"dependencies,omitempty" toml:"dependencies,omitempty"`
+type Dependencies struct {
+	Chains   []string `json:"chains,omitempty" yaml:"chains,omitempty" toml:"chains,omitempty"`
+	Services []string `json:"services,omitempty" yaml:"services,omitempty" toml:"services,omitempty"`
 }
 
 func BlankServiceDefinition() *ServiceDefinition {

--- a/docs/actions_specification.md
+++ b/docs/actions_specification.md
@@ -15,7 +15,7 @@ eris will marshal the following fields from action definition files:
 Name        string            `json:"name" yaml:"name" toml:"name"`
 // an array of strings listing the services which eris should start prior
 // to running the steps required for the action
-ServiceDeps []string          `json:"services" yaml:"services" toml:"services"`
+Dependencies []string          `json:"dependencies" yaml:"dependencies" toml:"dependencies"`
 // a chain which should be started by eris prior to running the steps
 // required for the action. can take a `$chain` string which would then
 // be passed in via a command line flag

--- a/docs/services_specification.md
+++ b/docs/services_specification.md
@@ -20,12 +20,13 @@ ServiceID string `mapstructure:"service_id,omitempty" json:"service_id,omitempty
 Chain string `json:"chain,omitempty" yaml:"chain,omitempty" toml:"chain,omitempty"`
 
 Service     *Service     `json:"service" yaml:"service" toml:"service"`
-ServiceDeps *ServiceDeps `mapstructure:"services" json:"services,omitempty", yaml:"services,omitempty" toml:"services,omitempty"`
+Dependencies *Dependencies `mapstructure:"dependencies" json:"dependencies,omitempty", yaml:"dependencies,omitempty" toml:"dependencies,omitempty"`
 ```
 
 ```go
-type ServiceDeps struct {
-  Dependencies []string `mapstructure:"dependencies" json:"dependencies,omitempty" yaml:"dependencies,omitempty" toml:"dependencies,omitempty"`
+type Dependenciesstruct {
+	Chains   []string `json:"chains,omitempty" yaml:"chains,omitempty" toml:"chains,omitempty"`
+	Services []string `json:"services,omitempty" yaml:"services,omitempty" toml:"services,omitempty"`
 }
 ```
 

--- a/initialize/default_chains.go
+++ b/initialize/default_chains.go
@@ -17,6 +17,9 @@ data_container = true
 ports          = [ "1337", "46656", "46657" ]
 entry_point    = "erisdb-wrapper"
 
+[dependencies]
+services = [ "keys" ] 
+
 [maintainer]
 name = "Eris Industries"
 email = "support@erisindustries.com"

--- a/initialize/default_services.go
+++ b/initialize/default_services.go
@@ -1,7 +1,7 @@
 package initialize
 
 func DefaultKeys() string {
-  return `[service]
+	return `[service]
 name = "keys"
 
 image = "eris/keys"
@@ -10,7 +10,7 @@ data_container = true
 }
 
 func DefaultIpfs() string {
-  return `name = "ipfs"
+	return `name = "ipfs"
 
 [service]
 name = "ipfs"
@@ -33,7 +33,7 @@ requires = [""]
 }
 
 func DefaultIpfs2() string {
-  return `name = "ipfs"
+	return `name = "ipfs"
 
 [service]
 name = "ipfs"
@@ -42,8 +42,8 @@ data_container = true
 ports = ["4001:4001", "5001:5001", "8080:8080"]
 user = "root"
 
-[services]
-dependencies = ["keys"]
+[dependencies]
+services = ["keys"]
 
 [maintainer]
 name = "Eris Industries"

--- a/perform/docker_run.go
+++ b/perform/docker_run.go
@@ -783,12 +783,7 @@ func configureServiceContainer(srv *def.Service, ops *def.Operation) (docker.Cre
 
 	for _, port := range srv.Ports {
 		pS := strings.Split(port, ":")
-
-		pR := pS[len(pS)-1]
-		if len(strings.Split(pR, "/")) == 1 {
-			pR = pR + "/tcp"
-		}
-		pC := docker.Port(fmt.Sprintf("%s", pR))
+		pC := docker.Port(util.PortAndProtocol(pS[len(pS)-1]))
 
 		if len(pS) > 1 {
 			pH := docker.PortBinding{

--- a/perform/docker_run.go
+++ b/perform/docker_run.go
@@ -85,7 +85,7 @@ func DockerRunVolumesFromContainer(volumesFrom string, interactive bool, args []
 
 	// start the container (either interactive or one off command)
 	logger.Infof("Exec Container ID =>\t\t%s\n", id_main)
-	if err := startContainer(id_main, &opts); err != nil {
+	if err = startContainer(id_main, &opts); err != nil {
 		return nil, err
 	}
 
@@ -98,13 +98,13 @@ func DockerRunVolumesFromContainer(volumesFrom string, interactive bool, args []
 	}
 
 	logger.Infof("Waiting to exit for removal =>\t%s\n", id_main)
-	if err := waitContainer(id_main); err != nil {
+	if err = waitContainer(id_main); err != nil {
 		return nil, err
 	}
 
 	if !interactive {
 		logger.Debugf("Getting logs for container =>\t%s\n", id_main)
-		if err := logsContainer(id_main, true, "all"); err != nil {
+		if err = logsContainer(id_main, true, "all"); err != nil {
 			return nil, err
 		}
 		// now lets get the logs out

--- a/services/manage.go
+++ b/services/manage.go
@@ -154,6 +154,20 @@ func InspectService(do *definitions.Do) error {
 	return nil
 }
 
+func PortsService(do *definitions.Do) error {
+	service, err := loaders.LoadServiceDefinition(do.Name, false, do.Operations.ContainerNumber)
+	if err != nil {
+		return err
+	}
+
+	if IsServiceExisting(service.Service, service.Operations) {
+		logger.Debugf("Service exists, getting port mapping.\n")
+		return perform.PrintPortMappings(service.Operations.SrvContainerID, do.Args)
+	}
+
+	return nil
+}
+
 func LogsService(do *definitions.Do) error {
 	service, err := loaders.LoadServiceDefinition(do.Name, false, do.Operations.ContainerNumber)
 	if err != nil {

--- a/services/manage.go
+++ b/services/manage.go
@@ -235,6 +235,7 @@ func UpdateService(do *definitions.Do) error {
 		return err
 	}
 	service.Service.Environment = append(service.Service.Environment, do.Env...)
+	service.Service.Links = append(service.Service.Links, do.Links...)
 	err = perform.DockerRebuild(service.Service, service.Operations, do.Pull, do.Timeout)
 	if err != nil {
 		return err

--- a/services/operate.go
+++ b/services/operate.go
@@ -31,7 +31,7 @@ func StartService(do *definitions.Do) (err error) {
 
 	logger.Debugln("services before build chain")
 	for _, s := range services {
-		logger.Debugln("\t", s.Name, s.ServiceDeps, s.Service.Links, s.Service.VolumesFrom)
+		logger.Debugln("\t", s.Name, s.Dependencies, s.Service.Links, s.Service.VolumesFrom)
 	}
 	services, err = BuildChainGroup(do.ChainName, services)
 	if err != nil {
@@ -39,7 +39,7 @@ func StartService(do *definitions.Do) (err error) {
 	}
 	logger.Debugln("services after build chain")
 	for _, s := range services {
-		logger.Debugln("\t", s.Name, s.ServiceDeps, s.Service.Links, s.Service.VolumesFrom)
+		logger.Debugln("\t", s.Name, s.Dependencies, s.Service.Links, s.Service.VolumesFrom)
 	}
 
 	// NOTE: the top level service should be at the end of the list
@@ -115,8 +115,8 @@ func BuildServicesGroup(srvName string, cNum int, services ...*definitions.Servi
 	if err != nil {
 		return nil, err
 	}
-	if srv.ServiceDeps != nil {
-		for _, sName := range srv.ServiceDeps.Dependencies {
+	if srv.Dependencies != nil {
+		for _, sName := range srv.Dependencies.Services {
 			logger.Debugf("Found service dependency =>\t%s\n", sName)
 			s, e := BuildServicesGroup(sName, cNum)
 			if e != nil {
@@ -183,7 +183,7 @@ func ConnectChainToService(chainFlag, chainNameAndOpts string, srv *definitions.
 	}
 	// link the service container linked to the chain
 	// XXX: we may have name collision here if we're not careful.
-	loaders.ConnectToAChain(srv, chainName, internalName, link, mount)
+	loaders.ConnectToAChain(srv.Service, srv.Operations, chainName, internalName, link, mount)
 
 	util.OverWriteOperations(s.Operations, srv.Operations)
 	return s, nil

--- a/services/operate.go
+++ b/services/operate.go
@@ -45,6 +45,7 @@ func StartService(do *definitions.Do) (err error) {
 	// NOTE: the top level service should be at the end of the list
 	topService := services[len(services)-1]
 	topService.Service.Environment = append(topService.Service.Environment, do.Env...)
+	topService.Service.Links = append(topService.Service.Links, do.Links...)
 	services[len(services)-1] = topService
 
 	logger.Infof("Starting Services Group.\n")

--- a/services/writer.go
+++ b/services/writer.go
@@ -57,9 +57,11 @@ func WriteServiceDefinitionFile(serviceDef *def.ServiceDefinition, fileName stri
 		}
 		writer.Write([]byte("[service]\n"))
 		enc.Encode(serviceDef.Service)
-		writer.Write([]byte("[services]\n"))
-		if serviceDef.ServiceDeps != nil && len(serviceDef.ServiceDeps.Dependencies) != 0 {
-			enc.Encode(serviceDef.ServiceDeps)
+		writer.Write([]byte("[dependencies]\n"))
+		if serviceDef.Dependencies != nil {
+			if len(serviceDef.Dependencies.Services) != 0 || len(serviceDef.Dependencies.Chains) != 0 {
+				enc.Encode(serviceDef.Dependencies)
+			}
 		}
 		writer.Write([]byte("\n[maintainer]\n"))
 		enc.Encode(serviceDef.Maintainer)

--- a/util/container_info.go
+++ b/util/container_info.go
@@ -317,3 +317,10 @@ func erisRegExpLinks(typ string) *regexp.Regexp {
 func NameAndNumber(name string, num int) string {
 	return fmt.Sprintf("%s_%d", name, num)
 }
+
+func PortAndProtocol(port string) docker.Port {
+	if len(strings.Split(port, "/")) == 1 {
+		port += "/tcp"
+	}
+	return docker.Port(port)
+}


### PR DESCRIPTION
- fixes csv handling on new so we can pass in two csvs (one for validators, one for accounts)
- add command for printing port mappings
- allow chains and services to link to arbitrary containers from command line (mostly to facilitate dev)