### PR TITLE
data inspect fix

### DIFF
--- a/commands/data.go
+++ b/commands/data.go
@@ -149,14 +149,15 @@ func RenameData(cmd *cobra.Command, args []string) {
 }
 
 func InspectData(cmd *cobra.Command, args []string) {
-	IfExit(ArgCheck(2, "ge", cmd, args))
-
-	if len(args) == 1 {
-		args = append(args, "all")
-	}
+	IfExit(ArgCheck(1, "ge", cmd, args))
 
 	do.Name = args[0]
-	do.Path = args[1]
+	if len(args) == 1 {
+		do.Args = []string{"all"}
+	} else {
+		do.Args = []string{args[1]}
+	}
+
 	IfExit(data.InspectData(do))
 }
 


### PR DESCRIPTION
The fix copies the similar behavior from `chains inspect`.

```
$ eris data inspect sample 
ID:                 57fe54ce9e1e379cd5ad4ce564cdbac1b01dc5ae21e5b30da2b76161e042a347
...

$ eris data inspect sample line
sample data eris_data_sample_1 1

$ eris data inspect sample Config.Image
quay.io/eris/data

```

Fixes #304.