### PR TITLE
Exec command fixes

### DIFF
--- a/chains/manage.go
+++ b/chains/manage.go
@@ -377,7 +377,6 @@ func RmChain(do *definitions.Do) error {
 		if err != nil {
 			return err
 		}
-		oldFile = path.Join(BlockchainsPath, oldFile) + ".toml"
 		logger.Printf("Removing file =>\t\t%s\n", oldFile)
 		if err := os.Remove(oldFile); err != nil {
 			return err

--- a/chains/operate.go
+++ b/chains/operate.go
@@ -34,46 +34,6 @@ func InstallChain(do *definitions.Do) error {
 	return setupChain(do, loaders.ErisChainInstall)
 }
 
-func StartChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)
-	if err != nil {
-		logger.Infoln("Cannot start a chain I cannot find.")
-		do.Result = "no file"
-		return nil
-	}
-
-	if chain.Name == "" {
-		logger.Infoln("Cannot start a chain without a name.")
-		do.Result = "no name"
-		return nil
-	}
-
-	// boot the dependencies (eg. keys)
-	if err := bootDependencies(chain, do); err != nil {
-		return err
-	}
-
-	chain.Service.Command = loaders.ErisChainStart
-	util.OverWriteOperations(chain.Operations, do.Operations)
-	chain.Service.Environment = append(chain.Service.Environment, "CHAIN_ID="+chain.ChainID)
-	chain.Service.Environment = append(chain.Service.Environment, do.Env...)
-	if do.Run {
-		chain.Service.Environment = append(chain.Service.Environment, "ERISDB_API=true")
-	}
-	chain.Service.Links = append(chain.Service.Links, do.Links...)
-
-	logger.Infof("StartChainRaw to DockerRun =>\t%s\n", chain.Service.Name)
-	logger.Debugf("\twith ChainID =>\t\t%v\n", chain.ChainID)
-	logger.Debugf("\twith Environment =>\t%v\n", chain.Service.Environment)
-	logger.Debugf("\twith AllPortsPublshd =>\t%v\n", chain.Operations.PublishAllPorts)
-	if err := perform.DockerRun(chain.Service, chain.Operations); err != nil {
-		do.Result = "error"
-		return err
-	}
-
-	return nil
-}
-
 func KillChain(do *definitions.Do) error {
 	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)
 	if err != nil {
@@ -103,20 +63,12 @@ func KillChain(do *definitions.Do) error {
 	return nil
 }
 
+func StartChain(do *definitions.Do) error {
+	return startChain(do, false)
+}
+
 func ExecChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)
-	if err != nil {
-		return err
-	}
-
-	if IsChainExisting(chain) {
-		logger.Infoln("Chain exists.")
-		return perform.DockerExec(chain.Service, chain.Operations, do.Args, do.Interactive)
-	} else {
-		return fmt.Errorf("Chain does not exist. Please start the chain container with eris chains start %s.\n", do.Name)
-	}
-
-	return nil
+	return startChain(do, true)
 }
 
 // Throw away chains are used for eris contracts
@@ -136,6 +88,51 @@ func ThrowAwayChain(do *definitions.Do) error {
 }
 
 //------------------------------------------------------------------------
+func startChain(do *definitions.Do, exec bool) error {
+	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)
+	if err != nil {
+		logger.Errorln("Cannot start a chain I cannot find.")
+		do.Result = "no file"
+		return nil
+	}
+
+	if chain.Name == "" {
+		logger.Errorln("Cannot start a chain without a name.")
+		do.Result = "no name"
+		return nil
+	}
+
+	// boot the dependencies (eg. keys)
+	if err := bootDependencies(chain, do); err != nil {
+		return err
+	}
+
+	chain.Service.Command = loaders.ErisChainStart
+	util.OverWriteOperations(chain.Operations, do.Operations)
+	chain.Service.Environment = append(chain.Service.Environment, "CHAIN_ID="+chain.ChainID)
+	chain.Service.Environment = append(chain.Service.Environment, do.Env...)
+	if do.Run {
+		chain.Service.Environment = append(chain.Service.Environment, "ERISDB_API=true")
+	}
+	chain.Service.Links = append(chain.Service.Links, do.Links...)
+
+	logger.Infof("StartChainRaw to DockerRun =>\t%s\n", chain.Service.Name)
+	logger.Debugf("\twith ChainID =>\t\t%v\n", chain.ChainID)
+	logger.Debugf("\twith Environment =>\t%v\n", chain.Service.Environment)
+	logger.Debugf("\twith AllPortsPublshd =>\t%v\n", chain.Operations.PublishAllPorts)
+
+	if exec {
+		err = perform.DockerRunInteractive(chain.Service, chain.Operations, do.Args, do.Interactive, "")
+	} else {
+		err = perform.DockerRun(chain.Service, chain.Operations)
+	}
+	if err != nil {
+		do.Result = "error"
+		return err
+	}
+
+	return nil
+}
 
 // boot chain dependencies
 // TODO: this currently only supports simple services (with no further dependencies)

--- a/commands/chains.go
+++ b/commands/chains.go
@@ -464,11 +464,11 @@ func ExecChain(cmd *cobra.Command, args []string) {
 
 	do.Name = args[0]
 	// if interactive, we ignore args. if not, run args as command
+	args = args[1:]
 	if !do.Interactive {
-		if len(args) < 2 {
+		if len(args) == 0 {
 			Exit(fmt.Errorf("Non-interactive exec sessions must provide arguments to execute"))
 		}
-		args = args[1:]
 	}
 	if len(args) == 1 {
 		args = strings.Split(args[0], " ")

--- a/commands/services.go
+++ b/commands/services.go
@@ -242,6 +242,7 @@ func addServicesFlags() {
 	servicesLogs.Flags().StringVarP(&do.Tail, "tail", "t", "150", "number of lines to show from end of logs")
 
 	servicesExec.Flags().BoolVarP(&do.Interactive, "interactive", "i", false, "interactive shell")
+	servicesExec.Flags().StringVarP(&do.Volume, "volume", "m", "", "mount a volume $HOME/.eris/VOLUME on a host machine to a /home/eris/.eris/VOLUME on a container")
 
 	servicesUpdate.Flags().BoolVarP(&do.Pull, "pull", "p", false, "skip the pulling feature and simply rebuild the service container")
 	servicesUpdate.Flags().UintVarP(&do.Timeout, "timeout", "t", 10, "manually set the timeout; overridden by --force")
@@ -286,12 +287,17 @@ func ExecService(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "ge", cmd, args))
 
 	do.Name = args[0]
+	// if interactive, we ignore args. if not, run args as command
 	args = args[1:]
+	if !do.Interactive {
+		if len(args) == 0 {
+			Exit(fmt.Errorf("Non-interactive exec sessions must provide arguments to execute"))
+		}
+	}
 	if len(args) == 1 {
 		args = strings.Split(args[0], " ")
 	}
 	do.Args = args
-
 	IfExit(srv.ExecService(do))
 }
 

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -43,6 +43,7 @@ type Do struct {
 	NewName       string   `mapstructure:"," json:"," yaml:"," toml:","`
 	ResultFormt   string   `mapstructure:"," json:"," yaml:"," toml:","`
 	Priv          string   `mapstructure:"," json:"," yaml:"," toml:","`
+	Volume        string   `mapstructure:"," json:"," yaml:"," toml:","`
 	ServicesSlice []string `mapstructure:"," json:"," yaml:"," toml:","`
 	ConfigOpts    []string `mapstructure:"," json:"," yaml:"," toml:","`
 

--- a/services/operate.go
+++ b/services/operate.go
@@ -94,14 +94,7 @@ func ExecService(do *definitions.Do) error {
 	if err != nil {
 		return err
 	}
-
-	if IsServiceExisting(service.Service, service.Operations) {
-		return ExecServiceByService(service.Service, service.Operations, do.Args, do.Interactive)
-	} else {
-		return fmt.Errorf("Services does not exist. Please start the service container with eris services start %s.\n", do.Name)
-	}
-
-	return nil
+	return StartServiceInteractiveByService(service.Service, service.Operations, do.Args, do.Interactive, do.Volume)
 }
 
 // TODO: test this recursion and service deps generally
@@ -187,6 +180,9 @@ func ConnectChainToService(chainFlag, chainNameAndOpts string, srv *definitions.
 
 // ------------------------------------------------------------------------------------------
 // Wrappers we want to be able to call from Chains package (mostly)
+func StartServiceInteractiveByService(srvMain *definitions.Service, ops *definitions.Operation, args []string, interactive bool, volume string) error {
+	return perform.DockerRunInteractive(srvMain, ops, args, interactive, volume)
+}
 
 func StartServiceByService(srvMain *definitions.Service, ops *definitions.Operation) error {
 	return perform.DockerRun(srvMain, ops)
@@ -196,13 +192,6 @@ func LogsServiceByService(srv *definitions.Service, ops *definitions.Operation, 
 	return perform.DockerLogs(srv, ops, follow, tail)
 }
 
-func ExecServiceByService(srvMain *definitions.Service, ops *definitions.Operation, cmd []string, attach bool) error {
-	return perform.DockerExec(srvMain, ops, cmd, attach)
-}
-
 func KillServiceByService(srvMain *definitions.Service, ops *definitions.Operation, timeout uint) error {
 	return perform.DockerStop(srvMain, ops, timeout)
 }
-
-// ------------------------------------------------------------------------------------------
-// Helpers

--- a/util/paths_and_fileops.go
+++ b/util/paths_and_fileops.go
@@ -107,5 +107,8 @@ func HostErisHome() string {
 // ContainerErisHome returns the Eris directory on a container machine
 // for a particular user.
 func ContainerErisHome(user string) string {
+	if user == "root" {
+		return filepath.Join("/root", ".eris")
+	}
 	return filepath.Join("/home", user, ".eris")
 }

--- a/util/paths_and_fileops.go
+++ b/util/paths_and_fileops.go
@@ -98,3 +98,14 @@ func MoveOutOfDirAndRmDir(src, dest string) error {
 
 	return nil
 }
+
+// HostErisHome returns the Eris directory on a host machine.
+func HostErisHome() string {
+	return filepath.Join(os.Getenv("HOME"), ".eris")
+}
+
+// ContainerErisHome returns the Eris directory on a container machine
+// for a particular user.
+func ContainerErisHome(user string) string {
+	return filepath.Join("/home", user, ".eris")
+}


### PR DESCRIPTION
* `services exec` and `chains exec` commands use `docker run` now to execute containers (both interactive and non-interactive). Fixes issues #273 and #246.
* `services exec` with a `-m` (`--volume`) flag specifies a directory from $HOME/`.eris` folder to be mounted inside the container under `/home/$USER/.eris` or `/root/.eris` (#273).
* `chains rm` command fix. Removed a duplicate of base folder — util.GetFileByNameAndType("chains"). Fixes #276.
* `exec` was able to handle quoted args (closing #246 and #250).
* Command prompt now appears immediately after running `exec` commands by attaching the container before starting it and waiting on the `Success` sentinel channel from Docker API. Fixes #278.

![](http://i.imgur.com/TjUZirg.png)