### PR TITLE
exec_host linking behaviour

### DIFF
--- a/commands/services.go
+++ b/commands/services.go
@@ -220,7 +220,9 @@ func addServicesFlags() {
 
 	servicesExec.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish random ports")
 	servicesExec.Flags().BoolVarP(&do.Operations.Interactive, "interactive", "i", false, "interactive shell")
-	servicesExec.Flags().StringVarP(&do.Operations.Volume, "volume", "l", "", fmt.Sprintf("mount a volume %v/VOLUME on a host machine to a %v/VOLUME on a container", ErisRoot, ErisContainerRoot))
+	servicesExec.Flags().StringVarP(&do.Operations.Volume, "volume", "", "", fmt.Sprintf("mount a volume %v/VOLUME on a host machine to a %v/VOLUME on a container", ErisRoot, ErisContainerRoot))
+	servicesExec.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val2 syntax")
+	servicesExec.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val2 syntax")
 
 	servicesUpdate.Flags().BoolVarP(&do.Pull, "pull", "p", false, "skip the pulling feature and simply rebuild the service container")
 	servicesUpdate.Flags().UintVarP(&do.Timeout, "timeout", "t", 10, "manually set the timeout; overridden by --force")

--- a/perform/docker_run.go
+++ b/perform/docker_run.go
@@ -379,6 +379,14 @@ func DockerRunInteractive(srv *def.Service, ops *def.Operation) error {
 		}
 	}
 
+	defer func() {
+		logger.Infof("Removing container =>\t\t%s\n", optsServ.Name)
+		if err := removeContainer(optsServ.Name, false); err != nil {
+			fmt.Errorf("Tragic! Error removing data container after executing (%v): %v", optsServ.Name, err)
+		}
+		logger.Infof("Container removed =>\t\t%s\n", optsServ.Name)
+	}()
+
 	_, err = createContainer(optsServ)
 	if err != nil {
 		return err
@@ -422,14 +430,6 @@ func DockerRunInteractive(srv *def.Service, ops *def.Operation) error {
 	if err := startContainer(optsServ.Name, &optsServ); err != nil {
 		return err
 	}
-
-	defer func() {
-		logger.Infof("Removing container =>\t\t%s\n", optsServ.Name)
-		if err := removeContainer(optsServ.Name, false); err != nil {
-			fmt.Errorf("Tragic! Error removing data container after executing (%v): %v", optsServ.Name, err)
-		}
-		logger.Infof("Container removed =>\t\t%s\n", optsServ.Name)
-	}()
 
 	// Wait for a console prompt to appear.
 	_, ok := <-attached


### PR DESCRIPTION
* Add the `--env` and `--links` flags to `services exec` command to be able to override linked service container links, and set up the `exec_host` setting manually.

* Make the `exec_host` warning an info rather than error message.

```bash
$ grep exec_host ~/.eris/services/tinydns.toml
exec_host   = "TINYDNS_VAR"
```

Service is linked:

```bash
$ eris services start tinydns
$ eris services exec -pi tinydns

root@4cf20b55cced:/go# grep tinydns /etc/hosts   
172.17.3.150	tinydns e24a25a11918 eris_service_tinydns_1
172.17.3.150	eris_service_tinydns_1
172.17.3.154	eris_interactive_eris_service_tinydns_1
172.17.3.150	eris_service_tinydns_1.bridge
172.17.3.154	eris_interactive_eris_service_tinydns_1.bridge

root@4cf20b55cced:/go# printenv TINYDNS_VAR
tinydns

root@4cf20b55cced:/go# ping tinydns
PING tinydns (172.17.3.156): 56 data bytes
64 bytes from 172.17.3.156: icmp_seq=0 ttl=64 time=0.120 ms
64 bytes from 172.17.3.156: icmp_seq=1 ttl=64 time=0.112 ms
64 bytes from 172.17.3.156: icmp_seq=2 ttl=64 time=0.134 ms
...
```

Not linked:

```bash
$ eris services stop tinydns
$ eris services exec -pi tinydns

root@e9326c5452bd:/go# grep tinydns /etc/hosts
172.17.3.155	eris_interactive_eris_service_tinydns_1
172.17.3.155	eris_interactive_eris_service_tinydns_1.bridge

root@e9326c5452bd:/go# printenv TINYDNS_VAR
root@e9326c5452bd:/go#
```

This PR fixes #322