### PR TITLE
Container labels refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+eris
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -47,7 +47,7 @@ func TestListActions(t *testing.T) {
 	do.Known = true
 	do.Running = false
 	do.Existing = false
-	do.Args = []string{"testing"}
+	do.Operations.Args = []string{"testing"}
 	ifExit(util.ListAll(do, "actions"))
 	k := strings.Split(do.Result, "\n") // tests output formatting.
 
@@ -78,9 +78,9 @@ func TestLoadActionDefinition(t *testing.T) {
 
 func TestDoAction(t *testing.T) {
 	do := definitions.NowDo()
-	do.Args = strings.Fields(actionName)
+	do.Operations.Args = strings.Fields(actionName)
 	do.Quiet = true
-	logger.Infof("Perform Action (from tests) =>\t%v\n", do.Args)
+	logger.Infof("Perform Action (from tests) =>\t%v\n", do.Operations.Args)
 	if err := Do(do); err != nil {
 		logger.Errorln(err)
 		t.Fail()
@@ -89,8 +89,8 @@ func TestDoAction(t *testing.T) {
 
 func TestNewAction(t *testing.T) {
 	do := definitions.NowDo()
-	do.Args = strings.Fields(oldName)
-	logger.Infof("New Action (from tests) =>\t%v\n", do.Args)
+	do.Operations.Args = strings.Fields(oldName)
+	logger.Infof("New Action (from tests) =>\t%v\n", do.Operations.Args)
 	if err := NewAction(do); err != nil {
 		logger.Errorln(err)
 		t.Fail()
@@ -127,7 +127,7 @@ func TestRenameAction(t *testing.T) {
 
 func TestRemoveAction(t *testing.T) {
 	do := definitions.NowDo()
-	do.Args = strings.Fields(oldName)
+	do.Operations.Args = strings.Fields(oldName)
 	do.File = true
 	if err := RmAction(do); err != nil {
 		logger.Errorln(err)
@@ -181,7 +181,7 @@ func testExist(t *testing.T, name string, toExist bool) {
 	do.Running = false
 	do.Existing = false
 	do.Quiet = true
-	do.Args = []string{"testing"}
+	do.Operations.Args = []string{"testing"}
 	if err := util.ListAll(do, "actions"); err != nil {
 		logger.Errorln(err)
 		t.Fail()

--- a/actions/manage.go
+++ b/actions/manage.go
@@ -17,7 +17,7 @@ import (
 )
 
 func NewAction(do *definitions.Do) error {
-	do.Name = strings.Join(do.Args, "_")
+	do.Name = strings.Join(do.Operations.Args, "_")
 	path := filepath.Join(ActionsPath, do.Name)
 	logger.Debugf("NewActionRaw to MockAction =>\t%v:%s\n", do.Name, path)
 	act, _ := MockAction(do.Name)
@@ -29,9 +29,9 @@ func NewAction(do *definitions.Do) error {
 
 func ImportAction(do *definitions.Do) error {
 	if do.Name == "" {
-		do.Name = strings.Join(do.Args, "_")
+		do.Name = strings.Join(do.Operations.Args, "_")
 	}
-	fileName := filepath.Join(ActionsPath, strings.Join(do.Args, " "))
+	fileName := filepath.Join(ActionsPath, strings.Join(do.Operations.Args, " "))
 	if filepath.Ext(fileName) == "" {
 		fileName = fileName + ".toml"
 	}
@@ -46,6 +46,7 @@ func ImportAction(do *definitions.Do) error {
 			return err
 		}
 
+		ipfsService.Operations.ContainerType = definitions.TypeService
 		err = perform.DockerRun(ipfsService.Service, ipfsService.Operations)
 		if err != nil {
 			return err
@@ -159,7 +160,7 @@ func RenameAction(do *definitions.Do) error {
 }
 
 func RmAction(do *definitions.Do) error {
-	do.Name = strings.Join(do.Args, "_")
+	do.Name = strings.Join(do.Operations.Args, "_")
 	if do.File {
 		oldFile := util.GetFileByNameAndType("actions", do.Name)
 		if oldFile == "" {

--- a/actions/perform.go
+++ b/actions/perform.go
@@ -12,13 +12,13 @@ import (
 )
 
 func Do(do *definitions.Do) error {
-	logger.Infof("Performing Action =>\t\t%v\n", do.Args)
+	logger.Infof("Performing Action =>\t\t%v\n", do.Operations.Args)
 	logger.Debugf("CLI Chain to turn on =>\t\t%v\n", do.ChainName)
 	logger.Debugf("CLI Services to turn on =>\t%v\n", do.ServicesSlice)
 
 	var err error
 	var actionVars []string
-	do.Action, actionVars, err = LoadActionDefinition(strings.Join(do.Args, "_"))
+	do.Action, actionVars, err = LoadActionDefinition(strings.Join(do.Operations.Args, "_"))
 	if err != nil {
 		return err
 	}
@@ -44,8 +44,8 @@ func StartServicesAndChains(do *definitions.Do) error {
 	if do.Action.Dependencies == nil || len(do.Action.Dependencies.Services) == 0 {
 		logger.Debugf("No services to start.\n")
 	} else {
-		doSrvs.Args = do.Action.Dependencies.Services
-		logger.Debugf("Starting Services. Args =>\t%v\n", doSrvs.Args)
+		doSrvs.Operations.Args = do.Action.Dependencies.Services
+		logger.Debugf("Starting Services. Args =>\t%v\n", doSrvs.Operations.Args)
 		if err := services.StartService(doSrvs); err != nil {
 			return err
 		}
@@ -129,5 +129,5 @@ func resolveServices(do *definitions.Do) {
 	if do.Action.Dependencies != nil {
 		do.Action.Dependencies.Services = append(do.Action.Dependencies.Services, do.ServicesSlice...)
 	}
-	logger.Debugf("Services to start =>\t\t%v\n", do.Args)
+	logger.Debugf("Services to start =>\t\t%v\n", do.Operations.Args)
 }

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -265,8 +265,10 @@ func RenameChain(do *definitions.Do) error {
 		}
 
 		chainDef.Name = newNameBase
-		// [pv]: why are these emptied at rename?
+		// Generally we won't want to use Service.Name
+		// as it will be confused with the Name.
 		chainDef.Service.Name = ""
+		// Service.Image should be taken from the default.toml.
 		chainDef.Service.Image = ""
 		err = WriteChainDefinitionFile(chainDef, newFile)
 		if err != nil {

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ test:
   override:
     - "cd ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/cmd/eris && go install"
     - "tests/test.sh | tee $CIRCLE_ARTIFACTS/output.log ; test ${PIPESTATUS[0]} -eq 0":
-      timeout: 1200
+        timeout: 1200
 
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,8 @@ dependencies:
 test:
   override:
     - "cd ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/cmd/eris && go install"
-    - "tests/test.sh | tee $CIRCLE_ARTIFACTS/output.log ; test ${PIPESTATUS[0]} -eq 0"
+    - "tests/test.sh | tee $CIRCLE_ARTIFACTS/output.log ; test ${PIPESTATUS[0]} -eq 0":
+      timeout: 1200
 
 deployment:
   master:

--- a/commands/actions.go
+++ b/commands/actions.go
@@ -192,7 +192,7 @@ func EditAction(cmd *cobra.Command, args []string) {
 
 func DoAction(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "ge", cmd, args))
-	do.Args = args
+	do.Operations.Args = args
 	IfExit(act.Do(do))
 }
 
@@ -211,6 +211,6 @@ func RenameAction(cmd *cobra.Command, args []string) {
 
 func RmAction(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "ge", cmd, args))
-	do.Args = args
+	do.Operations.Args = args
 	IfExit(act.RmAction(do))
 }

--- a/commands/chains.go
+++ b/commands/chains.go
@@ -407,7 +407,7 @@ func addChainsFlags() {
 	chainsLogs.Flags().StringVarP(&do.Tail, "tail", "t", "150", "number of lines to show from end of logs")
 
 	chainsExec.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish random ports")
-	chainsExec.Flags().BoolVarP(&do.Interactive, "interactive", "i", false, "interactive shell")
+	chainsExec.Flags().BoolVarP(&do.Operations.Interactive, "interactive", "i", false, "interactive shell")
 	chainsExec.Flags().StringVarP(&do.Image, "image", "", "", "Docker image")
 
 	chainsRemove.Flags().BoolVarP(&do.File, "file", "f", false, "remove chain definition file as well as chain container")
@@ -454,7 +454,7 @@ func ExecChain(cmd *cobra.Command, args []string) {
 	do.Name = args[0]
 	// if interactive, we ignore args. if not, run args as command
 	args = args[1:]
-	if !do.Interactive {
+	if !do.Operations.Interactive {
 		if len(args) == 0 {
 			Exit(fmt.Errorf("Non-interactive exec sessions must provide arguments to execute"))
 		}
@@ -462,7 +462,7 @@ func ExecChain(cmd *cobra.Command, args []string) {
 	if len(args) == 1 {
 		args = strings.Split(args[0], " ")
 	}
-	do.Args = args
+	do.Operations.Args = args
 	IfExit(chns.ExecChain(do))
 }
 
@@ -497,7 +497,7 @@ func NewChain(cmd *cobra.Command, args []string) {
 func RegisterChain(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(2, "ge", cmd, args))
 	do.Name = args[0]
-	do.Args = args[1:]
+	do.Operations.Args = args[1:]
 	IfExit(chns.RegisterChain(do))
 }
 
@@ -528,7 +528,7 @@ func PlopChain(cmd *cobra.Command, args []string) {
 	do.ChainID = args[0]
 	do.Type = args[1]
 	if len(args) > 2 {
-		do.Args = args[2:]
+		do.Operations.Args = args[2:]
 	}
 	IfExit(chns.PlopChain(do))
 }
@@ -536,7 +536,7 @@ func PlopChain(cmd *cobra.Command, args []string) {
 func PortsChain(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(2, "ge", cmd, args))
 	do.Name = args[0]
-	do.Args = args[1:]
+	do.Operations.Args = args[1:]
 	IfExit(chns.PortsChain(do))
 }
 
@@ -549,7 +549,7 @@ func EditChain(cmd *cobra.Command, args []string) {
 		configVals = args[1:]
 	}
 	do.Name = args[0]
-	do.Args = configVals
+	do.Operations.Args = configVals
 	IfExit(chns.EditChain(do))
 }
 
@@ -559,9 +559,9 @@ func InspectChain(cmd *cobra.Command, args []string) {
 
 	do.Name = args[0]
 	if len(args) == 1 {
-		do.Args = []string{"all"}
+		do.Operations.Args = []string{"all"}
 	} else {
-		do.Args = []string{args[1]}
+		do.Operations.Args = []string{args[1]}
 	}
 
 	IfExit(chns.InspectChain(do))

--- a/commands/data.go
+++ b/commands/data.go
@@ -153,9 +153,9 @@ func InspectData(cmd *cobra.Command, args []string) {
 
 	do.Name = args[0]
 	if len(args) == 1 {
-		do.Args = []string{"all"}
+		do.Operations.Args = []string{"all"}
 	} else {
-		do.Args = []string{args[1]}
+		do.Operations.Args = []string{args[1]}
 	}
 
 	IfExit(data.InspectData(do))

--- a/commands/data.go
+++ b/commands/data.go
@@ -121,7 +121,7 @@ var dataRm = &cobra.Command{
 func addDataFlags() {
 	dataRm.Flags().BoolVarP(&do.RmHF, "dir", "", false, "remove data folder from host")
 	dataRm.Flags().BoolVarP(&do.Volumes, "vol", "o", true, "remove volumes")
-	dataExec.Flags().BoolVarP(&do.Interactive, "interactive", "i", false, "interactive shell")
+	dataExec.Flags().BoolVarP(&do.Operations.Interactive, "interactive", "i", false, "interactive shell")
 
 	dataImport.Flags().StringVarP(&do.Path, "dest", "", "", "destination for import into data container")
 	dataExport.Flags().StringVarP(&do.Path, "src", "", "", "source inside data container to export from")
@@ -163,7 +163,7 @@ func InspectData(cmd *cobra.Command, args []string) {
 
 func RmData(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "ge", cmd, args))
-	do.Args = args
+	do.Operations.Args = args
 	IfExit(data.RmData(do))
 }
 
@@ -187,7 +187,7 @@ func ExecData(cmd *cobra.Command, args []string) {
 	do.Name = args[0]
 
 	// if interactive, we ignore args. if not, run args as command
-	if !do.Interactive {
+	if !do.Operations.Interactive {
 		if len(args) < 2 {
 			Exit(fmt.Errorf("Non-interactive exec sessions must provide arguments to execute"))
 		}
@@ -197,7 +197,7 @@ func ExecData(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	do.Args = args
+	do.Operations.Args = args
 	IfExit(data.ExecData(do))
 }
 

--- a/commands/services.go
+++ b/commands/services.go
@@ -235,8 +235,8 @@ func addServicesFlags() {
 	servicesLogs.Flags().StringVarP(&do.Tail, "tail", "t", "150", "number of lines to show from end of logs")
 
 	servicesExec.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish random ports")
-	servicesExec.Flags().BoolVarP(&do.Interactive, "interactive", "i", false, "interactive shell")
-	servicesExec.Flags().StringVarP(&do.Volume, "volume", "m", "", fmt.Sprintf("mount a volume %v/VOLUME on a host machine to a %v/VOLUME on a container", ErisRoot, ErisContainerRoot))
+	servicesExec.Flags().BoolVarP(&do.Operations.Interactive, "interactive", "i", false, "interactive shell")
+	servicesExec.Flags().StringVarP(&do.Operations.Volume, "volume", "m", "", fmt.Sprintf("mount a volume %v/VOLUME on a host machine to a %v/VOLUME on a container", ErisRoot, ErisContainerRoot))
 
 	servicesUpdate.Flags().BoolVarP(&do.Pull, "pull", "p", false, "skip the pulling feature and simply rebuild the service container")
 	servicesUpdate.Flags().UintVarP(&do.Timeout, "timeout", "t", 10, "manually set the timeout; overridden by --force")
@@ -272,7 +272,7 @@ func addServicesFlags() {
 
 func StartService(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "ge", cmd, args))
-	do.Args = args
+	do.Operations.Args = args
 	IfExit(srv.StartService(do))
 }
 
@@ -288,7 +288,7 @@ func ExecService(cmd *cobra.Command, args []string) {
 	do.Name = args[0]
 	// if interactive, we ignore args. if not, run args as command
 	args = args[1:]
-	if !do.Interactive {
+	if !do.Operations.Interactive {
 		if len(args) == 0 {
 			Exit(fmt.Errorf("Non-interactive exec sessions must provide arguments to execute"))
 		}
@@ -296,13 +296,13 @@ func ExecService(cmd *cobra.Command, args []string) {
 	if len(args) == 1 {
 		args = strings.Split(args[0], " ")
 	}
-	do.Args = args
+	do.Operations.Args = args
 	IfExit(srv.ExecService(do))
 }
 
 func KillService(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "ge", cmd, args))
-	do.Args = args
+	do.Operations.Args = args
 	IfExit(srv.KillService(do))
 }
 
@@ -317,7 +317,7 @@ func ImportService(cmd *cobra.Command, args []string) {
 func NewService(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(2, "ge", cmd, args))
 	do.Name = args[0]
-	do.Args = []string{args[1]}
+	do.Operations.Args = []string{args[1]}
 	IfExit(srv.NewService(do))
 }
 
@@ -339,9 +339,9 @@ func InspectService(cmd *cobra.Command, args []string) {
 
 	do.Name = args[0]
 	if len(args) == 1 {
-		do.Args = []string{"all"}
+		do.Operations.Args = []string{"all"}
 	} else {
-		do.Args = []string{args[1]}
+		do.Operations.Args = []string{args[1]}
 	}
 
 	IfExit(srv.InspectService(do))
@@ -350,7 +350,7 @@ func InspectService(cmd *cobra.Command, args []string) {
 func PortsService(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(2, "ge", cmd, args))
 	do.Name = args[0]
-	do.Args = args[1:]
+	do.Operations.Args = args[1:]
 	IfExit(srv.PortsService(do))
 }
 
@@ -394,7 +394,7 @@ func ListAllServices(cmd *cobra.Command, args []string) {
 
 func RmService(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "ge", cmd, args))
-	do.Args = args
+	do.Operations.Args = args
 	IfExit(srv.RmService(do))
 }
 

--- a/contracts/operate.go
+++ b/contracts/operate.go
@@ -187,6 +187,7 @@ func DefineDappActionService(do *definitions.Do, dapp *definitions.Contracts) er
 func PerformDappActionService(do *definitions.Do, dapp *definitions.Contracts) error {
 	logger.Infof("Performing DAPP Action =>\t%s:%s:%s\n", do.Service.Name, do.Service.Image, do.Service.Command)
 
+	do.Operations.ContainerType = definitions.TypeService
 	if err := perform.DockerRun(do.Service, do.Operations); err != nil {
 		do.Result = "could not perform dapp action"
 		return err
@@ -234,7 +235,7 @@ func bootChain(name string, do *definitions.Do) error {
 		if util.IsServiceContainer(name, do.Operations.ContainerNumber, true) {
 			startService := definitions.NowDo()
 			startService.Operations = do.Operations
-			startService.Args = []string{name}
+			startService.Operations.Args = []string{name}
 			err = services.StartService(startService)
 			if err != nil {
 				return err

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -74,6 +75,36 @@ func TestImportDataRawNoPriorExist(t *testing.T) {
 	testExist(t, dataName, true)
 }
 
+func TestExecData(t *testing.T) {
+	do := definitions.NowDo()
+	do.Name = dataName
+	do.Operations.Args = []string{"mv", "/home/eris/.eris/test", "/home/eris/.eris/tset"}
+	do.Operations.Interactive = false
+	do.Operations.ContainerNumber = 1
+
+	logger.Infof("Exec-ing Data (from tests) =>\t%s:%v\n", do.Name, do.Operations.Args)
+	if err := ExecData(do); err != nil {
+		fmt.Println("DATA EXEC", err)
+		logger.Errorln(err)
+		t.Fail()
+	}
+}
+
+func TestExportData(t *testing.T) {
+	do := definitions.NowDo()
+	do.Name = dataName
+	do.Operations.ContainerNumber = 1
+	if err := ExportData(do); err != nil {
+		logger.Errorln(err)
+		t.FailNow()
+	}
+
+	if _, err := os.Stat(path.Join(common.DataContainersPath, dataName, "tset")); os.IsNotExist(err) {
+		logger.Errorf("Tragic! Exported file does not exist: %s\n", err)
+		t.Fail()
+	}
+}
+
 func TestRenameData(t *testing.T) {
 	testExist(t, dataName, true)
 	testExist(t, newName, false)
@@ -108,9 +139,9 @@ func TestRenameData(t *testing.T) {
 func TestInspectData(t *testing.T) {
 	do := definitions.NowDo()
 	do.Name = dataName
-	do.Args = []string{"name"}
+	do.Operations.Args = []string{"name"}
 	do.Operations.ContainerNumber = 1
-	logger.Infof("Inspecting Data (from tests) =>\t%s:%v\n", do.Name, do.Args)
+	logger.Infof("Inspecting Data (from tests) =>\t%s:%v\n", do.Name, do.Operations.Args)
 	if err := InspectData(do); err != nil {
 		logger.Errorln(err)
 		t.FailNow()
@@ -118,39 +149,11 @@ func TestInspectData(t *testing.T) {
 
 	do = definitions.NowDo()
 	do.Name = dataName
-	do.Args = []string{"config.network_disabled"}
+	do.Operations.Args = []string{"config.network_disabled"}
 	do.Operations.ContainerNumber = 1
-	logger.Infof("Inspecting Data (from tests) =>\t%s:%v\n", do.Name, do.Args)
+	logger.Infof("Inspecting Data (from tests) =>\t%s:%v\n", do.Name, do.Operations.Args)
 	if err := InspectData(do); err != nil {
 		logger.Errorln(err)
-		t.Fail()
-	}
-}
-
-func TestExecData(t *testing.T) {
-	do := definitions.NowDo()
-	do.Name = dataName
-	do.Args = []string{"mv", "/home/eris/.eris/test", "/home/eris/.eris/tset"}
-	do.Interactive = false
-	do.Operations.ContainerNumber = 1
-	logger.Infof("Exec-ing Data (from tests) =>\t%s:%v\n", do.Name, do.Args)
-	if err := ExecData(do); err != nil {
-		logger.Errorln(err)
-		t.Fail()
-	}
-}
-
-func TestExportData(t *testing.T) {
-	do := definitions.NowDo()
-	do.Name = dataName
-	do.Operations.ContainerNumber = 1
-	if err := ExportData(do); err != nil {
-		logger.Errorln(err)
-		t.FailNow()
-	}
-
-	if _, err := os.Stat(path.Join(common.DataContainersPath, dataName, "tset")); os.IsNotExist(err) {
-		logger.Errorf("Tragic! Exported file does not exist: %s\n", err)
 		t.Fail()
 	}
 }
@@ -218,7 +221,7 @@ func testExist(t *testing.T, name string, toExist bool) {
 	do := definitions.NowDo()
 	do.Existing = true
 	do.Quiet = true
-	do.Args = []string{"testing"}
+	do.Operations.Args = []string{"testing"}
 	if err := util.ListAll(do, "data"); err != nil {
 		logger.Errorln(err)
 		t.FailNow()

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -84,7 +83,6 @@ func TestExecData(t *testing.T) {
 
 	logger.Infof("Exec-ing Data (from tests) =>\t%s:%v\n", do.Name, do.Operations.Args)
 	if err := ExecData(do); err != nil {
-		fmt.Println("DATA EXEC", err)
 		logger.Errorln(err)
 		t.Fail()
 	}

--- a/data/load.go
+++ b/data/load.go
@@ -55,8 +55,8 @@ func _parseKnown(name string) bool {
 	do := def.NowDo()
 	do.Existing = true
 	util.ListAll(do, "data")
-	if len(do.Args) != 0 {
-		for _, srv := range do.Args {
+	if len(do.Operations.Args) != 0 {
+		for _, srv := range do.Operations.Args {
 			if srv == name {
 				return true
 			}

--- a/definitions/container_types.go
+++ b/definitions/container_types.go
@@ -1,0 +1,23 @@
+package definitions
+
+const (
+	ContainerNamePrefix = "ipfs-"
+
+	Namespace = "eris"
+
+	LabelEris      = "ERIS"
+	LabelShortName = "NAME"
+	LabelNumber    = "CONTAINER_NUMBER"
+	LabelType      = "TYPE"
+	LabelService   = "SERVICE"
+	LabelSwarm     = "SWARM"
+	LabelMachine   = "MACHINE"
+	LabelUser      = "USER"
+	LabelID        = "ID"
+	LabelTest      = "TEST"
+	LabelTestID    = "TEST_ID"
+
+	TypeChain   = "chain"
+	TypeService = "service"
+	TypeData    = "data"
+)

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -6,7 +6,6 @@ type Do struct {
 	Existing      bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Force         bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	File          bool     `mapstructure:"," json:"," yaml:"," toml:","`
-	Interactive   bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Known         bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Pull          bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Running       bool     `mapstructure:"," json:"," yaml:"," toml:","`
@@ -48,12 +47,8 @@ type Do struct {
 	NewName       string   `mapstructure:"," json:"," yaml:"," toml:","`
 	ResultFormt   string   `mapstructure:"," json:"," yaml:"," toml:","`
 	Priv          string   `mapstructure:"," json:"," yaml:"," toml:","`
-	Volume        string   `mapstructure:"," json:"," yaml:"," toml:","`
 	ServicesSlice []string `mapstructure:"," json:"," yaml:"," toml:","`
 	ConfigOpts    []string `mapstructure:"," json:"," yaml:"," toml:","`
-
-	// Generalized string slice
-	Args []string `mapstructure:"," json:"," yaml:"," toml:","`
 
 	// <key>=<value> pairs
 	Env []string `mapstructure:"," json:"," yaml:"," toml:","`

--- a/definitions/operation.go
+++ b/definitions/operation.go
@@ -1,22 +1,26 @@
 package definitions
 
 type Operation struct {
-	// Filled in dynamically prerun
+	// Filled in dynamically prerun.
 	SrvContainerName  string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	SrvContainerID    string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	DataContainerName string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	DataContainerID   string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
+	ContainerType     string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	ContainerNumber   int               `json:",omitempty,omitzero" yaml:",omitempty" toml:",omitempty,omitzero"`
 	Restart           string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	Remove            bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	Privileged        bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	Attach            bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
+	Interactive       bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	AppName           string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	DockerHostConn    string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
+	Volume            string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	Labels            map[string]string `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	PublishAllPorts   bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	CapAdd            []string          `mapstructure:",omitempty", json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	CapDrop           []string          `mapstructure:",omitempty", json:",omitempty" yaml:",omitempty" toml:",omitempty"`
+	Args              []string          `mapstructure:",omitempty", json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 }
 
 func BlankOperation() *Operation {

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -124,7 +124,7 @@ func testsInit() error {
 	f.Write([]byte(content))
 
 	do1 := definitions.NowDo()
-	do1.Args = []string{"ipfs"}
+	do1.Operations.Args = []string{"ipfs"}
 	err = services.StartService(do1)
 	ifExit(err)
 	time.Sleep(5 * time.Second)
@@ -146,7 +146,7 @@ func testKillIPFS(t *testing.T) {
 
 	do := definitions.NowDo()
 	do.Name = serviceName
-	do.Args = []string{serviceName}
+	do.Operations.Args = []string{serviceName}
 	do.Rm = true
 	do.RmD = true
 	if e := services.KillService(do); e != nil {

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -30,7 +30,7 @@ func LoadChainDefinition(chainName string, newCont bool, cNum ...int) (*definiti
 	}
 
 	if cNum[0] == 0 {
-		cNum[0] = util.AutoMagic(0, "chain", newCont)
+		cNum[0] = util.AutoMagic(0, definitions.TypeChain, newCont)
 		logger.Debugf("Loading Chain Definition =>\t%s:%d (autoassigned)\n", chainName, cNum[0])
 	} else {
 		logger.Debugf("Loading Chain Definition =>\t%s:%d\n", chainName, cNum[0])
@@ -39,6 +39,8 @@ func LoadChainDefinition(chainName string, newCont bool, cNum ...int) (*definiti
 	chain := definitions.BlankChain()
 	chain.Name = chainName
 	chain.Operations.ContainerNumber = cNum[0]
+	chain.Operations.ContainerType = definitions.TypeChain
+	chain.Operations.Labels = util.Labels(chain.Name, chain.Operations)
 	if err := setChainDefaults(chain); err != nil {
 		return nil, err
 	}
@@ -111,7 +113,7 @@ func ServiceDefFromChain(chain *definitions.Chain, cmd string) *definitions.Serv
 }
 
 func ConnectToAChain(srv *definitions.Service, ops *definitions.Operation, name, internalName string, link, mount bool) {
-	connectToAService(srv, ops, "chain", name, internalName, link, mount)
+	connectToAService(srv, ops, definitions.TypeChain, name, internalName, link, mount)
 }
 
 func MockChainDefinition(chainName, chainID string, newCont bool, cNum ...int) *definitions.Chain {
@@ -121,12 +123,15 @@ func MockChainDefinition(chainName, chainID string, newCont bool, cNum ...int) *
 	chn.Service.AutoData = true
 
 	if len(cNum) == 0 {
-		chn.Operations.ContainerNumber = util.AutoMagic(cNum[0], "chain", newCont)
+		chn.Operations.ContainerNumber = util.AutoMagic(cNum[0], definitions.TypeChain, newCont)
 		logger.Debugf("Mocking Chain Definition =>\t%s:%d (autoassigned)\n", chainName, cNum[0])
 	} else {
 		chn.Operations.ContainerNumber = cNum[0]
 		logger.Debugf("Mocking Chain Definition =>\t%s:%d\n", chainName, cNum[0])
 	}
+
+	chn.Operations.ContainerType = definitions.TypeChain
+	chn.Operations.Labels = util.Labels(chainName, chn.Operations)
 
 	checkChainNames(chn)
 	return chn
@@ -143,7 +148,7 @@ func MarshalChainDefinition(chainConf *viper.Viper, chain *definitions.Chain) er
 	}
 	// logger.Debugf("Loader.Chain.Marshal: ChanID =>\t%v\n", chnTemp.ChainID)
 
-	mergeDefaultsAndChain(chain, chnTemp.Service)
+	util.Merge(chain, chnTemp.Service)
 	chain.ChainID = chnTemp.ChainID
 
 	// toml bools don't really marshal well
@@ -179,30 +184,4 @@ func checkChainNames(chain *definitions.Chain) {
 	chain.Service.Name = chain.Name
 	chain.Operations.SrvContainerName = util.ChainContainersName(chain.Name, chain.Operations.ContainerNumber)
 	chain.Operations.DataContainerName = util.DataContainersName(chain.Name, chain.Operations.ContainerNumber)
-}
-
-// overwrite service attributes with chain config
-func mergeDefaultsAndChain(chain *definitions.Chain, service *definitions.Service) {
-	chain.Service.Name = chain.Name
-	chain.Service.Image = util.OverWriteString(chain.Service.Image, service.Image)
-	chain.Service.Command = util.OverWriteString(chain.Service.Command, service.Command)
-	chain.Service.Links = util.OverWriteSlice(chain.Service.Links, service.Links)
-	chain.Service.Ports = util.OverWriteSlice(chain.Service.Ports, service.Ports)
-	chain.Service.Expose = util.OverWriteSlice(chain.Service.Expose, service.Expose)
-	chain.Service.Volumes = util.OverWriteSlice(chain.Service.Volumes, service.Volumes)
-	chain.Service.VolumesFrom = util.OverWriteSlice(chain.Service.VolumesFrom, service.VolumesFrom)
-	chain.Service.Environment = util.MergeSlice(chain.Service.Environment, service.Environment)
-	chain.Service.EnvFile = util.OverWriteSlice(chain.Service.EnvFile, service.EnvFile)
-	chain.Service.Net = util.OverWriteString(chain.Service.Net, service.Net)
-	chain.Service.PID = util.OverWriteString(chain.Service.PID, service.PID)
-	chain.Service.DNS = util.OverWriteSlice(chain.Service.DNS, service.DNS)
-	chain.Service.DNSSearch = util.OverWriteSlice(chain.Service.DNSSearch, service.DNSSearch)
-	chain.Service.CPUShares = util.OverWriteInt64(chain.Service.CPUShares, service.CPUShares)
-	chain.Service.WorkDir = util.OverWriteString(chain.Service.WorkDir, service.WorkDir)
-	chain.Service.EntryPoint = util.OverWriteString(chain.Service.EntryPoint, service.EntryPoint)
-	chain.Service.HostName = util.OverWriteString(chain.Service.HostName, service.HostName)
-	chain.Service.DomainName = util.OverWriteString(chain.Service.DomainName, service.DomainName)
-	chain.Service.User = util.OverWriteString(chain.Service.User, service.User)
-	chain.Service.MemLimit = util.OverWriteInt64(chain.Service.MemLimit, service.MemLimit)
-	chain.Service.ExecHost = util.OverWriteString(chain.Service.ExecHost, service.ExecHost)
 }

--- a/loaders/data.go
+++ b/loaders/data.go
@@ -5,8 +5,8 @@ import (
 	"github.com/eris-ltd/eris-cli/util"
 )
 
-// LoadDataDefinitions returns returns a container operations structure for
-// a blank data container specified by a name dataName and a cNum number.
+// LoadDataDefinition returns an Operation structure for a blank data container
+// specified by a name dataName and a cNum number.
 func LoadDataDefinition(dataName string, cNum int) *definitions.Operation {
 	if cNum == 0 {
 		cNum = 1

--- a/loaders/data.go
+++ b/loaders/data.go
@@ -1,0 +1,25 @@
+package loaders
+
+import (
+	"github.com/eris-ltd/eris-cli/definitions"
+	"github.com/eris-ltd/eris-cli/util"
+)
+
+// LoadDataDefinitions returns returns a container operations structure for
+// a blank data container specified by a name dataName and a cNum number.
+func LoadDataDefinition(dataName string, cNum int) *definitions.Operation {
+	if cNum == 0 {
+		cNum = 1
+	}
+
+	logger.Debugf("Loading Data Definition =>\t%s:%d\n", dataName, cNum)
+
+	ops := definitions.BlankOperation()
+	ops.ContainerNumber = cNum
+	ops.ContainerType = definitions.TypeData
+	ops.SrvContainerName = util.DataContainersName(dataName, cNum)
+	ops.DataContainerName = util.DataContainersName(dataName, cNum)
+	ops.Labels = util.Labels(dataName, ops)
+
+	return ops
+}

--- a/loaders/services.go
+++ b/loaders/services.go
@@ -21,14 +21,16 @@ func LoadServiceDefinition(servName string, newCont bool, cNum ...int) (*definit
 	}
 
 	if cNum[0] == 0 {
-		cNum[0] = util.AutoMagic(0, "service", newCont)
+		cNum[0] = util.AutoMagic(0, definitions.TypeService, newCont)
 		logger.Debugf("Loading Service Definition =>\t%s:%d (autoassigned)\n", servName, cNum[0])
 	} else {
 		logger.Debugf("Loading Service Definition =>\t%s:%d\n", servName, cNum[0])
 	}
 
 	srv := definitions.BlankServiceDefinition()
+	srv.Operations.ContainerType = definitions.TypeService
 	srv.Operations.ContainerNumber = cNum[0]
+	srv.Operations.Labels = util.Labels(servName, srv.Operations)
 	serviceConf, err := loadServiceDefinition(servName)
 	if err != nil {
 		return nil, err
@@ -60,12 +62,15 @@ func MockServiceDefinition(servName string, newCont bool, cNum ...int) *definiti
 	srv.Name = servName
 
 	if len(cNum) == 0 {
-		srv.Operations.ContainerNumber = util.AutoMagic(cNum[0], "service", newCont)
+		srv.Operations.ContainerNumber = util.AutoMagic(cNum[0], definitions.TypeService, newCont)
 		logger.Debugf("Mocking Service Definition =>\t%s:%d (autoassigned)\n", servName, cNum[0])
 	} else {
 		srv.Operations.ContainerNumber = cNum[0]
 		logger.Debugf("Mocking Service Definition =>\t%s:%d\n", servName, cNum[0])
 	}
+
+	srv.Operations.ContainerType = definitions.TypeService
+	srv.Operations.Labels = util.Labels(servName, srv.Operations)
 
 	ServiceFinalizeLoad(srv)
 	return srv
@@ -127,7 +132,7 @@ func ServiceFinalizeLoad(srv *definitions.ServiceDefinition) {
 }
 
 func ConnectToAService(srv *definitions.Service, ops *definitions.Operation, name, internalName string, link, mount bool) {
-	connectToAService(srv, ops, "service", name, internalName, link, mount)
+	connectToAService(srv, ops, definitions.TypeService, name, internalName, link, mount)
 }
 
 // --------------------------------------------------------------------

--- a/perform/docker_run.go
+++ b/perform/docker_run.go
@@ -1002,9 +1002,6 @@ func configureInteractiveContainer(srv *def.Service, ops *def.Operation) (docker
 	// we expect to link to the main service container
 	opts.HostConfig.Links = srv.Links
 
-	// temporary hack.
-	opts.HostConfig.PortBindings = make(map[docker.Port][]docker.PortBinding)
-
 	return opts, nil
 }
 

--- a/services/manage.go
+++ b/services/manage.go
@@ -52,7 +52,7 @@ func NewService(do *definitions.Do) error {
 	srv := definitions.BlankServiceDefinition()
 	srv.Name = do.Name
 	srv.Service.Name = do.Name
-	srv.Service.Image = do.Args[0]
+	srv.Service.Image = do.Operations.Args[0]
 	srv.Service.AutoData = true
 
 	var err error
@@ -98,7 +98,7 @@ func RenameService(do *definitions.Do) error {
 
 		if !transformOnly {
 			logger.Debugf("Asking Docker to Service =>\t%s:%s:%d\n", do.Name, do.NewName, do.Operations.ContainerNumber)
-			err = perform.DockerRename(serviceDef.Service, serviceDef.Operations, do.Name, do.NewName)
+			err = perform.DockerRename(serviceDef.Operations, do.NewName)
 			if err != nil {
 				return err
 			}
@@ -148,7 +148,7 @@ func InspectService(do *definitions.Do) error {
 	if err != nil {
 		return err
 	}
-	err = InspectServiceByService(service.Service, service.Operations, do.Args[0])
+	err = InspectServiceByService(service.Service, service.Operations, do.Operations.Args[0])
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func PortsService(do *definitions.Do) error {
 
 	if IsServiceExisting(service.Service, service.Operations) {
 		logger.Debugf("Service exists, getting port mapping.\n")
-		return util.PrintPortMappings(service.Operations.SrvContainerID, do.Args)
+		return util.PrintPortMappings(service.Operations.SrvContainerID, do.Operations.Args)
 	}
 
 	return nil
@@ -214,7 +214,7 @@ func UpdateService(do *definitions.Do) error {
 }
 
 func RmService(do *definitions.Do) error {
-	for _, servName := range do.Args {
+	for _, servName := range do.Operations.Args {
 		service, err := loaders.LoadServiceDefinition(servName, false, do.Operations.ContainerNumber)
 		if err != nil {
 			return err
@@ -260,14 +260,11 @@ func CatService(do *definitions.Do) error {
 }
 
 func InspectServiceByService(srv *definitions.Service, ops *definitions.Operation, field string) error {
-	// if IsServiceExisting(srv, ops) {
 	err := perform.DockerInspect(srv, ops, field)
 	if err != nil {
 		return err
 	}
-	// } else {
-	// 	return fmt.Errorf("No service matching that name.\n")
-	// }
+
 	return nil
 }
 

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -59,7 +59,7 @@ func TestKnownService(t *testing.T) {
 	do.Known = true
 	do.Existing = false
 	do.Running = false
-	do.Args = []string{"testing"}
+	do.Operations.Args = []string{"testing"}
 	ifExit(util.ListAll(do, "services"))
 	k := strings.Split(do.Result, "\n") // tests output formatting.
 
@@ -111,9 +111,9 @@ func TestInspectService(t *testing.T) {
 
 	do := def.NowDo()
 	do.Name = servName
-	do.Args = []string{"name"}
+	do.Operations.Args = []string{"name"}
 	do.Operations.ContainerNumber = 1
-	logger.Debugf("Inspect service (via tests) =>\t%s:%v:%d\n", servName, do.Args, do.Operations.ContainerNumber)
+	logger.Debugf("Inspect service (via tests) =>\t%s:%v:%d\n", servName, do.Operations.Args, do.Operations.ContainerNumber)
 	e := InspectService(do)
 	if e != nil {
 		logger.Infof("Error inspecting service =>\t%v\n", e)
@@ -122,9 +122,9 @@ func TestInspectService(t *testing.T) {
 
 	do = def.NowDo()
 	do.Name = servName
-	do.Args = []string{"config.user"}
+	do.Operations.Args = []string{"config.user"}
 	do.Operations.ContainerNumber = 1
-	logger.Debugf("Inspect service (via tests) =>\t%s:%v\n", servName, do.Args)
+	logger.Debugf("Inspect service (via tests) =>\t%s:%v\n", servName, do.Operations.Args)
 	e = InspectService(do)
 	if e != nil {
 		logger.Infof("Error inspecting service =>\t%v\n", e)
@@ -158,9 +158,9 @@ func TestExecService(t *testing.T) {
 
 	do := def.NowDo()
 	do.Name = servName
-	do.Interactive = false
-	do.Args = strings.Fields("ls -la /root/")
-	logger.Debugf("Exec-ing serv (via tests) =>\t%s:%v\n", servName, strings.Join(do.Args, " "))
+	do.Operations.Interactive = false
+	do.Operations.Args = strings.Fields("ls -la /root/")
+	logger.Debugf("Exec-ing serv (via tests) =>\t%s:%v\n", servName, strings.Join(do.Operations.Args, " "))
 	e := ExecService(do)
 	if e != nil {
 		logger.Errorln(e)
@@ -197,7 +197,7 @@ func TestKillRmService(t *testing.T) {
 	do.Name = servName
 	do.Rm = false
 	do.RmD = false
-	do.Args = []string{servName}
+	do.Operations.Args = []string{servName}
 	logger.Debugf("Stopping serv (via tests) =>\t%s\n", servName)
 	if e := KillService(do); e != nil {
 		logger.Errorln(e)
@@ -214,7 +214,7 @@ func TestKillRmService(t *testing.T) {
 
 	do = def.NowDo()
 	do.Name = servName
-	do.Args = []string{servName}
+	do.Operations.Args = []string{servName}
 	do.File = false
 	do.RmD = true
 	logger.Debugf("Removing serv (via tests) =>\t%s\n", servName)
@@ -240,7 +240,7 @@ func TestImportService(t *testing.T) {
 		}*/
 
 	do := def.NowDo()
-	do.Args = []string{"ipfs"}
+	do.Operations.Args = []string{"ipfs"}
 	e := StartService(do)
 	if e != nil {
 		logger.Infof("Error starting service =>\t%v\n", e)
@@ -278,8 +278,8 @@ func TestNewService(t *testing.T) {
 	do := def.NowDo()
 	servName := "keys"
 	do.Name = servName
-	do.Args = []string{"quay.io/eris/keys"}
-	logger.Debugf("New-ing serv (via tests) =>\t%s:%v\n", do.Name, do.Args)
+	do.Operations.Args = []string{"quay.io/eris/keys"}
+	logger.Debugf("New-ing serv (via tests) =>\t%s:%v\n", do.Name, do.Operations.Args)
 	e := NewService(do)
 	if e != nil {
 		logger.Errorln(e)
@@ -287,10 +287,10 @@ func TestNewService(t *testing.T) {
 	}
 
 	do = def.NowDo()
-	do.Args = []string{servName}
+	do.Operations.Args = []string{servName}
 	// do.Operations.ContainerNumber = util.AutoMagic(0, "service")
 	//do.Operations.ContainerNumber = 1
-	logger.Debugf("Starting serv (via tests) =>\t%v:%d\n", do.Args, do.Operations.ContainerNumber)
+	logger.Debugf("Starting serv (via tests) =>\t%v:%d\n", do.Operations.Args, do.Operations.ContainerNumber)
 	e = StartService(do)
 	if e != nil {
 		logger.Errorln(e)
@@ -304,15 +304,6 @@ func TestNewService(t *testing.T) {
 }
 
 func TestRenameService(t *testing.T) {
-	// do := def.NowDo()
-	// do.Name = "keys"
-	// do.Args = []string{"quay.io/eris/keys"}
-	// logger.Debugf("New-ing serv (via tests) =>\t%s:%v\n", do.Name, do.Args)
-	// if e := NewService(do); e != nil {
-	// 	logger.Errorln(e)
-	// 	fatal(t, nil)
-	// }
-
 	testStartService(t, "keys", false)
 	testExistAndRun(t, "keys", 1, true, true)
 	testNumbersExistAndRun(t, "keys", 1, 1)
@@ -346,8 +337,8 @@ func TestRenameService(t *testing.T) {
 
 	testExistAndRun(t, "keys", 1, true, true)
 	testExistAndRun(t, "syek", 1, false, false)
-	testNumbersExistAndRun(t, "syek", 0, 0)
 	testNumbersExistAndRun(t, "keys", 1, 1)
+	testNumbersExistAndRun(t, "syek", 0, 0)
 
 	testKillService(t, "keys", true)
 	testExistAndRun(t, "keys", 1, false, false)
@@ -367,7 +358,7 @@ func TestCatService(t *testing.T) {
 
 func TestStartKillServiceWithDependencies(t *testing.T) {
 	do := def.NowDo()
-	do.Args = []string{"do_not_use"}
+	do.Operations.Args = []string{"do_not_use"}
 	//do.Operations.ContainerNumber = 1
 	// do.Operations.ContainerNumber = util.AutoMagic(0, "service")
 	logger.Debugf("Starting service with deps =>\t%s:%s\n", servName, "keys")
@@ -400,7 +391,7 @@ func TestStartKillServiceWithDependencies(t *testing.T) {
 
 func testStartService(t *testing.T, serviceName string, publishAll bool) {
 	do := def.NowDo()
-	do.Args = []string{serviceName}
+	do.Operations.Args = []string{serviceName}
 	do.Operations.ContainerNumber = 1 //util.AutoMagic(0, "service", true)
 	do.Operations.PublishAllPorts = publishAll
 	logger.Debugf("Starting service (via tests) =>\t%s:%d\n", serviceName, do.Operations.ContainerNumber)
@@ -419,7 +410,7 @@ func testKillService(t *testing.T, serviceName string, wipe bool) {
 
 	do := def.NowDo()
 	do.Name = serviceName
-	do.Args = []string{serviceName}
+	do.Operations.Args = []string{serviceName}
 	if wipe {
 		do.Rm = true
 		do.RmD = true
@@ -443,7 +434,7 @@ func testExistAndRun(t *testing.T, servName string, containerNumber int, toExist
 	do.Existing = true
 	do.Running = false
 	do.Quiet = true
-	do.Args = []string{"testing"}
+	do.Operations.Args = []string{"testing"}
 	if err := util.ListAll(do, "services"); err != nil {
 		logger.Errorln(err)
 		fatal(t, err)
@@ -461,7 +452,7 @@ func testExistAndRun(t *testing.T, servName string, containerNumber int, toExist
 	do.Existing = false
 	do.Running = true
 	do.Quiet = true
-	do.Args = []string{"testing"}
+	do.Operations.Args = []string{"testing"}
 	if err := util.ListAll(do, "services"); err != nil {
 		ifExit(err)
 	}
@@ -549,7 +540,7 @@ func testsInit() error {
 	do.Existing = false
 	do.Running = true
 	do.Quiet = true
-	do.Args = []string{"testing"}
+	do.Operations.Args = []string{"testing"}
 	logger.Debugln("Finding the running services.")
 	if err := util.ListAll(do, "services"); err != nil {
 		ifExit(err)
@@ -557,7 +548,7 @@ func testsInit() error {
 	res := strings.Split(do.Result, "\n")
 	for _, r := range res {
 		if r == "ipfs" {
-			ifExit(fmt.Errorf("IPFS service is running.\nPlease stop it with.\neris services stop -rx ipfs\n"))
+			ifExit(fmt.Errorf("IPFS service is running.\nPlease stop it with: eris services stop -rx ipfs\n"))
 		}
 	}
 	// make sure ipfs container does not exist
@@ -566,7 +557,7 @@ func testsInit() error {
 	do.Existing = true
 	do.Running = false
 	do.Quiet = true
-	do.Args = []string{"testing"}
+	do.Operations.Args = []string{"testing"}
 	logger.Debugln("Finding the existing services.")
 	if err := util.ListAll(do, "services"); err != nil {
 		ifExit(err)

--- a/util/container_labels.go
+++ b/util/container_labels.go
@@ -7,13 +7,12 @@ import (
 	def "github.com/eris-ltd/eris-cli/definitions"
 )
 
-// Labels returns map with container labels, based on the container
+// Labels returns a map with container labels, based on the container
 // short name and ops settings.
 //
-// ops
-//   SrvContainerName  - container name
-//   ContainerNumber   - container number
-//   ContainerType     - container type
+//  ops.SrvContainerName  - container name
+//  ops.ContainerNumber   - container number
+//  ops.ContainerType     - container type
 //
 func Labels(name string, ops *def.Operation) map[string]string {
 	labels := ops.Labels

--- a/util/container_labels.go
+++ b/util/container_labels.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/eris-ltd/eris-cli/config"
+	def "github.com/eris-ltd/eris-cli/definitions"
+)
+
+// Labels returns map with container labels, based on the container
+// short name and ops settings.
+//
+// ops
+//   SrvContainerName  - container name
+//   ContainerNumber   - container number
+//   ContainerType     - container type
+//
+func Labels(name string, ops *def.Operation) map[string]string {
+	labels := ops.Labels
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	labels[def.Namespace+":"+def.LabelEris] = "true"
+	labels[def.Namespace+":"+def.LabelShortName] = name
+	labels[def.Namespace+":"+def.LabelType] = ops.ContainerType
+	labels[def.Namespace+":"+def.LabelNumber] = fmt.Sprintf("%v", ops.ContainerNumber)
+
+	if user, _, err := config.GitConfigUser(); err == nil {
+		labels[def.Namespace+":"+def.LabelUser] = user
+	}
+
+	return labels
+}
+
+// SetLabel returns a labels map with additional label name and value.
+func SetLabel(labels map[string]string, name, value string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	labels[def.Namespace+":"+name] = value
+
+	return labels
+}

--- a/util/container_operations_test.go
+++ b/util/container_operations_test.go
@@ -1,0 +1,194 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+type S struct {
+	String string
+	Bool   bool
+	Int    int
+	Float  float64
+	Map    map[string]string
+	Slice  []string
+}
+
+var BasicTests = []struct {
+	name string
+	base *S
+	over *S
+	want *S
+}{
+	{"s1", &S{}, &S{}, &S{}},
+	{"s2", &S{String: "a"}, &S{}, &S{String: "a"}},
+	{"s3", &S{}, &S{String: "a"}, &S{String: "a"}},
+	{"s4", &S{String: "a"}, &S{String: "b"}, &S{String: "a"}},
+
+	{"b1", &S{}, &S{}, &S{}},
+	{"b2", &S{Bool: true}, &S{}, &S{Bool: true}},
+	{"b3", &S{}, &S{Bool: true}, &S{Bool: true}},
+	{"b4", &S{Bool: true}, &S{Bool: false}, &S{Bool: true}},
+	{"b5", &S{Bool: false}, &S{Bool: true}, &S{Bool: true}},
+
+	{"i1", &S{}, &S{}, &S{}},
+	{"i2", &S{Int: 10}, &S{}, &S{Int: 10}},
+	{"i3", &S{}, &S{Int: 10}, &S{Int: 10}},
+	{"i4", &S{Int: 10}, &S{Int: 12}, &S{Int: 10}},
+
+	{"f1", &S{}, &S{}, &S{}},
+	{"f2", &S{Float: 10.0}, &S{}, &S{Float: 10.0}},
+	{"f3", &S{}, &S{Float: 10.0}, &S{Float: 10.0}},
+	{"f4", &S{Float: 10.0}, &S{Float: 12.0}, &S{Float: 10.0}},
+
+	{"m1",
+		&S{Map: nil},
+		&S{Map: nil},
+		&S{Map: nil},
+	},
+	{"m2",
+		&S{Map: nil},
+		&S{Map: map[string]string{"a": "1"}},
+		&S{Map: map[string]string{"a": "1"}},
+	},
+	{"m3",
+		&S{Map: map[string]string{"a": "1"}},
+		&S{Map: nil},
+		&S{Map: map[string]string{"a": "1"}},
+	},
+	{"m4",
+		&S{Map: map[string]string{}},
+		&S{Map: map[string]string{}},
+		&S{Map: map[string]string{}},
+	},
+	{"m5",
+		&S{Map: map[string]string{}},
+		&S{Map: map[string]string{"a": "1", "b": "2"}},
+		&S{Map: map[string]string{"a": "1", "b": "2"}},
+	},
+	{"m6",
+		&S{Map: map[string]string{"a": "1", "b": "2"}},
+		&S{Map: map[string]string{}},
+		&S{Map: map[string]string{"a": "1", "b": "2"}},
+	},
+	{"m7",
+		&S{Map: map[string]string{"a": "1", "b": "2"}},
+		&S{Map: map[string]string{"a": "1", "b": "2"}},
+		&S{Map: map[string]string{"a": "1", "b": "2"}},
+	},
+	{"m8",
+		&S{Map: map[string]string{"a": "1", "b": "2"}},
+		&S{Map: map[string]string{"c": "3", "a": "4"}},
+		&S{Map: map[string]string{"a": "4", "b": "2", "c": "3"}},
+	},
+
+	{"sl1",
+		&S{Slice: []string{}},
+		&S{Slice: []string{}},
+		&S{Slice: []string{}},
+	},
+	{"sl2",
+		&S{Slice: nil},
+		&S{Slice: nil},
+		&S{Slice: nil},
+	},
+	{"sl3",
+		&S{Slice: nil},
+		&S{Slice: []string{}},
+		&S{Slice: []string{}},
+	},
+	{"sl4",
+		&S{Slice: []string{}},
+		&S{Slice: nil},
+		&S{Slice: []string{}},
+	},
+	{"sl5",
+		&S{Slice: nil},
+		&S{Slice: []string{"a"}},
+		&S{Slice: []string{"a"}},
+	},
+	{"sl6",
+		&S{Slice: []string{"a"}},
+		&S{Slice: nil},
+		&S{Slice: []string{"a"}},
+	},
+	{"sl7",
+		&S{Slice: []string{}},
+		&S{Slice: []string{"1", "2"}},
+		&S{Slice: []string{"1", "2"}},
+	},
+	{"sl8",
+		&S{Slice: []string{"1", "2"}},
+		&S{Slice: []string{}},
+		&S{Slice: []string{"1", "2"}},
+	},
+	{"sl9",
+		&S{Slice: []string{"1", "2"}},
+		&S{Slice: []string{"1", "2"}},
+		&S{Slice: []string{"1", "2", "1", "2"}},
+	},
+	{"sl10",
+		&S{Slice: []string{"2", "1"}},
+		&S{Slice: []string{"2", "1"}},
+		&S{Slice: []string{"2", "1", "2", "1"}},
+	},
+
+	{"mix1",
+		&S{Bool: true, Int: 10, Map: map[string]string{"a": "1"}},
+		&S{Float: 12, Slice: []string{"2", "1"}},
+		&S{Bool: true, Int: 10, Float: 12,
+			Slice: []string{"2", "1"}, Map: map[string]string{"a": "1"}},
+	},
+	{"mix2",
+		&S{Map: map[string]string{"a": "1"}, Slice: []string{"1"}},
+		&S{Map: map[string]string{"a": "2"}, Slice: []string{"1"}, String: "a"},
+		&S{Map: map[string]string{"a": "2"}, Slice: []string{"1", "1"}, String: "a"},
+	},
+}
+
+func TestMergeBasic(t *testing.T) {
+	for _, test := range BasicTests {
+		if err := Merge(test.base, test.over); err != nil {
+			t.Fatalf("%q: expected %v, got error %v", test.name, test.want, err)
+		}
+		if reflect.DeepEqual(test.base, test.want) != true {
+			t.Errorf("%q: expected %v, got %v", test.name, test.want, test.base)
+		}
+	}
+}
+
+func TestMergeError(t *testing.T) {
+	if err := Merge(nil, nil); err != ErrMergeParameters {
+		t.Fatalf("e1: expected error, got %v", err)
+	}
+	if err := Merge(S{}, nil); err != ErrMergeParameters {
+		t.Fatalf("e2: expected error, got %v", err)
+	}
+	if err := Merge(nil, S{}); err != ErrMergeParameters {
+		t.Fatalf("e3: expected error, got %v", err)
+	}
+	if err := Merge(S{}, S{}); err != ErrMergeParameters {
+		t.Fatalf("e4: expected error, got %v", err)
+	}
+	if err := Merge(&S{}, "a"); err != ErrMergeParameters {
+		t.Fatalf("e5: expected error, got %v", err)
+	}
+	if err := Merge("a", &S{}); err != ErrMergeParameters {
+		t.Fatalf("e6: expected error, got %v", err)
+	}
+	if err := Merge(&struct{ A string }{A: "a"}, &S{}); err != ErrMergeParameters {
+		t.Fatalf("e7: expected error, got %v", err)
+	}
+	if err := Merge(&S{}, &struct{ A string }{A: "a"}); err != ErrMergeParameters {
+		t.Fatalf("e8: expected error, got %v", err)
+	}
+	if err := Merge(&[]int{}, &[]int{}); err != ErrMergeParameters {
+		t.Fatalf("e9: expected error, got %v", err)
+	}
+	if err := Merge(&[]int{}, &S{}); err != ErrMergeParameters {
+		t.Fatalf("e10: expected error, got %v", err)
+	}
+	if err := Merge(&S{}, &[]int{}); err != ErrMergeParameters {
+		t.Fatalf("e11: expected error, got %v", err)
+	}
+}

--- a/util/listing_functions.go
+++ b/util/listing_functions.go
@@ -19,7 +19,7 @@ func ListAll(do *definitions.Do, typ string) (err error) {
 		fmt.Println(result)
 	} else {
 
-		testing := len(do.Args) != 0 && do.Args[0] == "testing"
+		testing := len(do.Operations.Args) != 0 && do.Operations.Args[0] == "testing"
 
 		var resK, resR, resE string
 


### PR DESCRIPTION
Related to #258. This PR contains refactoring of code to accomodate container labels. The old naming scheme is still used alongside the new one, that is the labels can be observed with `docker inspect` and checked against the container name.

I decided to push this potentially dangerous change first to be sure that if anything breaks, it's not because of labels.

The remaining bit will be isolated in a few `util/container*.go` files.

The one difference with the requirements is that the `SERVICE` label of a volumes-from data container contains the name and not the ID of the service (the service itself may or may not be running to determine ID).

```
        "MacAddress": "",
        "OnBuild": null,
        "Labels": {
            "eris:CONTAINER_NUMBER": "1",
            "eris:ERIS": "true",
            "eris:NAME": "tinydns",
            "eris:SERVICE": "eris_service_tinydns_1",
            "eris:TYPE": "data",
            "eris:USER": "Peter-Vypov"
        }
    }

```

The `ID`, `MACHINE`, and `SWARM` labels are not stored in the container and will be determined at its run time.

The `TEST` and `TEST_ID` labels can be added either to `util.Labels()`, `util.SetLabel()` functions or be determined at run time, but they're not added anywhere yet.

Changes:

* A few Docker* function signatures has changed to avoid adding a 5th or 6th parameter to them. The parameters are now added to `Operations` or moved from `Do`: ContainerType, Args, Interactive, and Volume:

```
DockerCreateDataContainer(ops)
DockerRunVolumesFromContainer(ops, service)
DockerRunInteractive(srv, ops)
DockerRename(ops, newName)
```
* `DockerRename()` function now removes and recreates containers, not renames them. This is to support labels, which cannot be modified at container run time. This has one side effect that the changes made to the container before rename are not retained. This required to rearrange the `TestDataRename()` test to put it after the import and export tests. (The other side effect is that this is a longer operation.)
* `loaders.LoadDataDefinition()` which doesn't use its own type. It populates the `Operation` with initial settings and labels.
* `util.OverWriteOperations()` rewrite to allow using other structs.

Locally this has been tested with Docker 1.5 and 1.9 (on Debian Jessie, Fedora 22, and El Capitan 10.11.1 Beta).