### PR TITLE
Disentangle `init` & `update`; closes #254

### DIFF
--- a/commands/eris.go
+++ b/commands/eris.go
@@ -84,6 +84,9 @@ func AddCommands() {
 	ErisCmd.AddCommand(VerSion)
 	buildInitCommand()
 	ErisCmd.AddCommand(Init)
+	buildUpdateCommand()
+	ErisCmd.AddCommand(Update)
+
 }
 
 // Global Do struct

--- a/commands/init.go
+++ b/commands/init.go
@@ -9,9 +9,8 @@ import (
 
 // flags to add: --no-clone
 var Init = &cobra.Command{
-	Use:     "init",
-	Aliases: []string{"update"},
-	Short:   "Initialize the ~/.eris directory with default files or update to latest version",
+	Use:   "init",
+	Short: "Initialize the ~/.eris directory with default files or update to latest version",
 	Long: `Create the ~/.eris directory with actions and services subfolders
 and clone eris-ltd/eris-actions eris-ltd/eris-services into them, respectively.
 `,
@@ -29,28 +28,16 @@ func addInitFlags() {
 	Init.Flags().BoolVarP(&do.Services, "services", "", false, "only update the default services (requires git to be installed)")
 	Init.Flags().BoolVarP(&do.Actions, "actions", "", false, "only update the default actions (requires git to be installed)")
 	Init.Flags().BoolVarP(&do.Yes, "yes", "", false, "over-ride command-line prompts (requires git to be installed)")
-	Init.Flags().BoolVarP(&do.Tool, "tool", "", false, "only update the eris cli tool and nothing else (requires git and go to be installed)")
-	Init.Flags().StringVarP(&do.Branch, "branch", "b", "master", "specify a branch to update from (mostly used for eris update) (requires git to be installed)")
-	Init.Flags().BoolVarP(&do.All, "all", "", false, "update all the above and skip command-line prompts (requires git and go to be installed)")
 }
 
 func Router(cmd *cobra.Command, args []string) {
-	switch {
-	case do.Yes:
+	if do.Yes {
 		do.Services = true
 		do.Actions = true
-	case do.All:
-		do.Services = true
-		do.Actions = true
-		do.Tool = true
 	}
 
-	if do.Tool {
-		util.UpdateEris(do.Branch)
-
-		if !do.All {
-			return
-		}
+	if !do.Pull {
+		util.CheckGitAndGo(true, false)
 	}
 
 	ini.Initialize(do)

--- a/commands/update.go
+++ b/commands/update.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"github.com/eris-ltd/eris-cli/util"
+
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
+)
+
+var Update = &cobra.Command{
+	Use:   "update",
+	Short: "Update the eris tool",
+	Long: `Fetches the latest version (master branch by default)
+and re-installs eris; requires git and go to be installed.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		UpdateTool(cmd, args)
+	},
+}
+
+func buildUpdateCommand() {
+	addUpdateFlags()
+}
+
+func addUpdateFlags() {
+
+	Update.Flags().StringVarP(&do.Branch, "branch", "b", "master", "specify a branch to update from")
+}
+
+func UpdateTool(cmd *cobra.Command, args []string) {
+	util.UpdateEris(do.Branch)
+
+}

--- a/util/update_tool.go
+++ b/util/update_tool.go
@@ -5,14 +5,12 @@ import (
 	"os"
 	"os/exec"
 	"path"
-
-	"github.com/eris-ltd/eris-cli/version"
 )
 
 func UpdateEris(branch string) {
 
 	//check that git/go are installed
-	CheckGitAndGo()
+	CheckGitAndGo(true, true)
 
 	//change pwd to eris/cli
 	ChangeDirectory()
@@ -25,21 +23,27 @@ func UpdateEris(branch string) {
 	PullBranch(branch)
 
 	InstallEris()
+	ver := version() //because version.Version will be in RAM.
 
-	fmt.Printf("The marmots have updated eris successful.\nEris CLI Version is now: %s\n", version.VERSION)
+	logger.Printf("The marmots have updated eris successfully.\n%s", ver)
 }
 
-func CheckGitAndGo() {
-	stdOut1, err := exec.Command("go", "version").CombinedOutput()
-	if err != nil {
-		fmt.Printf("ensure you have go installed:\n%s\n", string(stdOut1))
-		os.Exit(1)
-	}
+func CheckGitAndGo(git, gO bool) {
+	if git {
+		stdOut1, err := exec.Command("git", "version").CombinedOutput()
+		if err != nil {
+			logger.Printf("ensure you have git installed:\n%v\n", string(stdOut1))
+			logger.Println("or if running `eris init` use the --skip-pull flag")
+			os.Exit(1)
 
-	stdOut2, err := exec.Command("git", "version").CombinedOutput()
-	if err != nil {
-		fmt.Printf("ensure you have git installed:\n%v\n", string(stdOut2))
-		os.Exit(1)
+		}
+	}
+	if gO {
+		stdOut2, err := exec.Command("go", "version").CombinedOutput()
+		if err != nil {
+			logger.Printf("ensure you have go installed:\n%s\n", string(stdOut2))
+			os.Exit(1)
+		}
 	}
 }
 
@@ -95,4 +99,16 @@ func InstallEris() {
 	}
 
 	logger.Debugf("Go install worked correctly.\n")
+}
+
+func version() string {
+	verArgs := []string{"version"}
+
+	stdOut, err := exec.Command("eris", verArgs...).CombinedOutput()
+	if err != nil {
+		fmt.Printf("error getting version:\n%s\n", string(stdOut))
+		os.Exit(1)
+	}
+	return string(stdOut)
+
 }


### PR DESCRIPTION
also, checks that git is installed for `eris init` otherwise "prompts" user to `--skip-pull` but that could be handled more cleanly