### PR TITLE
chain --image flag

### DIFF
--- a/chains/operate.go
+++ b/chains/operate.go
@@ -135,6 +135,9 @@ func startChain(do *definitions.Do, exec bool) error {
 	logger.Debugf("\twith AllPortsPublshd =>\t%v\n", chain.Operations.PublishAllPorts)
 
 	if exec {
+		if do.Image != "" {
+			chain.Service.Image = do.Image
+		}
 		err = perform.DockerRunInteractive(chain.Service, chain.Operations, do.Args, do.Interactive, "")
 	} else {
 		err = perform.DockerRun(chain.Service, chain.Operations)

--- a/commands/chains.go
+++ b/commands/chains.go
@@ -407,6 +407,7 @@ func addChainsFlags() {
 	chainsLogs.Flags().StringVarP(&do.Tail, "tail", "t", "150", "number of lines to show from end of logs")
 
 	chainsExec.Flags().BoolVarP(&do.Interactive, "interactive", "i", false, "interactive shell")
+	chainsExec.Flags().StringVarP(&do.Image, "image", "", "", "Docker image")
 
 	chainsRemove.Flags().BoolVarP(&do.File, "file", "f", false, "remove chain definition file as well as chain container")
 	chainsRemove.Flags().BoolVarP(&do.RmD, "data", "x", false, "remove data containers also")

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -42,6 +42,7 @@ type Do struct {
 	Gateway       string   `mapstructure:"," json:"," yaml:"," toml:","`
 	MachineName   string   `mapstructure:"," json:"," yaml:"," toml:","`
 	Name          string   `mapstructure:"," json:"," yaml:"," toml:","`
+	Image         string   `mapstructure:"," json:"," yaml:"," toml:","`
 	Path          string   `mapstructure:"," json:"," yaml:"," toml:","`
 	CSV           string   `mapstructure:"," json:"," yaml:"," toml:","`
 	NewName       string   `mapstructure:"," json:"," yaml:"," toml:","`


### PR DESCRIPTION
This PR adds the `--image` flag (no short name) to specify an alternative image to use with the `chains exec` command:

```
$ eris chains new sample

$ eris chains exec -i sample
$ docker inspect -f '{{.Config.Image}}' eris_interactive_eris_chain_sample_1
quay.io/eris/erisdb:0.10.4

$ eris chains exec -i --image ubuntu sample
$ docker inspect -f '{{.Config.Image}}' eris_interactive_eris_chain_sample_1
ubuntu

$ eris chains exec -i --image something sample
The docker image (something) is not found locally.
Would you like the marmots to pull it from the repository? (y/n)
```

Fixes #292.