### PR TITLE
Exec fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,8 @@ RUN groupadd --system $USER && \
 RUN mkdir $ERIS && \
   mkdir /home/$USER/.docker
 RUN mv $BASE/tests/* /home/$USER
-RUN chown --recursive $USER /home/$USER
+RUN chown --recursive $USER:$USER /home/$USER
+RUN chown --recursive $USER:$USER /go
 
 USER $USER
 WORKDIR /home/$USER

--- a/definitions/service.go
+++ b/definitions/service.go
@@ -45,6 +45,9 @@ type Service struct {
 	CPUShares int64 `mapstructure:"cpu_shares" json:"cpu_shares,omitempty,omitzero" yaml:"cpu_shares,omitempty" toml:"cpu_shares,omitempty,omitzero"`
 	// maps directly to docker mem_limit
 	MemLimit int64 `mapstructure:"mem_limit" json:"memory,omitempty,omitzero" yaml:"memory,omitempty" toml:"memory,omitempty,omitzero"`
+
+	// an env variable to set for when we are running `eris exec` so we can find the main container
+	ExecHost string `mapstructure:"exec_host" json:"memory,omitempty,omitzero" yaml:"memory,omitempty" toml:"memory,omitempty,omitzero"`
 }
 
 func BlankService() *Service {

--- a/initialize/default_services.go
+++ b/initialize/default_services.go
@@ -11,6 +11,7 @@ func DefaultKeys() string {
 name = "keys"
 image = "quay.io/eris/keys"
 data_container = true
+exec_host = "ERIS_KEYS_HOST"
 `)
 }
 

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -204,4 +204,5 @@ func mergeDefaultsAndChain(chain *definitions.Chain, service *definitions.Servic
 	chain.Service.DomainName = util.OverWriteString(chain.Service.DomainName, service.DomainName)
 	chain.Service.User = util.OverWriteString(chain.Service.User, service.User)
 	chain.Service.MemLimit = util.OverWriteInt64(chain.Service.MemLimit, service.MemLimit)
+	chain.Service.ExecHost = util.OverWriteString(chain.Service.ExecHost, service.ExecHost)
 }

--- a/perform/docker_run.go
+++ b/perform/docker_run.go
@@ -799,8 +799,13 @@ func configureInteractiveContainer(srv *def.Service, ops *def.Operation, args []
 	opts.Config.OpenStdin = true
 	opts.Config.Tty = true
 	if interactive {
-		// start an interactive shell
-		opts.Config.Entrypoint = []string{"/bin/bash"}
+		// if there are args, we overwrite the entrypoint
+		// else we just start an interactive shell
+		if len(args) > 0 {
+			opts.Config.Entrypoint = args
+		} else {
+			opts.Config.Entrypoint = []string{"/bin/bash"}
+		}
 	} else {
 		// use the image's own entrypoint
 		opts.Config.Cmd = args
@@ -817,6 +822,12 @@ func configureInteractiveContainer(srv *def.Service, ops *def.Operation, args []
 			opts.HostConfig.Binds = append(opts.HostConfig.Binds, bind)
 		}
 	}
+
+	// we expect to link to the main service container
+	opts.HostConfig.Links = srv.Links
+
+	// temporary hack.
+	opts.HostConfig.PortBindings = make(map[docker.Port][]docker.PortBinding)
 
 	return opts, nil
 }

--- a/services/operate.go
+++ b/services/operate.go
@@ -95,6 +95,18 @@ func ExecService(do *definitions.Do) error {
 		return err
 	}
 	util.OverWriteOperations(service.Operations, do.Operations)
+
+	// get main service containers name
+	cname := util.ContainersName("service", do.Name, 1) // TODO: N
+	if service.Service.ExecHost == "" {
+		logger.Errorf("Warning: exec_host not found in service definition file. May not be able to communicate with %s\n", cname)
+	} else {
+		service.Service.Environment = append(service.Service.Environment, fmt.Sprintf("%s=localhosty", service.Service.ExecHost))
+	}
+
+	// link us to the main service container (TODO: use something better than localhosty)
+	service.Service.Links = append(service.Service.Links, fmt.Sprintf("%s:localhosty", cname))
+
 	return StartServiceInteractiveByService(service.Service, service.Operations, do.Args, do.Interactive, do.Volume)
 }
 


### PR DESCRIPTION
- exec respects the image's own entrypoint, providing args, and overwriting only if given `-i`
- `exec_host` field in the service config allows exec container to find the main container through linking 