### PR TITLE
Use the `--dump` flag to return the man page source

### DIFF
--- a/commands/eris.go
+++ b/commands/eris.go
@@ -25,7 +25,7 @@ var ErisCmd = &cobra.Command{
 distributed applications with a blockchain backend. Eris makes it easy
 and simple to wrangle the dragons of smart contract blockchains.
 
-Made with ♥ by Eris Industries.
+Made with <3 by Eris Industries.
 
 Complete documentation is available at https://docs.erisindustries.com
 ` + "\nVersion:\n  " + VERSION,
@@ -86,10 +86,10 @@ func AddCommands() {
 	buildUpdateCommand()
 	ErisCmd.AddCommand(Update)
 	ErisCmd.AddCommand(ManPage)
+	buildManCommand()
 
 	ErisCmd.SetHelpCommand(Help)
 	ErisCmd.SetHelpTemplate(helpTemplate)
-
 }
 
 // Global Do struct

--- a/commands/man.go
+++ b/commands/man.go
@@ -10,7 +10,7 @@ import (
 	"os/signal"
 	"strings"
 
-	"github.com/docker/docker/pkg/term"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/docker/docker/pkg/term"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
 )
 

--- a/commands/man_template.go
+++ b/commands/man_template.go
@@ -147,9 +147,10 @@ var manHelpers = map[string]interface{}{
 	"escape": func(text string) string {
 		// See groff_char(7).
 		text = strings.Replace(text, `\`, `\\`, -1)
-		text = strings.Replace(text, `♥`, `\[HE]`, -1)
 		text = strings.Replace(text, `'`, `\[aq]`, -1)
 		text = strings.Replace(text, `"`, `\[dq]`, -1)
+		text = strings.Replace(text, `<`, `\[la]`, -1)
+		text = strings.Replace(text, `>`, `\[ra]`, -1)
 
 		// Replace empty strings with an empty string formatter.
 		//

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -25,6 +25,7 @@ type Do struct {
 	Yes           bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	OutputTable   bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Volumes       bool     `mapstructure:"," json:"," yaml:"," toml:","`
+	Dump          bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Lines         int      `mapstructure:"," json:"," yaml:"," toml:","` // XXX: for tail and logs
 	Timeout       uint     `mapstructure:"," json:"," yaml:"," toml:","`
 	N             uint     `mapstructure:"," json:"," yaml:"," toml:","`


### PR DESCRIPTION
* Use the `--dump` flag to return man page source code, otherwise run pager, or detect user's pager to display it.

* Use ASCII encoding instead of the default UTF-8 to display it. 