### PR TITLE
Fix the broken terminal state after exec commands

### DIFF
--- a/definitions/operation.go
+++ b/definitions/operation.go
@@ -11,7 +11,6 @@ type Operation struct {
 	Restart           string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	Remove            bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	Privileged        bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
-	Attach            bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	Interactive       bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	Follow            bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	AppName           string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`


### PR DESCRIPTION
The upgraded Docker client library closes the `stdin` of the attached container on exit. Use a proxy pipe for `stdin`.

Fixes the issue #321.