### PR TITLE
eris man command

### DIFF
--- a/commands/actions.go
+++ b/commands/actions.go
@@ -17,8 +17,8 @@ import (
 // flags to add: --global --project
 var Actions = &cobra.Command{
 	Use:   "actions",
-	Short: "Manage and Perform Structured Actions.",
-	Long: `Display and Manage actions for various components of the
+	Short: "Manage and perform structured actions.",
+	Long: `Display and manage actions for various components of the
 Eris platform and for the platform itself.
 
 Actions are bundles of commands which rely upon a project
@@ -54,20 +54,18 @@ func buildActionsCommand() {
 
 // Actions Sub-sub-Commands
 var actionsImport = &cobra.Command{
-	Use:   "import [name] [location]",
+	Use:   "import NAME LOCATION",
 	Short: "Import an action definition file from Github or IPFS.",
 	Long: `Import an action definition for your platform.
 
-By default, Eris will import from ipfs.
-
-To list known actions use: [eris actions known].`,
-	Example: "  eris actions import \"do not use\" QmNUhPtuD9VtntybNqLgTTevUmgqs13eMvo2fkCwLLx5MX",
+By default, Eris will import from ipfs.`,
+	Example: "$ eris actions import \"do not use\" QmNUhPtuD9VtntybNqLgTTevUmgqs13eMvo2fkCwLLx5MX",
 	Run:     ImportAction,
 }
 
 // flags to add: template
 var actionsNew = &cobra.Command{
-	Use:   "new [name]",
+	Use:   "new NAME",
 	Short: "Create a new action definition file.",
 	Long:  `Create a new action definition file optionally from a template.`,
 	Run:   NewAction,
@@ -82,7 +80,7 @@ var actionsList = &cobra.Command{
 }
 
 var actionsDo = &cobra.Command{
-	Use:   "do [name]",
+	Use:   "do NAME",
 	Short: "Perform an action.",
 	Long: `Perform an action according to the action definition file.
 
@@ -104,41 +102,39 @@ command line.
 
 The shells will be passed the host's environment as
 well as any additional env vars added to the action
-definition file.
-`,
-	Example: `  eris actions do dns register -> will run the ~/.eris/actions/dns_register action def file
-  eris actions do dns register name:cutemarm ip:111.111.111.111 -> will populate $name and $ip
-  eris actions do dns register cutemarm 111.111.111.111 -> will populate $1 and $2`,
+definition file.`,
+	Example: `$ eris actions do dns register -- will run the ~/.eris/actions/dns_register action def file
+$ eris actions do dns register name:cutemarm ip:111.111.111.111 -- will populate $name and $ip
+$ eris actions do dns register cutemarm 111.111.111.111 -- will populate $1 and $2`,
 	Run: DoAction,
 }
 
 var actionsEdit = &cobra.Command{
-	Use:   "edit [name]",
+	Use:   "edit NAME",
 	Short: "Edit an action definition file.",
 	Long:  `Edit an action definition file in the default editor.`,
 	Run:   EditAction,
 }
 
 var actionsExport = &cobra.Command{
-	Use:   "export [chainName]",
+	Use:   "export NAME",
 	Short: "Export an action definition file to IPFS.",
 	Long: `Export an action definition file to IPFS.
 
-Command will return a machine readable version of the IPFS hash
-`,
+Command will return a machine readable version of the IPFS hash.`,
 	Run: ExportAction,
 }
 
 var actionsRename = &cobra.Command{
-	Use:     "rename [old] [new]",
+	Use:     "rename OLD_NAME NEW_NAME",
 	Short:   "Rename an action.",
 	Long:    `Rename an action.`,
-	Example: "  eris actions rename \"old action name\" \"new action name\"",
+	Example: "$ eris actions rename OLD_NAME NEW_NAME",
 	Run:     RenameAction,
 }
 
 var actionsRemove = &cobra.Command{
-	Use:   "remove [name]",
+	Use:   "remove NAME",
 	Short: "Remove an action definition file.",
 	Long:  `Remove an action definition file.`,
 	Run:   RmAction,

--- a/commands/chains.go
+++ b/commands/chains.go
@@ -17,29 +17,21 @@ import (
 // Primary Chains Sub-Command
 var Chains = &cobra.Command{
 	Use:   "chains",
-	Short: "Start, Stop, and Manage Blockchains.",
-	Long: `Start, Stop, and Manage Blockchains.
+	Short: "Start, stop, and manage blockchains.",
+	Long: `Start, stop, and manage blockchains.
 
 The chains subcommand is used to work on erisdb smart contract
 blockchain networks. The name is not perfect, as eris is able
 to operate a wide variety of blockchains out of the box. Most
-of those existing blockchains should be ran via the
-
-[eris services ...]
-
+of those existing blockchains should be ran via the [eris services ...]
 commands. As they fall under the rubric of "things I just want
 to turn on or off". While you can develop against those
 blockchains, you generally aren't developing those blockchains
-themselves.
+themselves. [eris chains ...] commands are built to help you build
+blockchains. It is our opinionated gateway to the wonderful world
+of permissioned smart contract networks.
 
-[eris chains ...] is built to help you build blockchains. It is our
-opinionated gateway to the wonderful world of permissioned
-smart contract networks.
-
-Your own blockchain/smart contract machine is just an
-
-[eris chains new]
-
+Your own blockchain/smart contract machine is just an [eris chains new]
 away!`,
 	Run: func(cmd *cobra.Command, args []string) { cmd.Help() },
 }
@@ -72,9 +64,9 @@ func buildChainsCommand() {
 
 // Chains Sub-sub-Commands
 var chainsNew = &cobra.Command{
-	Use:   "new [name]",
+	Use:   "new NAME",
 	Short: "Create a new blockhain.",
-	Long: `Creates a new blockchain.
+	Long: `Create a new blockchain.
 
 The creation process will both create a blockchain on the current machine
 as well as start running that chain.
@@ -97,15 +89,14 @@ unless the --serverconf flag is passed.
 
 For more complex blockchain creation, you will want to "hand craft" a genesis.json
 see our tutorial for chain creation here:
-https://docs.erisindustries.com/tutorials/chainmaking/
-`,
+https://docs.erisindustries.com/tutorials/chainmaking/`,
 	Run: NewChain,
 }
 
 var chainsRegister = &cobra.Command{
-	Use:   "register [name]",
-	Short: "Registers a blockchain on etcb (a blockchain for registering other blockchains",
-	Long: `Registers a blockchain on etcb
+	Use:   "register NAME",
+	Short: "Register a blockchain on etcb (a blockchain for registering other blockchains).",
+	Long: `Register a blockchain on etcb.
 
 etcb is Eris's blockchain which is a public blockchain that can be used to
 register *other* blockchains. In other words it is an easy way to "share"
@@ -114,22 +105,22 @@ seemlessly with [eris chains install] so that other users and/or colleagues
 should be able to use your registered blockchain by simply using the install
 command.
 
-register it is not the *only* way to share your blockchains (you can) also
-export your chain definition file and genesis.json to IPFS and share the
-hash of the chain definition file and genesis.json with any colleagues or
-users who need to be able to connect into the blockchain.
-`,
+[eris chains register] is not the *only* way to share your blockchains.
+You can also export your chain definition file and genesis.json to IPFS 
+and share the hash of the chain definition file and genesis.json 
+with any colleagues or users who need to be able to connect 
+into the blockchain.`,
 	Run: RegisterChain,
 }
 
 var chainsInstall = &cobra.Command{
-	Use:   "install [chainID]",
+	Use:   "install NAME",
 	Short: "Install a blockchain from the etcb registry.",
 	Long: `Install a blockchain from the etcb registry.
 
 Install an existing erisdb based blockchain for use locally.
 
-Still a WIP.`,
+(Currently a work in progress.)`,
 	Run: InstallChain,
 }
 
@@ -137,49 +128,44 @@ Still a WIP.`,
 var chainsListAll = &cobra.Command{
 	Use:   "ls",
 	Short: "Lists everything chain related.",
-	Long: `Lists all:
+	Long: `Lists all: chain definition files (--known), current existing
+containers for each chain (--existing), current running containers for each
+chain (--running).
 
-	- chain definition files (--known)
-	- current existing containers for each chain (--existing)
-	- current running containers for each chain (--running)
+If no known chains exist yet, create a new blockchain with: [eris chains new NAME]
+command.
 
-If no known chains exist yet, create a new blockchain with:
-
-	$ eris chains new chainName
-
-To install and fetch a blockchain from a chain definition file, use:
-
-	$ eris chains install chainName
+To install and fetch a blockchain from a chain definition file, 
+use [eris chains install NAME] command.
 
 Services are handled using the [eris services] command.`,
 	Run: ListAllChains,
 }
 
 var chainsImport = &cobra.Command{
-	Use:   "import [name] [location]",
+	Use:   "import NAME LOCATION",
 	Short: "Import a chain definition file from Github or IPFS.",
 	Long: `Import a chain definition for your platform.
 
-By default, Eris will import from ipfs.
+By default, Eris will import from IPFS.
 
-To list known chains use: [eris chains known].`,
-	Example: "  eris chains import 2gather QmNUhPtuD9VtntybNqLgTTevUmgqs13eMvo2fkCwLLx5MX",
+To list known chains use: [eris chains ls --known].`,
+	Example: "$ eris chains import 2gather QmNUhPtuD9VtntybNqLgTTevUmgqs13eMvo2fkCwLLx5MX",
 	Run:     ImportChain,
 }
 
 var chainsCheckout = &cobra.Command{
-	Use:   "checkout",
-	Short: "Checks out a chain.",
-	Long: `Checks out a chain.
+	Use:   "checkout [NAME]",
+	Short: "Check out a chain.",
+	Long: `Check out a chain.
 
-Checkout is a convenience feature. For any eris command which accepts a
+Checkout is a convenience feature. For any Eris command which accepts a
 --chain or $chain variable, the checked out chain can replace manually
 passing in a --chain flag. If a --chain is passed to any command accepting
 --chain, the --chain which is passed will overwrite any checked out chain.
 
 If command is given without arguments it will clear the head and there will
-be no chain checked out.
-`,
+be no chain checked out.`,
 	Run: CheckoutChain,
 }
 
@@ -202,11 +188,10 @@ on the host.
 
 This is useful when stitching together chain networks which
 need to know how to connect into a specific chain (perhaps
-with or without a container number) container.
-`,
-	Example: `  eris chains ports myChain 1337 -> will display what port on the host is mapped to the eris:db API port
-  eris chains ports myChain 46656 -> will display what port on the host is mapped to the eris:db peer port
-  eris chains ports myChain 46657 -> will display what port on the host is mapped to the eris:db rpc port`,
+with or without a container number) container.`,
+	Example: `$ eris chains ports myChain 1337 -- will display what port on the host is mapped to the eris:db API port
+$ eris chains ports myChain 46656 -- will display what port on the host is mapped to the eris:db peer port
+$ eris chains ports myChain 46657 -- will display what port on the host is mapped to the eris:db rpc port`,
 	Run: PortsChain,
 }
 
@@ -215,25 +200,22 @@ var chainsHead = &cobra.Command{
 	Short: "The currently checked out chain.",
 	Long: `Displays the name of the currently checked out chain.
 
-To checkout a new chain use [eris chains checkout CHAINNAME]
+To checkout a new chain use [eris chains checkout NAME].
 
-To "uncheckout" a chain use [eris chains checkout] without any
-arguments.
-`,
+To "uncheckout" a chain use [eris chains checkout] without arguments.`,
 	Run: CurrentChain,
 }
 
 var chainsEdit = &cobra.Command{
-	Use:   "edit [name]",
+	Use:   "edit NAME",
 	Short: "Edit a blockchain.",
 	Long: `Edit a blockchain definition file.
 
 Edit will utilize the default editor set for your current shell
-or if none is set, it will use *vim*. Sorry for the bias emacs
+or if none is set, it will use *vim*. Sorry for the bias Emacs
 users, but we had to pick one and more marmots are known vim
-users ¯\_(ツ)_/¯ . Emacs users can set their $EDITOR variable
-and eris will default to that if you wise.
-`,
+users. Emacs users can set their EDITOR variable and eris 
+will default to that if you wise.`,
 	Run: EditChain,
 }
 
@@ -241,25 +223,24 @@ var chainsStart = &cobra.Command{
 	Use:   "start",
 	Short: "Start a blockchain.",
 	Long: `Start running a blockchain.
-
-[eris chains start name] by default will put the chain into the
+	
+[eris chains start NAME] by default will put the chain into the
 background so its logs will not be viewable from the command line.
 
-To stop the chain use:      [eris chains stop chainName].
-To view a chain's logs use: [eris chains logs chainName].
-`,
+To stop the chain use:      [eris chains stop NAME].
+To view a chain's logs use: [eris chains logs NAME].`,
 	Run: StartChain,
 }
 
 var chainsLogs = &cobra.Command{
-	Use:   "logs",
+	Use:   "logs NAME",
 	Short: "Display the logs of a blockchain.",
 	Long:  `Display the logs of a blockchain.`,
 	Run:   LogChain,
 }
 
 var chainsExec = &cobra.Command{
-	Use:   "exec [serviceName]",
+	Use:   "exec NAME",
 	Short: "Run a command or interactive shell",
 	Long: `Run a command or interactive shell in a container
 with volumes-from the data container`,
@@ -267,59 +248,56 @@ with volumes-from the data container`,
 }
 
 var chainsStop = &cobra.Command{
-	Use:   "stop [name]",
+	Use:   "stop NAME",
 	Short: "Stop a running blockchain.",
 	Long:  `Stop a running blockchain.`,
 	Run:   KillChain,
 }
 
 var chainsInspect = &cobra.Command{
-	Use:   "inspect [chainName] [key]",
+	Use:   "inspect NAME [KEY]",
 	Short: "Machine readable chain operation details.",
-	Long: `Displays machine readable details about running containers.
+	Long: `Display machine readable details about running containers.
 
 Information available to the inspect command is provided by the
 Docker API. For more information about return values,
 see: https://github.com/fsouza/go-dockerclient/blob/master/container.go#L235`,
-	Example: `  eris chains inspect 2gather -> will display the entire information about 2gather containers
-  eris chains inspect 2gather name -> will display the name in machine readable format
-  eris chains inspect 2gather host_config.binds -> will display only that value`,
+	Example: `$ eris chains inspect 2gather -- will display the entire information about 2gather containers
+$ eris chains inspect 2gather name -- will display the name in machine readable format
+$ eris chains inspect 2gather host_config.binds -- will display only that value`,
 	Run: InspectChain,
 }
 
 var chainsExport = &cobra.Command{
-	Use:   "export [chainName]",
+	Use:   "export NAME",
 	Short: "Export a chain definition file to IPFS.",
 	Long: `Export a chain definition file to IPFS.
 
-Command will return a machine readable version of the IPFS hash
-`,
+Command will return a machine readable version of the IPFS hash.`,
 	Run: ExportChain,
 }
 
 var chainsRename = &cobra.Command{
-	Use:   "rename [old] [new]",
+	Use:   "rename OLD_NAME NEW_NAME",
 	Short: "Rename a blockchain.",
 	Long:  `Rename a blockchain.`,
 	Run:   RenameChain,
 }
 
 var chainsRemove = &cobra.Command{
-	Use:   "rm [name]",
-	Short: "Removes an installed chain.",
-	Long: `Removes an installed chain.
+	Use:   "rm NAME",
+	Short: "Remove an installed chain.",
+	Long: `Remove an installed chain.
 
 Command will remove the chain's container but will not
-remove the chain definition file.
-
-Use the --force flag to also remove the chain definition file.`,
+remove the chain definition file.`,
 	Run: RmChain,
 }
 
 var chainsUpdate = &cobra.Command{
-	Use:   "update [name]",
-	Short: "Updates an installed chain.",
-	Long: `Updates an installed chain, or installs it if it has not been installed.
+	Use:   "update NAME",
+	Short: "Update an installed chain.",
+	Long: `Update an installed chain, or install it if it has not been installed.
 
 Functionally this command will perform the following sequence:
 
@@ -329,16 +307,16 @@ Functionally this command will perform the following sequence:
 4. Rebuild the container from the updated image
 5. Restart the chain (if it was previously running)
 
-**NOTE**: If the chain uses data containers those will not be affected
+NOTE: If the chain uses data containers those will not be affected
 by the update command.
 `,
 	Run: UpdateChain,
 }
 
 var chainsGraduate = &cobra.Command{
-	Use:   "graduate",
-	Short: "Graduates a chain to a service.",
-	Long: `Graduates a chain to a service.
+	Use:   "graduate NAME",
+	Short: "Graduate a chain to a service.",
+	Long: `Graduate a chain to a service.
 
 Graduate works by translating the chain's definition into a service definition
 file with the chain_id set as the service name and everything set for you to
@@ -351,15 +329,14 @@ easier to work with chains as a service rather than as a chain when they are
 stable and not longer need to be worked "on" which is why this functionality
 exists. Ultimately, graduate is a convenience function as there is little to
 no difference in how chains and services "run", however the [eris chains]
-functions have more convenience functions for working "on" chains themselves.
-`,
+functions have more convenience functions for working "on" chains themselves.`,
 	Run: GraduateChain,
 }
 
 var chainsCat = &cobra.Command{
-	Use:   "cat [name]",
-	Short: "Displays chains definition file.",
-	Long: `Displays chains definition file.
+	Use:   "cat NAME",
+	Short: "Display chains definition file.",
+	Long: `Display chains definition file.
 
 Command will cat local chains definition file.`,
 	Run: CatChain,
@@ -379,12 +356,12 @@ func addChainsFlags() {
 	chainsNew.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish random ports")
 	chainsNew.PersistentFlags().BoolVarP(&do.Run, "api", "a", false, "turn the chain on using erisdb's api")
 	chainsNew.PersistentFlags().BoolVarP(&do.Force, "force", "f", false, "overwrite data in  ~/.eris/data/chainName")
-	chainsNew.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val1 syntax")
-	chainsNew.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked using the KEY1:val1,KEY2:val1 syntax")
+	chainsNew.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val2 syntax")
+	chainsNew.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked using the KEY1:val1,KEY2:val2 syntax")
 
 	chainsRegister.PersistentFlags().StringVarP(&do.Pubkey, "pub", "p", "", "pubkey to use for registering the chain in etcb")
-	chainsRegister.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked using the KEY1:val1,KEY2:val1 syntax")
-	chainsRegister.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1:val1,KEY2:val1 syntax")
+	chainsRegister.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked using the KEY1:val1,KEY2:val2 syntax")
+	chainsRegister.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1:val1,KEY2:val2 syntax")
 	chainsRegister.PersistentFlags().StringVarP(&do.Gateway, "etcb-host", "", "interblock.io:46657", "set the address of the etcb chain")
 	chainsRegister.PersistentFlags().StringVarP(&do.ChainID, "etcb-chain", "", "etcb_testnet", "set the chain id of the etcb chain")
 
@@ -415,14 +392,14 @@ func addChainsFlags() {
 	chainsRemove.Flags().BoolVarP(&do.Volumes, "vol", "o", true, "remove volumes")
 
 	chainsUpdate.Flags().BoolVarP(&do.SkipPull, "pull", "p", true, "pull an updated version of the chain's base service image from docker hub")
-	chainsUpdate.Flags().UintVarP(&do.Timeout, "timeout", "t", 10, "manually set the timeout; overridden by --force")
-	chainsUpdate.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val1 syntax")
-	chainsUpdate.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val1 syntax")
+	chainsUpdate.Flags().UintVarP(&do.Timeout, "timeout", "t", 10, "manually set the timeout; can be overridden by --force")
+	chainsUpdate.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val2 syntax")
+	chainsUpdate.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val2 syntax")
 
 	chainsStop.Flags().BoolVarP(&do.Rm, "rm", "r", false, "remove containers after stopping")
 	chainsStop.Flags().BoolVarP(&do.RmD, "data", "x", false, "remove data containers after stopping")
 	chainsStop.Flags().BoolVarP(&do.Force, "force", "f", false, "kill the container instantly without waiting to exit")
-	chainsStop.Flags().UintVarP(&do.Timeout, "timeout", "t", 10, "manually set the timeout; overridden by --force")
+	chainsStop.Flags().UintVarP(&do.Timeout, "timeout", "t", 10, "manually set the timeout; can be overridden by --force")
 	chainsStop.Flags().BoolVarP(&do.Volumes, "vol", "o", false, "remove volumes")
 
 	chainsListAll.Flags().BoolVarP(&do.Known, "known", "k", false, "list all the chain definition files that exist")

--- a/commands/chains.go
+++ b/commands/chains.go
@@ -105,10 +105,10 @@ seemlessly with [eris chains install] so that other users and/or colleagues
 should be able to use your registered blockchain by simply using the install
 command.
 
-[eris chains register] is not the *only* way to share your blockchains.
-You can also export your chain definition file and genesis.json to IPFS 
-and share the hash of the chain definition file and genesis.json 
-with any colleagues or users who need to be able to connect 
+The [eris chains register] command is not the *only* way to 
+share your blockchains. You can also export your chain definition file and 
+genesis.json to IPFS, and share the hash of the chain definition file and 
+genesis.json with any colleagues or users who need to be able to connect 
 into the blockchain.`,
 	Run: RegisterChain,
 }
@@ -172,14 +172,14 @@ be no chain checked out.`,
 var chainsPlop = &cobra.Command{
 	Use:   "plop",
 	Short: "Plop the genesis or config file",
-	Long:  "Display the genesis or config file in a machine readable output",
+	Long:  "Display the genesis or config file in a machine readable output.",
 	Run:   PlopChain,
 }
 
 var chainsPorts = &cobra.Command{
 	Use:   "ports",
-	Short: "Print the port mapping",
-	Long: `Print the port mapping
+	Short: "Print the port mappings.",
+	Long: `Print the port mappings.
 
 eris chains ports is mostly a developer convenience function.
 It returns a machine readable port mapping of a port which is
@@ -301,11 +301,11 @@ var chainsUpdate = &cobra.Command{
 
 Functionally this command will perform the following sequence:
 
-1. Stop the chain (if it is running)
-2. Remove the container which ran the chain
-3. Pull the image the container uses from a hub
-4. Rebuild the container from the updated image
-5. Restart the chain (if it was previously running)
+1. Stop the chain (if it is running).
+2. Remove the container which ran the chain.
+3. Pull the image the container uses from a hub.
+4. Rebuild the container from the updated image.
+5. Restart the chain (if it was previously running).
 
 NOTE: If the chain uses data containers those will not be affected
 by the update command.

--- a/commands/chains.go
+++ b/commands/chains.go
@@ -73,8 +73,8 @@ as well as start running that chain.
 
 If you need to update a chain after creation, you can update any of the
 appropriate settings in the chains definition file for the named chain
-(which will be located at ~/.eris/chains/CHAINNAME.toml) and then
-utilize [eris chains update CHAINNAME -p] to update the blockchain appropriately
+(which will be located at ~/.eris/chains/NAME.toml) and then
+utilize [eris chains update NAME -p] to update the blockchain appropriately
 (using the -p flag will force eris not to pull the most recent docker image
 for eris:db).
 

--- a/commands/config.go
+++ b/commands/config.go
@@ -9,16 +9,15 @@ import (
 
 var Config = &cobra.Command{
 	Use:   "config",
-	Short: "Manage Configuration Settings for Eris.",
-	Long: `Display and Manage configuration settings for various components of the
+	Short: "Manage configuration settings.",
+	Long: `Display and manage configuration settings for various components of the
 Eris platform and for the platform itself.
 
-NOTE: [eris config] is only for configuring the Eris platform
+The [eris config] command is only for configuring the Eris platform:
 it will not work to configure any of the blockchains, services
 or projects which are managed by the Eris platform. To configure
 blockchains use [eris chains config]; to configure services
-use [eris services config]; to configure projects use
-[eris projects config].`,
+use [eris services config]; to configure projects use [eris projects config].`,
 	Run: func(cmd *cobra.Command, args []string) { cmd.Help() },
 }
 
@@ -34,13 +33,12 @@ func buildConfigCommand() {
 
 // set
 var configSet = &cobra.Command{
-	Use:   "set [key]:[var]",
-	Short: "Set a config for the Eris Platform CLI.",
-	Long: `Set a config for the Eris Platform CLI.
-
-Note [eris config set] only operates on the settings for the eris
-cli. To set the config for a blockchain use [eris chains config]
-and to set the config for a service use [eris services config].`,
+	Use:   "set KEY:VALUE",
+	Short: "Set a config value.",
+	Long: `Set a config value.
+NOTE: the [eris config set] command only operates on the settings 
+for the eris CLI. To set the config for a blockchain use [eris chains config]
+command, and to set the config for a service use [eris services config].`,
 	Run: func(cmd *cobra.Command, args []string) {
 		config.Set(args)
 	},
@@ -49,8 +47,8 @@ and to set the config for a service use [eris services config].`,
 // show
 var configPlop = &cobra.Command{
 	Use:   "show",
-	Short: "Display the config for the Eris Platform CLI.",
-	Long:  `Display the config for the Eris Platform CLI.`,
+	Short: "Display the config.",
+	Long:  `Display the config.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// fmt.Println(Cum)
 		// config.PlopEntireConfig(globalConfig, args)
@@ -60,8 +58,8 @@ var configPlop = &cobra.Command{
 // edit
 var configEdit = &cobra.Command{
 	Use:   "edit",
-	Short: "Edit a config for the Eris Platform CLI in an editor.",
-	Long:  `Edit a config for the Eris Platform CLI in your default editor.`,
+	Short: "Edit a config for in an editor.",
+	Long:  `Edit a config for in your default editor.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		config.Edit()
 	},

--- a/commands/config.go
+++ b/commands/config.go
@@ -16,8 +16,8 @@ Eris platform and for the platform itself.
 The [eris config] command is only for configuring the Eris platform:
 it will not work to configure any of the blockchains, services
 or projects which are managed by the Eris platform. To configure
-blockchains use [eris chains config]; to configure services
-use [eris services config]; to configure projects use [eris projects config].`,
+blockchains use [eris chains config]; to configure services use [eris services config]; 
+to configure projects use [eris projects config] command.`,
 	Run: func(cmd *cobra.Command, args []string) { cmd.Help() },
 }
 
@@ -38,7 +38,8 @@ var configSet = &cobra.Command{
 	Long: `Set a config value.
 NOTE: the [eris config set] command only operates on the settings 
 for the eris CLI. To set the config for a blockchain use [eris chains config]
-command, and to set the config for a service use [eris services config].`,
+command, and to set the config for a service use [eris services config] 
+command.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		config.Set(args)
 	},

--- a/commands/contracts.go
+++ b/commands/contracts.go
@@ -53,15 +53,11 @@ var contractsTest = &cobra.Command{
 Tests can be structured using three different
 test types.
 
-1. epm - epm apps can be tested against tendermint
-style blockchains.
-2. embark - embark apps can be tested against
-ethereum style blockchains.
+1. epm - epm apps can be tested against tendermint style blockchains.
+2. embark - embark apps can be tested against ethereum style blockchains.
 3. truffle - HELP WANTED!
-4. solUnit - pure solidity smart contract packages
-may be tested via solUnit test framework.
-5. manual - a simple gulp task can be given to the
-test environment.`,
+4. solUnit - pure solidity smart contract packages may be tested via solUnit test framework.
+5. manual - a simple gulp task can be given to the test environment.`,
 	Run: ContractsTest,
 }
 
@@ -73,14 +69,11 @@ var contractsDeploy = &cobra.Command{
 Deployments can be structured using three different
 deploy types.
 
-1. epm - epm apps can be deployed to tendermint style
-blockchains simply.
-2. embark - embark apps can be deployed to an
-ethereum style blockchain simply.
+1. epm - epm apps can be deployed to tendermint style blockchains simply.
+2. embark - embark apps can be deployed to an ethereum style blockchain simply.
 3. truffle - HELP WANTED!
 4. pyepm - IF THIS IS STILL A THING, HELP WANTED!
-5. manual - a simple gulp task can be given to the
-deployer.`,
+5. manual - a simple gulp task can be given to the deployer.`,
 	Run: ContractsDeploy,
 }
 

--- a/commands/contracts.go
+++ b/commands/contracts.go
@@ -31,7 +31,7 @@ func buildContractsCommand() {
 }
 
 var contractsImport = &cobra.Command{
-	Use:   "import [hash] [packageName]",
+	Use:   "import HASH PACKAGE",
 	Short: "Pull a package of smart contracts from IPFS.",
 	Long: `Pull a package of smart contracts from IPFS
 via its hash and save it locally.`,
@@ -53,14 +53,14 @@ var contractsTest = &cobra.Command{
 Tests can be structured using three different
 test types.
 
-* epm -- epm apps can be tested against tendermint
+1. epm - epm apps can be tested against tendermint
 style blockchains.
-* embark -- embark apps can be tested against
+2. embark - embark apps can be tested against
 ethereum style blockchains.
-* truffle -- HELP WANTED!
-* solUnit -- pure solidity smart contract packages
+3. truffle - HELP WANTED!
+4. solUnit - pure solidity smart contract packages
 may be tested via solUnit test framework.
-* manual -- a simple gulp task can be given to the
+5. manual - a simple gulp task can be given to the
 test environment.`,
 	Run: ContractsTest,
 }
@@ -73,15 +73,14 @@ var contractsDeploy = &cobra.Command{
 Deployments can be structured using three different
 deploy types.
 
-* epm -- epm apps can be deployed to tendermint style
+1. epm - epm apps can be deployed to tendermint style
 blockchains simply.
-* embark -- embark apps can be deployed to an
+2. embark - embark apps can be deployed to an
 ethereum style blockchain simply.
-* truffle -- HELP WANTED!
-* pyepm -- IF THIS IS STILL A THING, HELP WANTED!
-* manual -- a simple gulp task can be given to the
-deployer.
-`,
+3. truffle - HELP WANTED!
+4. pyepm - IF THIS IS STILL A THING, HELP WANTED!
+5. manual - a simple gulp task can be given to the
+deployer.`,
 	Run: ContractsDeploy,
 }
 

--- a/commands/data.go
+++ b/commands/data.go
@@ -16,24 +16,24 @@ import (
 // Primary Data Sub-Command
 var Data = &cobra.Command{
 	Use:   "data",
-	Short: "Manage Data Containers for your Application.",
+	Short: "Manage data containers for your application.",
 	Long: `The data subcommand is used to import, and export
 data into containers for use by your application.
 
-eris data import and eris data export should be thought of from
-the point of view of the container.
+The [eris data import] and [eris data export] commands should be 
+thought of from the point of view of the container.
 
-eris data import sends files *as is* from ~/.eris/data/NAME on
-the host to ~/.eris/ inside of the data container.
+The [eris data import] command sends files *as is* from 
+~/.eris/data/NAME on the host to ~/.eris/ inside 
+of the data container.
 
-eris data export performs this process in the reverse. It sucks
-out whatever is in the volumes of the data container and sticks
-it back into ~/.eris/data/NAME on the host.
+The [eris data export] command performs this process in the reverse. 
+It sucks out whatever is in the volumes of the data container 
+and sticks it back into ~/.eris/data/NAME on the host.
 
-At eris, we use this functionality to formulate little jsons
+At Eris, we use this functionality to formulate little JSONs
 and configs on the host and then "stick them back into the
-containers"
-`,
+containers"`,
 	Run: func(cmd *cobra.Command, args []string) { cmd.Help() },
 }
 
@@ -50,7 +50,7 @@ func buildDataCommand() {
 }
 
 var dataImport = &cobra.Command{
-	Use:   "import [name]",
+	Use:   "import NAME",
 	Short: "Import ~/.eris/data/name folder to a named data container",
 	Long:  `Import ~/.eris/data/name folder to a named data container`,
 	Run:   ImportData,
@@ -82,35 +82,35 @@ Exec can also be used as an interactive shell. When put in
 this mode, you can "get inside of" your containers. You will
 have root access to a throwaway container which has the volumes
 of the data container mounted to it.`,
-	Example: `  eris data exec name ls /home/eris/.eris -> will list the eris dir
-  eris data exec name "ls -la /home/eris/.eris" -> will pass flags to the ls command
-  eris data exec --interactive name -> will start interactive console`,
+	Example: `$ eris data exec name ls /home/eris/.eris -- will list the eris dir
+$ eris data exec name "ls -la /home/eris/.eris" -- will pass flags to the ls command
+$ eris data exec --interactive name -- will start interactive console`,
 	Run: ExecData,
 }
 
 var dataRename = &cobra.Command{
-	Use:   "rename [oldName] [newName]",
+	Use:   "rename OLD_NAME NEW_NAME",
 	Short: "Rename a data container",
 	Long:  `Rename a data container`,
 	Run:   RenameData,
 }
 
 var dataInspect = &cobra.Command{
-	Use:   "inspect [name] [key]",
-	Short: "Machine readable details.",
-	Long:  `Displays machine readable details about running containers.`,
+	Use:   "inspect NAME [KEY]",
+	Short: "Show machine readable details.",
+	Long:  `Display machine readable details about running containers.`,
 	Run:   InspectData,
 }
 
 var dataExport = &cobra.Command{
-	Use:   "export [name] [folder]",
+	Use:   "export NAME DIRECTORY",
 	Short: "Export a named data container's volumes to ~/.eris/data/name",
 	Long:  `Export a named data container's volumes to ~/.eris/data/name`,
 	Run:   ExportData,
 }
 
 var dataRm = &cobra.Command{
-	Use:   "rm [name]",
+	Use:   "rm NAME",
 	Short: "Remove a data container",
 	Long:  `Remove a data container`,
 	Run:   RmData,

--- a/commands/eris.go
+++ b/commands/eris.go
@@ -19,13 +19,13 @@ const VERSION = version.VERSION
 
 // Defining the root command
 var ErisCmd = &cobra.Command{
-	Use:   "eris [command] [flags]",
+	Use:   "eris COMMAND [FLAG ...]",
 	Short: "The Blockchain Application Platform",
 	Long: `Eris is a platform for building, testing, maintaining, and operating
 distributed applications with a blockchain backend. Eris makes it easy
 and simple to wrangle the dragons of smart contract blockchains.
 
-Made with <3 by Eris Industries.
+Made with ♥ by Eris Industries.
 
 Complete documentation is available at https://docs.erisindustries.com
 ` + "\nVersion:\n  " + VERSION,
@@ -85,6 +85,10 @@ func AddCommands() {
 	ErisCmd.AddCommand(Init)
 	buildUpdateCommand()
 	ErisCmd.AddCommand(Update)
+	ErisCmd.AddCommand(ManPage)
+
+	ErisCmd.SetHelpCommand(Help)
+	ErisCmd.SetHelpTemplate(helpTemplate)
 
 }
 
@@ -98,7 +102,6 @@ func AddGlobalFlags() {
 	ErisCmd.PersistentFlags().BoolVarP(&do.Debug, "debug", "d", false, "debug level output")
 	ErisCmd.PersistentFlags().IntVarP(&do.Operations.ContainerNumber, "num", "n", 1, "container number")
 	ErisCmd.PersistentFlags().StringVarP(&do.MachineName, "machine", "m", "eris", "machine name for docker-machine that is running VM")
-
 }
 
 func InitializeConfig() {

--- a/commands/files.go
+++ b/commands/files.go
@@ -11,7 +11,7 @@ import (
 // Flags to add: ipfsHost
 var Files = &cobra.Command{
 	Use:   "files",
-	Short: "Manage Files Needed for Your Application Using IPFS.",
+	Short: "Manage files needed for your application using IPFS.",
 	Long: `The files subcommand is used to import, and export
 files to and from IPFS for use on the host machine.
 
@@ -40,53 +40,53 @@ func buildFilesCommand() {
 }
 
 var filesImport = &cobra.Command{
-	Use:   "get [hash] [fileName]",
+	Use:   "get HASH [FILE]",
 	Short: "Pull files from IPFS via a hash and save them locally.",
 	Long: `Pull files from IPFS via a hash and save them locally.
 
-Optionally pass in a csv with: get --csv=[fileName]`,
+Optionally pass in a CSV with: get --csv=FILE`,
 	Run: FilesGet,
 }
 
 var filesExport = &cobra.Command{
-	Use:   "put [fileName]",
+	Use:   "put FILE",
 	Short: "Post files to IPFS.",
 	Long: `Post files to IPFS.
 
-Optionally post all contents of a directory with: put [dirName] --dir`,
+Optionally post all contents of a directory with: put --dir=DIRNAME`,
 	Run: FilesPut,
 }
 
 var filesCache = &cobra.Command{
-	Use:   "cache [fileHash]",
+	Use:   "cache HASH",
 	Short: "Cache files to IPFS.",
 	Long: `Cache files to IPFS' local daemon.
 
-Caches a files locally via IPFS pin, by hash.
-Optionally pass in a csv with: cache --csv=[fileName]
-Note: "put" will "cache" recursively by default`,
+It caches files locally via IPFS pin, by hash.
+Optionally pass in a CSV with: cache --csv=[FILE]
+NOTE: "put" will "cache" recursively by default.`,
 	Run: FilesPin,
 }
 
 var filesCat = &cobra.Command{
-	Use:   "cat [fileHash]",
+	Use:   "cat HASH",
 	Short: "Cat the contents of a file from IPFS.",
 	Long:  "Cat the contents of a file from IPFS.",
 	Run:   FilesCat,
 }
 
 var filesList = &cobra.Command{
-	Use:   "ls [objectHash]",
+	Use:   "ls HASH",
 	Short: "List links from an IPFS object.",
 	//TODO [zr] test listing up and down through DAG
-	Long: "Lists object named by [objectHash/Path] and displays the link it contains.",
+	Long: "List an object named by HASH/FILE and display the link it contains.",
 	Run:  FilesList,
 }
 
 var filesCached = &cobra.Command{
 	Use:   "cached",
-	Short: "Lists files cached locally.",
-	Long:  `Displays list of files cached locally.`,
+	Short: "List files cached locally.",
+	Long:  `Display list of files cached locally.`,
 	Run:   FilesManageCached,
 }
 
@@ -94,14 +94,14 @@ var filesCached = &cobra.Command{
 // cli flags
 func addFilesFlags() {
 
-	filesImport.Flags().StringVarP(&do.CSV, "csv", "", "", "specify a .csv with entries of format: hash,fileName")
+	filesImport.Flags().StringVarP(&do.CSV, "csv", "", "", "specify a .csv with entries of format: HASH,FILE")
 	filesImport.Flags().StringVarP(&do.NewName, "dirname", "", "", "name of new directory to dump IPFS files from --csv")
 	filesExport.Flags().StringVarP(&do.Gateway, "gateway", "", "", "specify a hosted gateway. default is IPFS' gateway; type \"eris\" for our gateway, or use your own with \"http://yourhost\"")
 	//TODO `put files --dir -r` once pr to ipfs is merged
 	filesExport.Flags().BoolVarP(&do.AddDir, "dir", "", false, "add all files from a directory (note: this will not create an ipfs object). returns a log file (ipfs_hashes.csv) to pass into `eris files get`")
 
 	//command will ignore fileName but that's ok
-	filesCache.Flags().StringVarP(&do.CSV, "csv", "", "", "specify a .csv with entries of format: hash,fileName")
+	filesCache.Flags().StringVarP(&do.CSV, "csv", "", "", "specify a .csv with entries of format: HASH,FILE")
 
 	filesCached.Flags().BoolVarP(&do.Rm, "rma", "", false, "remove all cached files")
 	filesCached.Flags().StringVarP(&do.Hash, "rm", "", "", "remove a cached file by hash")

--- a/commands/files.go
+++ b/commands/files.go
@@ -63,7 +63,8 @@ var filesCache = &cobra.Command{
 	Long: `Cache files to IPFS' local daemon.
 
 It caches files locally via IPFS pin, by hash.
-Optionally pass in a CSV with: cache --csv=[FILE]
+Optionally pass in a CSV with: cache --csv=[FILE].
+
 NOTE: "put" will "cache" recursively by default.`,
 	Run: FilesPin,
 }

--- a/commands/help.go
+++ b/commands/help.go
@@ -1,0 +1,48 @@
+package commands
+
+import "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
+
+const helpTemplate = `Usage: {{.UseLine}}{{if .Runnable}}{{if .HasSubCommands}} COMMAND{{end}}{{if .HasFlags}} [FLAG...]{{end}}{{end}}{{if gt .Aliases 0}}
+
+Aliases:
+  {{.NameAndAliases}}
+{{end}}{{if .HasExample}}
+
+Examples:
+{{ .Example }}{{end}}{{ if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimRightSpace}}{{end}}{{ if .HasInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasSubCommands }}
+
+Use "{{.CommandPath}} COMMAND --help" for more information about a command.{{end}}
+`
+
+var Help = &cobra.Command{
+	Use:   "help COMMAND",
+	Short: "Help about a command",
+	Long: `Provide help for any command in the application.
+Type eris help COMMAND for full details.`,
+	PersistentPreRun:  func(cmd *cobra.Command, args []string) {},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {},
+
+	Run: func(c *cobra.Command, args []string) {
+		cmd, _, e := c.Root().Find(args)
+		if cmd == nil || e != nil {
+			c.Printf("Unknown help topic %#q.", args)
+			c.Root().Usage()
+		} else {
+
+			helpFunc := cmd.HelpFunc()
+			helpFunc(cmd, args)
+		}
+	},
+}

--- a/commands/help.go
+++ b/commands/help.go
@@ -2,15 +2,14 @@ package commands
 
 import "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
 
-const helpTemplate = `Usage: {{.UseLine}}{{if .Runnable}}{{if .HasSubCommands}} COMMAND{{end}}{{if .HasFlags}} [FLAG...]{{end}}{{end}}{{if gt .Aliases 0}}
+const helpTemplate = `Usage: {{.UseLine}}{{if .Runnable}}{{if .HasSubCommands}} COMMAND{{end}}{{if .HasFlags}} [FLAG...]{{end}}{{end}}
 
+{{.Long}}
+{{if gt .Aliases 0}}
 Aliases:
-  {{.NameAndAliases}}
-{{end}}{{if .HasExample}}
-
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
 Examples:
 {{ .Example }}{{end}}{{ if .HasAvailableSubCommands}}
-
 Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasLocalFlags}}
 

--- a/commands/init.go
+++ b/commands/init.go
@@ -12,8 +12,7 @@ var Init = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize the ~/.eris directory with default files or update to latest version",
 	Long: `Create the ~/.eris directory with actions and services subfolders
-and clone eris-ltd/eris-actions eris-ltd/eris-services into them, respectively.
-`,
+and clone eris-ltd/eris-actions eris-ltd/eris-services into them, respectively.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		Router(cmd, args)
 	},

--- a/commands/list.go
+++ b/commands/list.go
@@ -8,18 +8,14 @@ import (
 
 var ListEverything = &cobra.Command{
 	Use:   "ls",
-	Short: "Lists all the things eris knows about.",
-	Long: `Lists all known definition files for services
-and chains. Also lists all existing and running services and 
-chains and, data containers. 
+	Short: "List all the things eris knows about.",
+	Long: `List all known definition files for services
+and chains. Also lists all existing and running services and
+chains and, data containers.
 
-For more specific output, use:
-
-	$ eris services ls
-	$ eris chains ls
-	$ eris data ls
-
-with respective flags (--known, --existing, --running).`,
+For more detailed output, use [eris services ls], [eris chains ls], 
+and [eris data ls] commands with respective flags (--known, --existing, 
+--running).`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		ListAllTheThings()

--- a/commands/man.go
+++ b/commands/man.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/docker/docker/pkg/term"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
+)
+
+var ManPage = &cobra.Command{
+	Use:   "man",
+	Short: "Display a man page.",
+	Long:  `Display or dump the Eris man page.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		man := new(bytes.Buffer)
+
+		GenerateManPage(man)
+		DisplayManPage(man)
+	},
+}
+
+// GenerateManPages uses the Cobra commands' info to construct a man page.
+// It fills in the man buffer with the groff(1) markup code.
+func GenerateManPage(man *bytes.Buffer) {
+	generatePrologue(man)
+	generateCommands(man)
+	generateGlobalFlags(man)
+	generateEnvironment(man)
+	generateEpilogue(man)
+}
+
+func generatePrologue(man *bytes.Buffer) {
+	template.Must(template.New("prologue").Funcs(manHelpers).Parse(manPrologue)).Execute(man, ErisCmd)
+}
+
+func generateCommands(man *bytes.Buffer) {
+	template.Must(template.New("commands").Funcs(manHelpers).Parse(manMidsection)).ExecuteTemplate(man, "commands", ErisCmd)
+}
+
+func generateGlobalFlags(man *bytes.Buffer) {
+	template.Must(template.New("global flags").Funcs(manHelpers).Parse(manMidsection)).ExecuteTemplate(man, "global flags", ErisCmd)
+}
+
+func generateEnvironment(man *bytes.Buffer) {
+	template.Must(template.New("environment").Funcs(manHelpers).Parse(manEnvironment)).Execute(man, nil)
+}
+
+func generateEpilogue(man *bytes.Buffer) {
+	template.Must(template.New("epilogue").Funcs(manHelpers).Parse(manEpilogue)).Execute(man, ErisCmd)
+}
+
+// DisplayManPage runs the groff(1) formatter on a buffer
+// and then starts a pager to display the result.
+func DisplayManPage(in *bytes.Buffer) {
+	// If not a terminal, just dump the man page to stdout:
+	//
+	//  $ eris man > eris.1
+	//
+	if !term.IsTerminal(os.Stdout.Fd()) {
+		fmt.Println(in)
+		return
+	}
+
+	out := new(bytes.Buffer)
+	nroff := exec.Command("nroff", "-mdoc")
+	nroff.Stdin = in
+	nroff.Stdout = out
+	nroff.Run()
+
+	r, w := io.Pipe()
+	go func(w *io.PipeWriter, out *bytes.Buffer) {
+		fmt.Fprint(w, out)
+		w.Close()
+	}(w, out)
+
+	// Behave like less(1), which ignores SIGINT. more(1), on the other hand,
+	// handles SIGINT, but ignoring it doesn't harm.
+	// Ignoring the interrupt signal is important, because interrupting
+	// less(1) leaves the terminal in a broken state.
+	signal.Ignore(os.Interrupt)
+
+	// Use PAGER value if set, or less(1) by default.
+	pagerCommand := os.Getenv("PAGER")
+	if pagerCommand == "" {
+		pagerCommand = "less"
+	}
+
+	pagerArgs := strings.Split(pagerCommand, " ")
+	pager := exec.Command(pagerArgs[0], pagerArgs[1:]...)
+	pager.Stdin = r
+	pager.Stdout = os.Stdout
+	pager.Start()
+	pager.Wait()
+}

--- a/commands/man.go
+++ b/commands/man.go
@@ -84,7 +84,7 @@ func DisplayManPage(in *bytes.Buffer) {
 	// handles SIGINT, but ignoring it doesn't harm.
 	// Ignoring the interrupt signal is important, because interrupting
 	// less(1) leaves the terminal in a broken state.
-	signal.Ignore(os.Interrupt)
+	signal.Notify(make(chan os.Signal, 1), os.Interrupt)
 
 	// Use PAGER value if set, or less(1) by default.
 	pagerCommand := os.Getenv("PAGER")

--- a/commands/man_template.go
+++ b/commands/man_template.go
@@ -172,7 +172,7 @@ var manHelpers = map[string]interface{}{
 
 		// Insert a line break before a line which starts with a number and a period
 		// (prevent numbered lists to be reformatted).
-		text = regexp.MustCompile(`(?m)^(\ ?[[:digit:]]+\..+)`).ReplaceAllString(text, ".Bd -literal -compact\n$1\n.Ed\n")
+		text = regexp.MustCompile(`(?m)^(\ ?[[:digit:]]+\..+)`).ReplaceAllString(text, ".Bd -ragged -compact\n$1\n.Ed\n")
 
 		// Replace double new lines with single new lines (if any).
 		text = regexp.MustCompile(`(?s)\n\n`).ReplaceAllString(text, "\n")

--- a/commands/man_template.go
+++ b/commands/man_template.go
@@ -1,0 +1,201 @@
+package commands
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/pflag"
+)
+
+// Rendering Cobra commands directly to groff_mdoc(7).
+// This method is preffered here to using Cobra's GenMan() and GenManTree()
+// functions. Those unjustifiably use intermediary Markdown format and in turn
+// convert it to the old-fashioned and less flexible groff_man(7)
+// macros using the "github.com/cpuguy83/go-md2man/md2man" package.
+
+const manPrologue = `.Dd {{date "January 2, 2006"}}
+.Os
+.Dt ERIS 1
+.Sh NAME
+.Nm eris
+.Nd {{.Short}}
+.Sh SYNOPSIS
+.Nm
+.Cm COMMAND Op FLAG Ns ...
+.Sh DESCRIPTION
+{{escape .Long}}
+`
+
+const manMidsection = `
+{{define "commands"}}.Sh COMMANDS
+.Bd -filled
+To list available commands, ether run
+.Cm eris
+with no parameters or run
+.Cm eris help .
+.Ed
+{{range .Commands}}
+{{template "command prologue" .}}{{end}}
+{{end}}
+
+{{define "command prologue"}}.Ss {{.Name}}
+{{if .HasSubCommands}}
+.Bd -filled
+{{escape .Long}}
+.Ed
+{{range .Commands}}{{template "command" .}}{{end}}{{else}}
+{{template "command" .}}{{end}}{{end}}
+
+{{define "command"}}
+.Bd -ragged
+.Cm {{.UseLine}}
+
+{{escape .Long}}{{if .Aliases}}{{template "aliases" .Aliases}}{{end}}{{if .HasFlags}}
+{{template "flags" .NonInheritedFlags}}{{end}}{{if .HasExample}}{{template "examples" .Example}}{{end}}
+.Ed
+{{end}}
+
+{{define "flags"}}.Bl -ohang
+{{range escapeFlags .}}.It
+{{if .Shorthand}}.Fl {{.Shorthand}} , Fl Ns Fl {{.Name}}{{else}}.Fl Ns Fl {{.Name}}{{end}}{{if .DefValue}} Ns Op ={{.DefValue}}{{end}}
+.D1 {{escape .Usage}}
+{{end}}.El{{end}}
+
+{{define "examples"}}
+.Pp
+.Em Examples :
+.Bl -ohang -offset indent
+{{range splitExamples .}}.It
+{{escape .}}
+{{end}}.El{{end}}
+
+{{define "aliases"}}
+.Pp
+(Alternative command name:
+.Cm {{index . 0}} . ){{end}}
+
+{{define "global flags"}}.Sh GLOBAL FLAGS
+There are a few flags that are available for every single command. Global flags,
+just as regular command flags, can start with one or two dashes. Default
+values, if meaningful, are provided in square brackets.
+{{template "flags" .NonInheritedFlags}}
+{{end}}
+`
+
+const manEnvironment = `.Sh ENVIRONMENT
+.Nm
+uses the following environment variables:
+.Bl -tag -width "ERIS_PULL_APPROVE"
+.It Ev ERIS
+.Nm
+home directory. Supersedes the default
+.Pa $HOME/.eris
+path.
+.It Ev ERIS_PULL_APPROVE
+If set, answers
+.Em yes
+to the confirmation of whether to pull a Docker image,
+potentially a long-running operation. Used, for example, by
+.Cm eris services start
+and
+.Cm eris chains exec
+commands.
+.It Ev DOCKER_HOST
+Docker service host, which
+.Nm
+connects to.
+.It Ev DOCKER_CERT_PATH
+Docker secure connection key and certificate. See
+.Cm docker-machine env
+command or similar.
+.It Ev GOPATH
+.Xr go 1
+source and binary packages path. Used by the
+.Cm eris update
+self-update command.
+.It Ev EDITOR
+Default interactive text editor. Used by the
+.Cm eris services edit
+and
+.Cm eris chains edit
+commands. If not set, the
+.Xr vim 1
+editor is used by default.
+.El
+`
+
+const manEpilogue = `.Sh WWW
+http://erisindustries.com
+.Sh SEE ALSO
+.Xr docker 1 ,
+.Xr docker-machine 1 ,
+.Xr go 1 ,
+.Xr git 1 ,
+.Xr http://ipfs.io ,
+.Xr http://www.tutum.co ,
+.Xr http://quay.io
+.Sh AUTHORS
+Team of marmots.
+.Sh COPYRIGHT
+Copyright \[co] 2014-{{date "2006"}} by Eris Industries, Ltd.
+
+The software is distributed under the terms of the
+.Em GNU General Public License Version 3 .
+.Sh BUGS
+http://github.com/eris-ltd/eris-cli/issues
+`
+
+var manHelpers = map[string]interface{}{
+	"escape": func(text string) string {
+		// See groff_char(7).
+		text = strings.Replace(text, `\`, `\\`, -1)
+		text = strings.Replace(text, `♥`, `\[HE]`, -1)
+		text = strings.Replace(text, `'`, `\[aq]`, -1)
+		text = strings.Replace(text, `"`, `\[dq]`, -1)
+
+		// Reformat example description (as in "$ eris command -- description").
+		text = strings.Replace(text, " -- ", "\n.D1 ", -1)
+
+		// Some Ad-hoc formatting:
+
+		// Highlight "[eris command ...]".
+		text = regexp.MustCompile(`\[(eris\ [^]]+)\]([.,;:]?)`).ReplaceAllString(text, "\n.Cm $1 $2 No")
+
+		// Highlight "NOTE:".
+		text = regexp.MustCompile(`(NOTE):\ *`).ReplaceAllString(text, "\n.Em $1  :\n")
+
+		// Insert a line break before a line which starts with a number and a period
+		// (prevent numbered lists to be reformatted). Applicable for this:
+		text = regexp.MustCompile(`(?m)^(\ ?[[:digit:]]+\.)`).ReplaceAllString(text, ".It\n$1")
+
+		return text
+	},
+	// Cobra package doesn't provide a way to get a slice of flags;
+	// it requires "visiting" them.
+	"escapeFlags": func(flagSet *pflag.FlagSet) []*pflag.Flag {
+		flags := []*pflag.Flag{}
+
+		flagSet.VisitAll(func(flag *pflag.Flag) {
+			// Don't show empty lists or "false" as default flag values.
+			if flag.DefValue == "[]" || flag.DefValue == "false" {
+				flag.DefValue = ""
+			}
+
+			// Don't include the "--help" flag in the man page.
+			if flag.Name == "help" {
+				return
+			}
+
+			flags = append(flags, flag)
+		})
+
+		return flags
+	},
+	"splitExamples": func(examples string) []string {
+		return strings.Split(examples, "\n")
+	},
+	"date": func(format string) string {
+		return time.Now().Format(format)
+	},
+}

--- a/commands/man_template.go
+++ b/commands/man_template.go
@@ -172,7 +172,7 @@ var manHelpers = map[string]interface{}{
 
 		// Insert a line break before a line which starts with a number and a period
 		// (prevent numbered lists to be reformatted).
-		text = regexp.MustCompile(`(?m)^(\ ?[[:digit:]]+\..+)`).ReplaceAllString(text, ".Ed -literal -compact\n.It\n$1\n.Ed\n")
+		text = regexp.MustCompile(`(?m)^(\ ?[[:digit:]]+\..+)`).ReplaceAllString(text, ".Bd -literal -compact\n$1\n.Ed\n")
 
 		// Replace double new lines with single new lines (if any).
 		text = regexp.MustCompile(`(?s)\n\n`).ReplaceAllString(text, "\n")

--- a/commands/man_template.go
+++ b/commands/man_template.go
@@ -35,30 +35,29 @@ To list available commands, ether run
 with no parameters or run
 .Cm eris help .
 .Ed
-{{range .Commands}}
-{{template "command prologue" .}}{{end}}
-{{end}}
+{{range .Commands}}.Pp
+{{template "command prologue" .}}{{end}}{{end}}
 
 {{define "command prologue"}}.Ss {{.Name}}
-{{if .HasSubCommands}}
+{{if .HasSubCommands}}.Pp
 .Bd -filled
 {{escape .Long}}
 .Ed
-{{range .Commands}}{{template "command" .}}{{end}}{{else}}
+{{range .Commands}}.D1 \~
+{{template "command" .}}{{end}}{{else}}.Pp
 {{template "command" .}}{{end}}{{end}}
 
-{{define "command"}}
+{{define "command"}}.Pp
 .Bd -ragged
 .Cm {{.UseLine}}
-
+.Pp
 {{escape .Long}}{{if .Aliases}}{{template "aliases" .Aliases}}{{end}}{{if .HasFlags}}
 {{template "flags" .NonInheritedFlags}}{{end}}{{if .HasExample}}{{template "examples" .Example}}{{end}}
 .Ed
 {{end}}
 
 {{define "flags"}}.Bl -ohang
-{{range escapeFlags .}}.It
-{{if .Shorthand}}.Fl {{.Shorthand}} , Fl Ns Fl {{.Name}}{{else}}.Fl Ns Fl {{.Name}}{{end}}{{if .DefValue}} Ns Op ={{.DefValue}}{{end}}
+{{range escapeFlags .}}.It {{if .Shorthand}}Fl {{.Shorthand}} , Fl Ns Fl {{.Name}}{{else}}Fl Ns Fl {{.Name}}{{end}}{{if .DefValue}} Ns Op ={{.DefValue}}{{end}}
 .D1 {{escape .Usage}}
 {{end}}.El{{end}}
 
@@ -66,8 +65,7 @@ with no parameters or run
 .Pp
 .Em Examples :
 .Bl -ohang -offset indent
-{{range splitExamples .}}.It
-{{escape .}}
+{{range splitExamples .}}.It {{escape .}}
 {{end}}.El{{end}}
 
 {{define "aliases"}}
@@ -139,12 +137,11 @@ http://erisindustries.com
 Team of marmots.
 .Sh COPYRIGHT
 Copyright \[co] 2014-{{date "2006"}} by Eris Industries, Ltd.
-
+.Pp
 The software is distributed under the terms of the
 .Em GNU General Public License Version 3 .
 .Sh BUGS
-http://github.com/eris-ltd/eris-cli/issues
-`
+http://github.com/eris-ltd/eris-cli/issues`
 
 var manHelpers = map[string]interface{}{
 	"escape": func(text string) string {
@@ -154,20 +151,23 @@ var manHelpers = map[string]interface{}{
 		text = strings.Replace(text, `'`, `\[aq]`, -1)
 		text = strings.Replace(text, `"`, `\[dq]`, -1)
 
+		// Replace empty strings with an empty string formatter.
+		text = regexp.MustCompile(`(?m)^$`).ReplaceAllString(text, ".Pp")
+
 		// Reformat example description (as in "$ eris command -- description").
 		text = strings.Replace(text, " -- ", "\n.D1 ", -1)
 
 		// Some Ad-hoc formatting:
 
 		// Highlight "[eris command ...]".
-		text = regexp.MustCompile(`\[(eris\ [^]]+)\]([.,;:]?)`).ReplaceAllString(text, "\n.Cm $1 $2 No")
+		text = regexp.MustCompile(`\[(eris\ [^]]+)\]([.,;:]?)[[:space:]]*`).ReplaceAllString(text, "\n.Cm $1 $2\n")
 
 		// Highlight "NOTE:".
 		text = regexp.MustCompile(`(NOTE):\ *`).ReplaceAllString(text, "\n.Em $1  :\n")
 
 		// Insert a line break before a line which starts with a number and a period
-		// (prevent numbered lists to be reformatted). Applicable for this:
-		text = regexp.MustCompile(`(?m)^(\ ?[[:digit:]]+\.)`).ReplaceAllString(text, ".It\n$1")
+		// (prevent numbered lists to be reformatted).
+		text = regexp.MustCompile(`(?m)^(\ ?[[:digit:]]+\..+)`).ReplaceAllString(text, "\n$1")
 
 		return text
 	},

--- a/commands/man_template.go
+++ b/commands/man_template.go
@@ -172,7 +172,7 @@ var manHelpers = map[string]interface{}{
 
 		// Insert a line break before a line which starts with a number and a period
 		// (prevent numbered lists to be reformatted).
-		text = regexp.MustCompile(`(?m)^(\ ?[[:digit:]]+\..+)`).ReplaceAllString(text, "\n.Dl $1")
+		text = regexp.MustCompile(`(?m)^(\ ?[[:digit:]]+\..+)`).ReplaceAllString(text, ".Ed -literal -compact\n.It\n$1\n.Ed\n")
 
 		// Replace double new lines with single new lines (if any).
 		text = regexp.MustCompile(`(?s)\n\n`).ReplaceAllString(text, "\n")

--- a/commands/man_template.go
+++ b/commands/man_template.go
@@ -152,22 +152,30 @@ var manHelpers = map[string]interface{}{
 		text = strings.Replace(text, `"`, `\[dq]`, -1)
 
 		// Replace empty strings with an empty string formatter.
+		//
+		// Regexp flags:
+		//  (?m) - match begin of line and end of line in a multiline buffer.
+		//  (?s) - match newlines in a long buffer.
+		//
 		text = regexp.MustCompile(`(?m)^$`).ReplaceAllString(text, ".Pp")
+
+		// Some Ad-hoc formatting:
 
 		// Reformat example description (as in "$ eris command -- description").
 		text = strings.Replace(text, " -- ", "\n.D1 ", -1)
 
-		// Some Ad-hoc formatting:
-
 		// Highlight "[eris command ...]".
-		text = regexp.MustCompile(`\[(eris\ [^]]+)\]([.,;:]?)[[:space:]]*`).ReplaceAllString(text, "\n.Cm $1 $2\n")
+		text = regexp.MustCompile(`(?s)\n?\ *\[(eris\ [^]]+)\]([.,;:]?)[[:space:]]*`).ReplaceAllString(text, "\n.Cm $1 $2\n")
 
 		// Highlight "NOTE:".
-		text = regexp.MustCompile(`(NOTE):\ *`).ReplaceAllString(text, "\n.Em $1  :\n")
+		text = regexp.MustCompile(`(NOTE):[[:space:]]*`).ReplaceAllString(text, "\n.Em $1  :\n")
 
 		// Insert a line break before a line which starts with a number and a period
 		// (prevent numbered lists to be reformatted).
-		text = regexp.MustCompile(`(?m)^(\ ?[[:digit:]]+\..+)`).ReplaceAllString(text, "\n$1")
+		text = regexp.MustCompile(`(?m)^(\ ?[[:digit:]]+\..+)`).ReplaceAllString(text, "\n.Dl $1")
+
+		// Replace double new lines with single new lines (if any).
+		text = regexp.MustCompile(`(?s)\n\n`).ReplaceAllString(text, "\n")
 
 		return text
 	},

--- a/commands/man_template.go
+++ b/commands/man_template.go
@@ -165,7 +165,7 @@ var manHelpers = map[string]interface{}{
 		text = strings.Replace(text, " -- ", "\n.D1 ", -1)
 
 		// Highlight "[eris command ...]".
-		text = regexp.MustCompile(`(?s)\n?\ *\[(eris\ [^]]+)\]([.,;:]?)[[:space:]]*`).ReplaceAllString(text, "\n.Cm $1 $2\n")
+		text = regexp.MustCompile(`\[(eris\ [^]]+)\]([.,;:]?)[[:space:]]*`).ReplaceAllString(text, "\n.Cm $1 $2\n")
 
 		// Highlight "NOTE:".
 		text = regexp.MustCompile(`(NOTE):[[:space:]]*`).ReplaceAllString(text, "\n.Em $1  :\n")

--- a/commands/services.go
+++ b/commands/services.go
@@ -17,8 +17,8 @@ import (
 // Primary Services Sub-Command
 var Services = &cobra.Command{
 	Use:   "services",
-	Short: "Start, Stop, and Manage Services Required for your Application.",
-	Long: `Start, Stop, and Manage Services Required for your Application.
+	Short: "Start, stop, and manage services required for your application.",
+	Long: `Start, stop, and manage services required for your application.
 
 Services are all services known and used by the Eris platform with the
 exception of blockchain services.`,
@@ -51,122 +51,107 @@ func buildServicesCommand() {
 var servicesListAll = &cobra.Command{
 	Use:   "ls",
 	Short: "Lists everything service related.",
-	Long: `Lists all:
+	Long: `Lists all: service definition files (--known), current existing containers
+for each service (--existing), and current running containers
+for each service (--running).
 
-	- service definition files (--known)
-	- current existing containers for each service (--existing)
-	- current running containers for each service (--running)
-
-Known services can be started with:
-
-	$ eris services start serviceName
-
-To install a new service, use:
-
-	$ eris services import
-
-Services include all executable services supported by the
-Eris platform which are NOT blockchains or key managers.
+Known services can be started with the [eris services start NAME] command.
+To install a new service, use [eris services import]. Services include
+all executable services supported by the Eris platform which are
+NOT blockchains or key managers.
 
 Blockchains are handled using the [eris chains] command.`,
 	Run: ListAllServices,
 }
 
 var servicesImport = &cobra.Command{
-	Use:   "import [name] [hash]",
-	Short: "Import a service definition file from IPFS.",
-	Long: `Import a service for your platform.
-
-
-To list known services use: [eris services known].`,
-	Example: "  eris services import eth QmQ1LZYPNG4wSb9dojRicWCmM4gFLTPKFUhFnMTR3GKuA2",
+	Use:     "import NAME HASH",
+	Short:   "Import a service definition file from IPFS.",
+	Long:    `Import a service for your platform.`,
+	Example: "$ eris services import eth QmQ1LZYPNG4wSb9dojRicWCmM4gFLTPKFUhFnMTR3GKuA2",
 	Run:     ImportService,
 }
 
 var servicesNew = &cobra.Command{
-	Use:   "new [name] [image]",
-	Short: "Creates a new service.",
-	Long: `Creates a new service.
+	Use:   "new NAME IMAGE",
+	Short: "Create a new service.",
+	Long: `Create a new service.
 
-Command must be given a name and a Container Image using standard
+Command must be given a NAME and a container IMAGE using the standard
 docker format of [repository/organization/image].`,
-	Example: `  eris services new eth eris/eth
-  eris services new mint tutum.co/tendermint/tendermint`,
+	Example: "$ eris services new eth eris/eth\n" +
+		"$ eris services new mint tutum.co/tendermint/tendermint",
 	Run: NewService,
 }
 
 var servicesEdit = &cobra.Command{
-	Use:   "edit [name]",
+	Use:   "edit NAME",
 	Short: "Edit a service.",
 	Long: `Edit a service definition file which is kept in ~/.eris/services.
-
-Edit will utilize your default editor.
+Edit will utilize your default editor. (See also the ERIS environment variable.)
 
 NOTE: Do not use this command for configuring a *specific* service. This
 command will only operate on *service configuration file* which tell Eris
 how to start and stop a specific service.
 
 How that service is used for a specific project is handled from project
-definition files.
-
-For more information on project definition files please see: [eris help projects].`,
+definition files.`,
 	Run: EditService,
 }
 
 var servicesStart = &cobra.Command{
-	Use:   "start [name]",
+	Use:   "start NAME",
 	Short: "Start a service.",
-	Long: `Starts a service according to the service definition file which
+	Long: `Start a service according to the service definition file which
 eris stores in the ~/.eris/services directory.
 
-[eris services start name] by default will put the service into the
+[eris services start NAME] by default will put the service into the
 background so its logs will not be viewable from the command line.
 
-To stop the service use:      [eris services stop serviceName].
-To view a service's logs use: [eris services logs serviceName].`,
+To stop the service use:      [eris services stop NAME].
+To view a service's logs use: [eris services logs NAME].`,
 	Run: StartService,
 }
 
 var servicesInspect = &cobra.Command{
-	Use:   "inspect [serviceName] [key]",
+	Use:   "inspect NAME [KEY]",
 	Short: "Machine readable service operation details.",
-	Long: `Displays machine readable details about running containers.
+	Long: `Display machine readable details about running containers.
 
-Information available to the inspect command is provided by the
-Docker API. For more information about return values,
-see: https://github.com/fsouza/go-dockerclient/blob/master/container.go#L235`,
-	Example: `  eris services inspect ipfs -> will display the entire information about ipfs containers
-  eris services inspect ipfs name -> will display the name in machine readable format
-  eris services inspect ipfs host_config.binds -> will display only that value`,
+Information available to the inspect command is provided by the Docker API.
+For more information about return values, see:
+https://github.com/fsouza/go-dockerclient/blob/master/container.go#L235`,
+	Example: `$ eris services inspect ipfs -- will display the entire information about ipfs containers
+$ eris services inspect ipfs name -- will display the name in machine readable format
+$ eris services inspect ipfs host_config.binds -- will display only that value`,
 	Run: InspectService,
 }
 
 var servicesPorts = &cobra.Command{
-	Use:   "ports [port]",
-	Short: "Print port mapping",
-	Long:  "Print port mapping",
+	Use:   "ports PORT",
+	Short: "Print port mappings",
+	Long:  "Print port mappings",
 	Run:   PortsService,
 }
 
 var servicesExport = &cobra.Command{
-	Use:   "export [serviceName]",
+	Use:   "export NAME",
 	Short: "Export a service definition file to IPFS.",
 	Long: `Export a service definition file to IPFS.
 
-Command will return a machine readable version of the IPFS hash
-`,
+Command will return a machine readable version of the IPFS hash.`,
 	Run: ExportService,
 }
 
 var servicesLogs = &cobra.Command{
-	Use:   "logs [name]",
-	Short: "Displays the logs of a running service.",
-	Long:  `Displays the logs of a running service.`,
+	Use:   "logs NAME",
+	Short: "Display the logs of a running service.",
+	Long:  `Display the logs of a running service.`,
 	Run:   LogService,
 }
 
 var servicesExec = &cobra.Command{
-	Use:   "exec [serviceName]",
+	Use:   "exec NAME",
 	Short: "Run a command or interactive shell",
 	Long:  "Run a command or interactive shell in a container with volumes-from the data container",
 	Run:   ExecService,
@@ -174,26 +159,26 @@ var servicesExec = &cobra.Command{
 
 // stop stops a running service
 var servicesStop = &cobra.Command{
-	Use:   "stop [name]",
-	Short: "Stops a running service.",
-	Long:  `Stops a service which is currently running.`,
+	Use:   "stop NAME",
+	Short: "Stop a running service.",
+	Long:  `Stop a service which is currently running.`,
 	Run:   KillService,
 }
 
 var servicesRename = &cobra.Command{
-	Use:   "rename [oldName] [newName]",
-	Short: "Renames an installed service.",
-	Long:  `Renames an installed service.`,
+	Use:   "rename OLD_NAME NEW_NAME",
+	Short: "Rename an installed service.",
+	Long:  `Rename an installed service.`,
 	Run:   RenameService,
 }
 
 var servicesUpdate = &cobra.Command{
-	Use:     "update [name]",
+	Use:     "update NAME",
 	Aliases: []string{"restart"},
-	Short:   "Updates an installed service.",
-	Long: `Updates an installed service, or installs it if it has not been installed.
+	Short:   "Update an installed service.",
+	Long: `Update an installed service, or install it if it has not been installed.
 
-Functionally this command will perform the following sequence:
+Functionally this command will perform the following sequence of steps:
 
 1. Stop the service (if it is running)
 2. Remove the container which ran the service
@@ -201,27 +186,25 @@ Functionally this command will perform the following sequence:
 4. Rebuild the container from the updated image
 5. Restart the service (if it was previously running)
 
-**NOTE**: If the service uses data containers those will not be affected
-by the update command.`,
+NOTE: If the service uses data containers, those will not be affected
+by the [eris update] command.`,
 	Run: UpdateService,
 }
 
 var servicesRm = &cobra.Command{
-	Use:   "rm [name]",
-	Short: "Removes an installed service.",
-	Long: `Removes an installed service.
+	Use:   "rm NAME",
+	Short: "Remove an installed service.",
+	Long: `Remove an installed service.
 
-Command will remove the service's container but will not
-remove the service definition file.
-
-Use the --force flag to also remove the service definition file.`,
+Command will remove the service's container but will not remove
+the service definition file.`,
 	Run: RmService,
 }
 
 var servicesCat = &cobra.Command{
-	Use:   "cat [name]",
-	Short: "Displays service definition file.",
-	Long: `Displays service definition file.
+	Use:   "cat NAME",
+	Short: "Display the service definition file.",
+	Long: `Display the service definition file.
 
 Command will cat local service definition file.`,
 	Run: CatService,
@@ -240,13 +223,13 @@ func addServicesFlags() {
 
 	servicesUpdate.Flags().BoolVarP(&do.Pull, "pull", "p", false, "skip the pulling feature and simply rebuild the service container")
 	servicesUpdate.Flags().UintVarP(&do.Timeout, "timeout", "t", 10, "manually set the timeout; overridden by --force")
-	servicesUpdate.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val1 syntax")
-	servicesUpdate.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val1 syntax")
+	servicesUpdate.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val2 syntax")
+	servicesUpdate.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val2 syntax")
 
 	servicesStart.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish random ports")
 	servicesStart.Flags().StringVarP(&do.ChainName, "chain", "c", "", "specify a chain the service depends on")
-	servicesStart.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val1 syntax")
-	servicesStart.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val1 syntax")
+	servicesStart.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val2 syntax")
+	servicesStart.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val2 syntax")
 
 	servicesStop.Flags().BoolVarP(&do.All, "all", "a", false, "stop the primary service and its dependent services")
 	servicesStop.Flags().StringVarP(&do.ChainName, "chain", "c", "", "specify a chain the service should also stop")

--- a/commands/services.go
+++ b/commands/services.go
@@ -105,8 +105,9 @@ var servicesStart = &cobra.Command{
 	Long: `Start a service according to the service definition file which
 eris stores in the ~/.eris/services directory.
 
-[eris services start NAME] by default will put the service into the
-background so its logs will not be viewable from the command line.
+The [eris services start NAME] command by default will put the 
+service into the background so its logs will not be viewable 
+from the command line.
 
 To stop the service use:      [eris services stop NAME].
 To view a service's logs use: [eris services logs NAME].`,
@@ -180,11 +181,11 @@ var servicesUpdate = &cobra.Command{
 
 Functionally this command will perform the following sequence of steps:
 
-1. Stop the service (if it is running)
-2. Remove the container which ran the service
-3. Pull the image the container uses from a hub
-4. Rebuild the container from the updated image
-5. Restart the service (if it was previously running)
+1. Stop the service (if it is running).
+2. Remove the container which ran the service.
+3. Pull the image the container uses from a hub.
+4. Rebuild the container from the updated image.
+5. Restart the service (if it was previously running).
 
 NOTE: If the service uses data containers, those will not be affected
 by the [eris update] command.`,

--- a/commands/update.go
+++ b/commands/update.go
@@ -9,8 +9,8 @@ import (
 var Update = &cobra.Command{
 	Use:   "update",
 	Short: "Update the eris tool",
-	Long: `Fetches the latest version (master branch by default)
-and re-installs eris; requires git and go to be installed.`,
+	Long: `Fetch the latest version (master branch by default)
+and re-install eris; requires git and go to be installed.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		UpdateTool(cmd, args)
 	},


### PR DESCRIPTION
`eris man` command to display or generate a man page.

```
$ eris man

$ eris man > eris.1
$ nroff -mdoc eris.1 | less
```

The command doesn't use the Cobra's `GenMan()` or `GenManTree()` commands and uses Go templates to populate man markup directly (for more flexibility and to avoid using intermediary Markdown format).

The are a couple of changes made to how the command line help output looks:

![cli output](http://i.imgur.com/T3A8WC6.png)

1. command line parameters are now capitalized to differentiate between command line itself and a parameter name. Square brackets now mean an optional parameter. 
2. examples are now prefixed with the `$` dollar sign so that they look better in the man page.

![man output](http://i.imgur.com/fUJ936n.png)

This fixes the issue #185.