### PR TITLE
dependencies refactor, chains dependencies

### DIFF
--- a/actions/perform.go
+++ b/actions/perform.go
@@ -41,10 +41,10 @@ func Do(do *definitions.Do) error {
 func StartServicesAndChains(do *definitions.Do) error {
 	// start the services and chains
 	doSrvs := definitions.NowDo()
-	doSrvs.Args = do.Action.ServiceDeps
-	if len(doSrvs.Args) == 0 {
+	if do.Action.Dependencies == nil || len(do.Action.Dependencies.Services) == 0 {
 		logger.Debugf("No services to start.\n")
 	} else {
+		doSrvs.Args = do.Action.Dependencies.Services
 		logger.Debugf("Starting Services. Args =>\t%v\n", doSrvs.Args)
 		if err := services.StartService(doSrvs); err != nil {
 			return err
@@ -126,6 +126,8 @@ func resolveChain(do *definitions.Do) {
 }
 
 func resolveServices(do *definitions.Do) {
-	do.Action.ServiceDeps = append(do.Action.ServiceDeps, do.ServicesSlice...)
+	if do.Action.Dependencies != nil {
+		do.Action.Dependencies.Services = append(do.Action.Dependencies.Services, do.ServicesSlice...)
+	}
 	logger.Debugf("Services to start =>\t\t%v\n", do.Args)
 }

--- a/actions/writer.go
+++ b/actions/writer.go
@@ -50,7 +50,6 @@ func WriteActionDefinitionFile(actDef *def.Action, fileName string) error {
 		enc := toml.NewEncoder(writer)
 		enc.Indent = ""
 		writer.Write([]byte("name = \"" + actDef.Name + "\"\n"))
-		writer.Write([]byte("services = [ \"" + strings.Join(actDef.ServiceDeps, "\",\"") + "\" ]\n"))
 		writer.Write([]byte("chain = \"" + actDef.Chain + "\"\n"))
 		writer.Write([]byte("steps = [ \n"))
 		for _, s := range actDef.Steps {
@@ -62,6 +61,12 @@ func WriteActionDefinitionFile(actDef *def.Action, fileName string) error {
 		writer.Write([]byte("] \n"))
 		writer.Write([]byte("\n[environment]\n"))
 		enc.Encode(actDef.Environment)
+		writer.Write([]byte("[dependencies]\n"))
+		if actDef.Dependencies != nil {
+			if len(actDef.Dependencies.Services) != 0 || len(actDef.Dependencies.Chains) != 0 {
+				enc.Encode(actDef.Dependencies)
+			}
+		}
 		writer.Write([]byte("\n[maintainer]\n"))
 		enc.Encode(actDef.Maintainer)
 		writer.Write([]byte("\n[location]\n"))

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -107,8 +107,8 @@ func TestChainGraduate(t *testing.T) {
 		fatal(t, fmt.Errorf("FAILURE: improper service autodata on GRADUATE. expected: %t\tgot: %t\n", true, srvDef.Service.AutoData))
 	}
 
-	if len(srvDef.ServiceDeps.Dependencies) != 1 {
-		fatal(t, fmt.Errorf("FAILURE: improper service deps on GRADUATE. expected: [\"keys\"]\tgot: %s\n", srvDef.ServiceDeps))
+	if len(srvDef.Dependencies.Services) != 1 {
+		fatal(t, fmt.Errorf("FAILURE: improper service deps on GRADUATE. expected: [\"keys\"]\tgot: %s\n", srvDef.Dependencies.Services))
 	}
 }
 
@@ -357,8 +357,7 @@ func TestUpdateChain(t *testing.T) {
 	do.Name = chainName
 	do.SkipPull = true
 	logger.Infof("Updating chain (from tests) =>\t%s\n", do.Name)
-	e := UpdateChain(do)
-	if e != nil {
+	if e := UpdateChain(do); e != nil {
 		fatal(t, e)
 	}
 
@@ -374,8 +373,7 @@ func TestInspectChain(t *testing.T) {
 	do.Args = []string{"name"}
 	do.Operations.ContainerNumber = 1
 	logger.Debugf("Inspect chain (via tests) =>\t%s:%v\n", chainName, do.Args)
-	e := InspectChain(do)
-	if e != nil {
+	if e := InspectChain(do); e != nil {
 		fatal(t, fmt.Errorf("Error inspecting chain =>\t%v\n", e))
 	}
 	// log.SetLoggers(0, os.Stdout, os.Stderr)
@@ -391,8 +389,7 @@ func TestRenameChain(t *testing.T) {
 	do.Name = oldName
 	do.NewName = newName
 	logger.Infof("Renaming chain (from tests) =>\t%s:%s\n", do.Name, do.NewName)
-	e := RenameChain(do)
-	if e != nil {
+	if e := RenameChain(do); e != nil {
 		fatal(t, e)
 	}
 
@@ -402,8 +399,7 @@ func TestRenameChain(t *testing.T) {
 	do.Name = newName
 	do.NewName = chainName
 	logger.Infof("Renaming chain (from tests) =>\t%s:%s\n", do.Name, do.NewName)
-	e = RenameChain(do)
-	if e != nil {
+	if e := RenameChain(do); e != nil {
 		fatal(t, e)
 	}
 
@@ -447,8 +443,7 @@ func TestRmChain(t *testing.T) {
 	do.Name = chainName
 	do.RmD = true
 	logger.Infof("Removing chain (from tests) =>\n%s\n", do.Name)
-	e := RmChain(do)
-	if e != nil {
+	if e := RmChain(do); e != nil {
 		fatal(t, e)
 	}
 
@@ -463,8 +458,7 @@ func testStartChain(t *testing.T, chain string) {
 	do.Name = chain
 	do.Operations.ContainerNumber = 1
 	logger.Infof("Starting chain (from tests) =>\t%s\n", do.Name)
-	e := StartChain(do)
-	if e != nil {
+	if e := StartChain(do); e != nil {
 		logger.Errorln(e)
 		fatal(t, nil)
 	}
@@ -599,7 +593,21 @@ func removeChainContainer(t *testing.T, chainID string, cNum int) {
 }
 
 func testsTearDown() error {
+	killService("keys")
 	return os.RemoveAll(erisDir)
+}
+
+func killService(name string) {
+	do := def.NowDo()
+	do.Name = name
+	do.Args = []string{name}
+	do.Rm = true
+	do.RmD = true
+	e := services.KillService(do)
+	if e != nil {
+		logger.Errorln(e)
+		fatal(nil, e)
+	}
 }
 
 func ifExit(err error) {

--- a/definitions/actions.go
+++ b/definitions/actions.go
@@ -5,7 +5,7 @@ type Action struct {
 	Name string `json:"name" yaml:"name" toml:"name"`
 	// an array of strings listing the services which eris should start prior
 	// to running the steps required for the action
-	ServiceDeps []string `json:"services" yaml:"services" toml:"services"`
+	Dependencies *Dependencies `json:"dependencies" yaml:"dependencies" toml:"dependencies"`
 	// a chain which should be started by eris prior to running the steps
 	// required for the action. can take a `$chain` string which would then
 	// be passed in via a command line flag

--- a/definitions/chains.go
+++ b/definitions/chains.go
@@ -9,11 +9,12 @@ type Chain struct {
 	ChainType string `mapstructure:"chain_type" json:"chain_type" yaml:"chain_type" toml:"chain_type"`
 
 	// same fields as in the Service Struct/Service Specification
-	Service    *Service    `json:"service,omitempty" yaml:"service,omitempty" toml:"service,omitempty"`
-	Maintainer *Maintainer `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
-	Location   *Location   `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
-	Machine    *Machine    `json:"machine,omitempty" yaml:"machine,omitempty" toml:"machine,omitempty"`
-	Operations *Operation
+	Service      *Service      `json:"service,omitempty" yaml:"service,omitempty" toml:"service,omitempty"`
+	Dependencies *Dependencies `json:"dependencies,omitempty" yaml:"dependencies,omitempty" toml:"dependencies,omitempty"`
+	Maintainer   *Maintainer   `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
+	Location     *Location     `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
+	Machine      *Machine      `json:"machine,omitempty" yaml:"machine,omitempty" toml:"machine,omitempty"`
+	Operations   *Operation
 }
 
 func BlankChain() *Chain {

--- a/definitions/contracts.go
+++ b/definitions/contracts.go
@@ -7,17 +7,17 @@ type Package struct {
 
 type Contracts struct {
 	// TODO: harmonize with dapps_definition_spec.md
-	Name        string            `json:"name" yaml:"name" toml:"name"`
-	PackageID   string            `json:"package_id" yaml:"package_id" toml:"package_id"`
-	Environment map[string]string `json:"environment" yaml:"environment" toml:"environment"`
-	ServiceDeps []string          `mapstructure:"services" json:"services" yaml:"services" toml:"services"`
-	ChainName   string            `json:"chain_name" yaml:"chain_name" toml:"chain_name"`
-	ChainID     string            `mapstructure:"chain_id" json:"chain_id" yaml:"chain_id" toml:"chain_id"`
-	ChainTypes  []string          `mapstructure:"chain_types" json:"chain_types" yaml:"chain_types" toml:"chain_types"`
-	TestType    string            `mapstructure:"test_type" json:"test_type" yaml:"test_type" toml:"test_type"`
-	DeployType  string            `mapstructure:"deploy_type" json:"deploy_type" yaml:"deploy_type" toml:"deploy_type"`
-	TestTask    string            `mapstructure:"test_task" json:"test_task" yaml:"test_task" toml:"test_task"`
-	DeployTask  string            `mapstructure:"deploy_task" json:"deploy_task" yaml:"deploy_task" toml:"deploy_task"`
+	Name         string            `json:"name" yaml:"name" toml:"name"`
+	PackageID    string            `json:"package_id" yaml:"package_id" toml:"package_id"`
+	Environment  map[string]string `json:"environment" yaml:"environment" toml:"environment"`
+	Dependencies *Dependencies     `json:"dependencies" yaml:"dependencies" toml:"dependencies"`
+	ChainName    string            `json:"chain_name" yaml:"chain_name" toml:"chain_name"`
+	ChainID      string            `mapstructure:"chain_id" json:"chain_id" yaml:"chain_id" toml:"chain_id"`
+	ChainTypes   []string          `mapstructure:"chain_types" json:"chain_types" yaml:"chain_types" toml:"chain_types"`
+	TestType     string            `mapstructure:"test_type" json:"test_type" yaml:"test_type" toml:"test_type"`
+	DeployType   string            `mapstructure:"deploy_type" json:"deploy_type" yaml:"deploy_type" toml:"deploy_type"`
+	TestTask     string            `mapstructure:"test_task" json:"test_task" yaml:"test_task" toml:"test_task"`
+	DeployTask   string            `mapstructure:"deploy_task" json:"deploy_task" yaml:"deploy_task" toml:"deploy_task"`
 
 	Maintainer *Maintainer `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
 	Location   *Location   `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`

--- a/definitions/service_definition.go
+++ b/definitions/service_definition.go
@@ -9,17 +9,18 @@ type ServiceDefinition struct {
 	// which would then be passed in via a command line flag
 	Chain string `json:"chain,omitempty" yaml:"chain,omitempty" toml:"chain,omitempty"`
 
-	Service     *Service     `json:"service" yaml:"service" toml:"service"`
-	ServiceDeps *ServiceDeps `mapstructure:"services" json:"services,omitempty", yaml:"services,omitempty" toml:"services,omitempty"`
-	Maintainer  *Maintainer  `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
-	Location    *Location    `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
-	Machine     *Machine     `json:"machine,omitempty" yaml:"machine,omitempty" toml:"machine,omitempty"`
-	Srvs        []*Service
-	Operations  *Operation
+	Service      *Service      `json:"service" yaml:"service" toml:"service"`
+	Dependencies *Dependencies `json:"dependencies,omitempty", yaml:"dependencies,omitempty" toml:"dependencies,omitempty"`
+	Maintainer   *Maintainer   `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
+	Location     *Location     `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
+	Machine      *Machine      `json:"machine,omitempty" yaml:"machine,omitempty" toml:"machine,omitempty"`
+	Srvs         []*Service
+	Operations   *Operation
 }
 
-type ServiceDeps struct {
-	Dependencies []string `mapstructure:"dependencies" json:"dependencies,omitempty" yaml:"dependencies,omitempty" toml:"dependencies,omitempty"`
+type Dependencies struct {
+	Chains   []string `json:"chains,omitempty" yaml:"chains,omitempty" toml:"chains,omitempty"`
+	Services []string `json:"services,omitempty" yaml:"services,omitempty" toml:"services,omitempty"`
 }
 
 func BlankServiceDefinition() *ServiceDefinition {

--- a/docs/actions_specification.md
+++ b/docs/actions_specification.md
@@ -15,7 +15,7 @@ eris will marshal the following fields from action definition files:
 Name        string            `json:"name" yaml:"name" toml:"name"`
 // an array of strings listing the services which eris should start prior
 // to running the steps required for the action
-ServiceDeps []string          `json:"services" yaml:"services" toml:"services"`
+Dependencies []string          `json:"dependencies" yaml:"dependencies" toml:"dependencies"`
 // a chain which should be started by eris prior to running the steps
 // required for the action. can take a `$chain` string which would then
 // be passed in via a command line flag

--- a/docs/services_specification.md
+++ b/docs/services_specification.md
@@ -20,12 +20,13 @@ ServiceID string `mapstructure:"service_id,omitempty" json:"service_id,omitempty
 Chain string `json:"chain,omitempty" yaml:"chain,omitempty" toml:"chain,omitempty"`
 
 Service     *Service     `json:"service" yaml:"service" toml:"service"`
-ServiceDeps *ServiceDeps `mapstructure:"services" json:"services,omitempty", yaml:"services,omitempty" toml:"services,omitempty"`
+Dependencies *Dependencies `mapstructure:"dependencies" json:"dependencies,omitempty", yaml:"dependencies,omitempty" toml:"dependencies,omitempty"`
 ```
 
 ```go
-type ServiceDeps struct {
-  Dependencies []string `mapstructure:"dependencies" json:"dependencies,omitempty" yaml:"dependencies,omitempty" toml:"dependencies,omitempty"`
+type Dependenciesstruct {
+	Chains   []string `json:"chains,omitempty" yaml:"chains,omitempty" toml:"chains,omitempty"`
+	Services []string `json:"services,omitempty" yaml:"services,omitempty" toml:"services,omitempty"`
 }
 ```
 

--- a/initialize/default_chains.go
+++ b/initialize/default_chains.go
@@ -17,6 +17,9 @@ data_container = true
 ports          = [ "1337", "46656", "46657" ]
 entry_point    = "erisdb-wrapper"
 
+[dependencies]
+services = [ "keys" ] 
+
 [maintainer]
 name = "Eris Industries"
 email = "support@erisindustries.com"

--- a/initialize/default_services.go
+++ b/initialize/default_services.go
@@ -1,7 +1,7 @@
 package initialize
 
 func DefaultKeys() string {
-  return `[service]
+	return `[service]
 name = "keys"
 
 image = "eris/keys"
@@ -10,7 +10,7 @@ data_container = true
 }
 
 func DefaultIpfs() string {
-  return `name = "ipfs"
+	return `name = "ipfs"
 
 [service]
 name = "ipfs"
@@ -33,7 +33,7 @@ requires = [""]
 }
 
 func DefaultIpfs2() string {
-  return `name = "ipfs"
+	return `name = "ipfs"
 
 [service]
 name = "ipfs"
@@ -42,8 +42,8 @@ data_container = true
 ports = ["4001:4001", "5001:5001", "8080:8080"]
 user = "root"
 
-[services]
-dependencies = ["keys"]
+[dependencies]
+services = ["keys"]
 
 [maintainer]
 name = "Eris Industries"

--- a/perform/docker_run.go
+++ b/perform/docker_run.go
@@ -85,7 +85,7 @@ func DockerRunVolumesFromContainer(volumesFrom string, interactive bool, args []
 
 	// start the container (either interactive or one off command)
 	logger.Infof("Exec Container ID =>\t\t%s\n", id_main)
-	if err := startContainer(id_main, &opts); err != nil {
+	if err = startContainer(id_main, &opts); err != nil {
 		return nil, err
 	}
 
@@ -98,13 +98,13 @@ func DockerRunVolumesFromContainer(volumesFrom string, interactive bool, args []
 	}
 
 	logger.Infof("Waiting to exit for removal =>\t%s\n", id_main)
-	if err := waitContainer(id_main); err != nil {
+	if err = waitContainer(id_main); err != nil {
 		return nil, err
 	}
 
 	if !interactive {
 		logger.Debugf("Getting logs for container =>\t%s\n", id_main)
-		if err := logsContainer(id_main, true, "all"); err != nil {
+		if err = logsContainer(id_main, true, "all"); err != nil {
 			return nil, err
 		}
 		// now lets get the logs out

--- a/services/operate.go
+++ b/services/operate.go
@@ -31,7 +31,7 @@ func StartService(do *definitions.Do) (err error) {
 
 	logger.Debugln("services before build chain")
 	for _, s := range services {
-		logger.Debugln("\t", s.Name, s.ServiceDeps, s.Service.Links, s.Service.VolumesFrom)
+		logger.Debugln("\t", s.Name, s.Dependencies, s.Service.Links, s.Service.VolumesFrom)
 	}
 	services, err = BuildChainGroup(do.ChainName, services)
 	if err != nil {
@@ -39,7 +39,7 @@ func StartService(do *definitions.Do) (err error) {
 	}
 	logger.Debugln("services after build chain")
 	for _, s := range services {
-		logger.Debugln("\t", s.Name, s.ServiceDeps, s.Service.Links, s.Service.VolumesFrom)
+		logger.Debugln("\t", s.Name, s.Dependencies, s.Service.Links, s.Service.VolumesFrom)
 	}
 
 	// NOTE: the top level service should be at the end of the list
@@ -115,8 +115,8 @@ func BuildServicesGroup(srvName string, cNum int, services ...*definitions.Servi
 	if err != nil {
 		return nil, err
 	}
-	if srv.ServiceDeps != nil {
-		for _, sName := range srv.ServiceDeps.Dependencies {
+	if srv.Dependencies != nil {
+		for _, sName := range srv.Dependencies.Services {
 			logger.Debugf("Found service dependency =>\t%s\n", sName)
 			s, e := BuildServicesGroup(sName, cNum)
 			if e != nil {
@@ -183,7 +183,7 @@ func ConnectChainToService(chainFlag, chainNameAndOpts string, srv *definitions.
 	}
 	// link the service container linked to the chain
 	// XXX: we may have name collision here if we're not careful.
-	loaders.ConnectToAChain(srv, chainName, internalName, link, mount)
+	loaders.ConnectToAChain(srv.Service, srv.Operations, chainName, internalName, link, mount)
 
 	util.OverWriteOperations(s.Operations, srv.Operations)
 	return s, nil

--- a/services/writer.go
+++ b/services/writer.go
@@ -57,9 +57,11 @@ func WriteServiceDefinitionFile(serviceDef *def.ServiceDefinition, fileName stri
 		}
 		writer.Write([]byte("[service]\n"))
 		enc.Encode(serviceDef.Service)
-		writer.Write([]byte("[services]\n"))
-		if serviceDef.ServiceDeps != nil && len(serviceDef.ServiceDeps.Dependencies) != 0 {
-			enc.Encode(serviceDef.ServiceDeps)
+		writer.Write([]byte("[dependencies]\n"))
+		if serviceDef.Dependencies != nil {
+			if len(serviceDef.Dependencies.Services) != 0 || len(serviceDef.Dependencies.Chains) != 0 {
+				enc.Encode(serviceDef.Dependencies)
+			}
 		}
 		writer.Write([]byte("\n[maintainer]\n"))
 		enc.Encode(serviceDef.Maintainer)


### PR DESCRIPTION
dependencies now show up as

```
[dependencies]
services = [ "..." ]
chains = [ "..." ]
```

The current state of this PR does not use the chains dependencies from services (we should probably leave that for a much later TODO).

Services depending on services is as before.

Chains depending on services only works for simple services (ie. without recursive dependencies) - but we can fix that easily in this PR

Chains depending on chains require those chains to already be up and running else the command will fail.

