### PR TITLE
--publish flag for exec commands

### DIFF
--- a/commands/chains.go
+++ b/commands/chains.go
@@ -406,6 +406,7 @@ func addChainsFlags() {
 	chainsLogs.Flags().BoolVarP(&do.Follow, "follow", "f", false, "follow logs, like tail -f")
 	chainsLogs.Flags().StringVarP(&do.Tail, "tail", "t", "150", "number of lines to show from end of logs")
 
+	chainsExec.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish random ports")
 	chainsExec.Flags().BoolVarP(&do.Interactive, "interactive", "i", false, "interactive shell")
 	chainsExec.Flags().StringVarP(&do.Image, "image", "", "", "Docker image")
 

--- a/commands/services.go
+++ b/commands/services.go
@@ -234,6 +234,7 @@ func addServicesFlags() {
 	servicesLogs.Flags().BoolVarP(&do.Follow, "follow", "f", false, "follow logs")
 	servicesLogs.Flags().StringVarP(&do.Tail, "tail", "t", "150", "number of lines to show from end of logs")
 
+	servicesExec.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish random ports")
 	servicesExec.Flags().BoolVarP(&do.Interactive, "interactive", "i", false, "interactive shell")
 	servicesExec.Flags().StringVarP(&do.Volume, "volume", "m", "", "mount a volume $HOME/.eris/VOLUME on a host machine to a /home/eris/.eris/VOLUME on a container")
 

--- a/services/operate.go
+++ b/services/operate.go
@@ -94,6 +94,7 @@ func ExecService(do *definitions.Do) error {
 	if err != nil {
 		return err
 	}
+	util.OverWriteOperations(service.Operations, do.Operations)
 	return StartServiceInteractiveByService(service.Service, service.Operations, do.Args, do.Interactive, do.Volume)
 }
 

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -101,12 +101,12 @@ func TestLoadServiceDefinition(t *testing.T) {
 }
 
 func TestStartKillService(t *testing.T) {
-	testStartService(t, servName)
+	testStartService(t, servName, false)
 	testKillService(t, servName, true)
 }
 
 func TestInspectService(t *testing.T) {
-	testStartService(t, servName)
+	testStartService(t, servName, false)
 	defer testKillService(t, servName, true)
 
 	do := def.NowDo()
@@ -133,7 +133,7 @@ func TestInspectService(t *testing.T) {
 }
 
 func TestLogsService(t *testing.T) {
-	testStartService(t, servName)
+	testStartService(t, servName, false)
 	defer testKillService(t, servName, true)
 	do := def.NowDo()
 	do.Name = servName
@@ -153,7 +153,7 @@ func TestExecService(t *testing.T) {
 		return
 	}*/
 
-	testStartService(t, servName)
+	testStartService(t, servName, true)
 	defer testKillService(t, servName, true)
 
 	do := def.NowDo()
@@ -169,7 +169,7 @@ func TestExecService(t *testing.T) {
 }
 
 func TestUpdateService(t *testing.T) {
-	testStartService(t, servName)
+	testStartService(t, servName, false)
 	defer testKillService(t, servName, true)
 	if os.Getenv("TEST_IN_CIRCLE") == "true" {
 		logger.Println("Testing in Circle. Where we don't have rm privileges (due to their driver). Skipping test.")
@@ -192,7 +192,7 @@ func TestUpdateService(t *testing.T) {
 }
 
 func TestKillRmService(t *testing.T) {
-	testStartService(t, servName)
+	testStartService(t, servName, false)
 	do := def.NowDo()
 	do.Name = servName
 	do.Rm = false
@@ -228,7 +228,7 @@ func TestKillRmService(t *testing.T) {
 }
 
 func TestImportService(t *testing.T) {
-	testStartService(t, "ipfs")
+	testStartService(t, "ipfs", false)
 	//	defer testKillService(t, "ipfs", true)
 	//XXX above functions paniced; this worked
 	/*
@@ -313,7 +313,7 @@ func TestRenameService(t *testing.T) {
 	// 	fatal(t, nil)
 	// }
 
-	testStartService(t, "keys")
+	testStartService(t, "keys", false)
 	testExistAndRun(t, "keys", 1, true, true)
 	testNumbersExistAndRun(t, "keys", 1, 1)
 
@@ -398,11 +398,11 @@ func TestStartKillServiceWithDependencies(t *testing.T) {
 //----------------------------------------------------------------------
 // test utils!
 
-func testStartService(t *testing.T, serviceName string) {
+func testStartService(t *testing.T, serviceName string, publishAll bool) {
 	do := def.NowDo()
 	do.Args = []string{serviceName}
 	do.Operations.ContainerNumber = 1 //util.AutoMagic(0, "service", true)
-	do.Operations.PublishAllPorts = true
+	do.Operations.PublishAllPorts = publishAll
 	logger.Debugf("Starting service (via tests) =>\t%s:%d\n", serviceName, do.Operations.ContainerNumber)
 	e := StartService(do)
 	if e != nil {


### PR DESCRIPTION
* `--publish` flag is added to `chains exec` and `services exec` to randomize a container's published listening ports in case the port is already occupied.

```
$ eris chains new sample
$ eris chains exec -i sample
API error (500): Cannot start container 97e1fb48aa4aa5467960d708dee111c66f59d4061857d3f9ca80336ed0b1f362: Bind for 0.0.0.0:46657 failed: port is already allocated
$ eris chains exec -pi sample 
root@dfcb7a017a1f:/home/eris/.eris#
```

* The `chains start` and `services start` commands with the `--publish` flag also match the above behaviour.

```
$ eris services start ipfs
$ eris services start ipfs -n 2
API error (500): Cannot start container 0baebd8c51c6ae9ad50faa21841dd8c9368c9822b3a1406961bfeee3b108e94c: Bind for 0.0.0.0:8080 failed: port is already allocated
$ eris services start ipfs -n 2 -p

$ eris services inspect ipfs NetworkSettings.Ports
map[8080/tcp:[{0.0.0.0 8080}] 4001/tcp:[{0.0.0.0 4001}] 5001/tcp:[{0.0.0.0 5001}]]
$ eris services inspect ipfs -n 2 NetworkSettings.Ports
map[5001/tcp:[{0.0.0.0 33056}] 8080/tcp:[{0.0.0.0 33055}] 4001/tcp:[{0.0.0.0 33057}]]

```

* The `testStartService()` test function has changed that it accepts now the `publishAll` boolean parameter of whether or not to randomize ports at service start. The function used to randomize ports by default. Except for the `TestExecService()`, the value for `publishAll` is false. (`TestExecService()` requires the ports to be randomized because it is run after the `ipfs` service start.)

This PR fixes the issue #300.