### PR TITLE
perform refactoring and tests

### DIFF
--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/eris-ltd/eris-cli/definitions"
-	tests "github.com/eris-ltd/eris-cli/testings"
+	tests "github.com/eris-ltd/eris-cli/testutils"
 	"github.com/eris-ltd/eris-cli/util"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"

--- a/actions/manage.go
+++ b/actions/manage.go
@@ -47,7 +47,7 @@ func ImportAction(do *definitions.Do) error {
 		}
 
 		ipfsService.Operations.ContainerType = definitions.TypeService
-		err = perform.DockerRun(ipfsService.Service, ipfsService.Operations)
+		err = perform.DockerRunService(ipfsService.Service, ipfsService.Operations)
 		if err != nil {
 			return err
 		}
@@ -84,7 +84,7 @@ func ExportAction(do *definitions.Do) error {
 	if err != nil {
 		return err
 	}
-	err = perform.DockerRun(ipfsService.Service, ipfsService.Operations)
+	err = perform.DockerRunService(ipfsService.Service, ipfsService.Operations)
 	if err != nil {
 		return err
 	}

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/eris-ltd/eris-cli/loaders"
 	"github.com/eris-ltd/eris-cli/perform"
 	"github.com/eris-ltd/eris-cli/services"
-	tests "github.com/eris-ltd/eris-cli/testings"
+	tests "github.com/eris-ltd/eris-cli/testutils"
 	"github.com/eris-ltd/eris-cli/util"
 	"github.com/eris-ltd/eris-cli/version"
 
@@ -200,7 +200,7 @@ func TestChainsNewDirGen(t *testing.T) {
 	ops := loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
 	util.Merge(ops, do.Operations)
 	ops.Args = []string{"cat", fmt.Sprintf("/home/eris/.eris/file.file")}
-	b, err := perform.DockerRunVolumesFromContainer(ops, nil)
+	b, err := perform.DockerRunData(ops, nil)
 	if err != nil {
 		fatal(t, err)
 	}
@@ -220,7 +220,7 @@ func TestChainsNewDirGen(t *testing.T) {
 	ops = loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
 	util.Merge(ops, do.Operations)
 	ops.Args = []string{"cat", fmt.Sprintf("/home/eris/.eris/chains/%s/genesis.json", chainID)} //, "|", "jq", ".chain_id"}
-	b, err = perform.DockerRunVolumesFromContainer(ops, nil)
+	b, err = perform.DockerRunData(ops, nil)
 	if err != nil {
 		fatal(t, err)
 	}
@@ -545,7 +545,7 @@ func runContainer(t *testing.T, ops *def.Operation) []byte {
 	newWriter := new(bytes.Buffer)
 	config.GlobalConfig.Writer = newWriter
 
-	b, err := perform.DockerRunVolumesFromContainer(ops, nil)
+	b, err := perform.DockerRunData(ops, nil)
 	if err != nil {
 		fatal(t, err)
 	}

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -61,10 +61,9 @@ func RegisterChain(do *definitions.Do) error {
 	logger.Debugf("Starting chain container via Docker =>\t%s\n", chain.Service.Name)
 	logger.Debugf("\twith Image =>\t\t%s\n", chain.Service.Image)
 	chain.Operations = loaders.LoadDataDefinition(chain.Service.Name, do.Operations.ContainerNumber)
-	chain.Operations.Interactive = do.Operations.Interactive
 	chain.Operations.Args = []string{loaders.ErisChainRegister}
 
-	_, err = perform.DockerRunVolumesFromContainer(chain.Operations, chain.Service)
+	_, err = perform.DockerRunData(chain.Operations, chain.Service)
 
 	return err
 }

--- a/chains/operate.go
+++ b/chains/operate.go
@@ -129,7 +129,7 @@ func startChain(do *definitions.Do, exec bool) error {
 	}
 	chain.Service.Links = append(chain.Service.Links, do.Links...)
 
-	logger.Infof("StartChainRaw to DockerRun =>\t%s\n", chain.Service.Name)
+	logger.Infof("StartChainRaw to DockerRunService =>\t%s\n", chain.Service.Name)
 	logger.Debugf("\twith ChainID =>\t\t%v\n", chain.ChainID)
 	logger.Debugf("\twith Environment =>\t%v\n", chain.Service.Environment)
 	logger.Debugf("\twith AllPortsPublshd =>\t%v\n", chain.Operations.PublishAllPorts)
@@ -144,9 +144,9 @@ func startChain(do *definitions.Do, exec bool) error {
 		// the perform package will respect the images entryPoint if it
 		// exists.
 		chain.Service.EntryPoint = ""
-		err = perform.DockerRunInteractive(chain.Service, chain.Operations)
+		err = perform.DockerExecService(chain.Service, chain.Operations)
 	} else {
-		err = perform.DockerRun(chain.Service, chain.Operations)
+		err = perform.DockerRunService(chain.Service, chain.Operations)
 	}
 	if err != nil {
 		do.Result = "error"
@@ -173,7 +173,7 @@ func bootDependencies(chain *definitions.Chain, do *definitions.Do) error {
 			if !services.IsServiceRunning(srv.Service, srv.Operations) {
 				name := strings.ToUpper(do.Name)
 				logger.Infof("%s is not running. Starting now. Waiting for %s to become available \n", name, name)
-				if err = perform.DockerRun(srv.Service, srv.Operations); err != nil {
+				if err = perform.DockerRunService(srv.Service, srv.Operations); err != nil {
 					return err
 				}
 			}
@@ -229,7 +229,7 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 	// ensure/create data container
 	if !data.IsKnown(do.Name) {
 		ops := loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
-		if err := perform.DockerCreateDataContainer(ops); err != nil {
+		if err := perform.DockerCreateData(ops); err != nil {
 			return fmt.Errorf("Error creating data container =>\t%v", err)
 		}
 	} else {
@@ -375,7 +375,7 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 	logger.Debugf("Starting chain via Docker =>\t%s\n", chain.Service.Name)
 	logger.Debugf("\twith Image =>\t\t%s\n", chain.Service.Image)
 
-	err = perform.DockerRun(chain.Service, chain.Operations)
+	err = perform.DockerRunService(chain.Service, chain.Operations)
 	// this err is caught in the defer above
 
 	return

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ test:
   override:
     - "cd ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/cmd/eris && go install"
     - "tests/test.sh | tee $CIRCLE_ARTIFACTS/output.log ; test ${PIPESTATUS[0]} -eq 0":
-        timeout: 1200
+        timeout: 900
 
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ test:
   override:
     - "cd ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/cmd/eris && go install"
     - "tests/test.sh | tee $CIRCLE_ARTIFACTS/output.log ; test ${PIPESTATUS[0]} -eq 0":
-        timeout: 900
+        timeout: 1200
 
 deployment:
   master:

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -7,7 +7,7 @@ import (
 
 	def "github.com/eris-ltd/eris-cli/definitions"
 	srv "github.com/eris-ltd/eris-cli/services"
-	tests "github.com/eris-ltd/eris-cli/testings"
+	tests "github.com/eris-ltd/eris-cli/testutils"
 	"github.com/eris-ltd/eris-cli/util"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"

--- a/contracts/contracts_test.go
+++ b/contracts/contracts_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	tests "github.com/eris-ltd/eris-cli/testings"
+	tests "github.com/eris-ltd/eris-cli/testutils"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
 )

--- a/contracts/operate.go
+++ b/contracts/operate.go
@@ -180,7 +180,7 @@ func PerformAppActionService(do *definitions.Do, app *definitions.Contracts) err
 	logger.Infof("Performing App Action =>\t%s:%s:%s\n", do.Service.Name, do.Service.Image, do.Service.Command)
 
 	do.Operations.ContainerType = definitions.TypeService
-	if err := perform.DockerRun(do.Service, do.Operations); err != nil {
+	if err := perform.DockerRunService(do.Service, do.Operations); err != nil {
 		do.Result = "could not perform app action"
 		return err
 	}

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/eris-ltd/eris-cli/definitions"
-	tests "github.com/eris-ltd/eris-cli/testings"
+	tests "github.com/eris-ltd/eris-cli/testutils"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"

--- a/data/operate.go
+++ b/data/operate.go
@@ -66,13 +66,13 @@ func ImportData(do *definitions.Do) error {
 		doStuff.Operations.ContainerType = "data"
 		doStuff.Operations.ContainerNumber = 1
 		doStuff.Operations.Args = []string{"chown", "--recursive", "eris", do.Path}
-		_, err = perform.DockerRunVolumesFromContainer(doStuff.Operations, nil)
+		_, err = perform.DockerRunData(doStuff.Operations, nil)
 		if err != nil {
 			return fmt.Errorf("Error changing owner: %v\n", err)
 		}
 	} else {
 		ops := loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
-		if err := perform.DockerCreateDataContainer(ops); err != nil {
+		if err := perform.DockerCreateData(ops); err != nil {
 			return fmt.Errorf("Error creating data container %v.", err)
 		}
 		return ImportData(do)
@@ -87,7 +87,7 @@ func ExecData(do *definitions.Do) error {
 
 		ops := loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
 		util.Merge(ops, do.Operations)
-		if _, err := perform.DockerRunVolumesFromContainer(ops, nil); err != nil {
+		if err := perform.DockerExecData(ops, nil); err != nil {
 			return err
 		}
 	} else {

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -35,9 +35,9 @@ func fatal(t *testing.T, err error) {
 func TestMain(m *testing.M) {
 	var logLevel log.LogLevel
 
-	logLevel = 0
+	// logLevel = 0
 	// logLevel = 1
-	// logLevel = 3
+	logLevel = 3
 
 	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
 

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -35,9 +35,9 @@ func fatal(t *testing.T, err error) {
 func TestMain(m *testing.M) {
 	var logLevel log.LogLevel
 
-	// logLevel = 0
+	logLevel = 0
 	// logLevel = 1
-	logLevel = 3
+	// logLevel = 3
 
 	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
 

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/services"
-	tests "github.com/eris-ltd/eris-cli/testings"
+	tests "github.com/eris-ltd/eris-cli/testutils"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
 )

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -1,0 +1,1009 @@
+package perform
+
+import (
+	"os"
+	"testing"
+
+	def "github.com/eris-ltd/eris-cli/definitions"
+	"github.com/eris-ltd/eris-cli/loaders"
+	tests "github.com/eris-ltd/eris-cli/testutils"
+	"github.com/eris-ltd/eris-cli/util"
+
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
+)
+
+func TestMain(m *testing.M) {
+	var logLevel log.LogLevel
+
+	logLevel = 0
+	// logLevel = 1
+	// logLevel = 3
+
+	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
+
+	tests.IfExit(tests.TestsInit("perform"))
+
+	tests.RemoveAllContainers()
+
+	exitCode := m.Run()
+
+	if os.Getenv("TEST_IN_CIRCLE") != "true" {
+		tests.IfExit(tests.TestsTearDown())
+	}
+
+	os.Exit(exitCode)
+}
+
+func TestCreateDataSimple(t *testing.T) {
+	const (
+		name   = "testdata"
+		number = 199
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	ops := loaders.LoadDataDefinition(name, number)
+	if err := DockerCreateData(ops); err != nil {
+		t.Fatalf("expected data container created, got %v", err)
+	}
+
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 containers, got %v", n)
+	}
+
+	// Try to create a duplicate.
+	if err := DockerCreateData(ops); err == nil {
+		t.Fatalf("expected an error, got nil")
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestRunDataSimple(t *testing.T) {
+	const (
+		name   = "testdata"
+		number = 199
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	ops := loaders.LoadDataDefinition(name, number)
+	if err := DockerCreateData(ops); err != nil {
+		t.Fatalf("expected data container created, got %v", err)
+	}
+
+	ops.Args = []string{"uptime"}
+	if _, err := DockerRunData(ops, nil); err != nil {
+		t.Fatalf("expected data successfully run, got %v", err)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestRunDataBadCommandLine(t *testing.T) {
+	const (
+		name   = "testdata"
+		number = 199
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	ops := loaders.LoadDataDefinition(name, number)
+	if err := DockerCreateData(ops); err != nil {
+		t.Fatalf("expected data container created, got %v", err)
+	}
+
+	ops.Args = []string{"/bad/command/line"}
+	if _, err := DockerRunData(ops, nil); err == nil {
+		t.Fatalf("expected command line error, got nil")
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestExecDataSimple(t *testing.T) {
+	const (
+		name   = "testdata"
+		number = 199
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	ops := loaders.LoadDataDefinition(name, number)
+	if err := DockerCreateData(ops); err != nil {
+		t.Fatalf("expected data container created, got %v", err)
+	}
+
+	ops.Args = []string{"uptime"}
+	if err := DockerExecData(ops, nil); err != nil {
+		t.Fatalf("expected data successfully run, got %v", err)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestExecDataBadCommandLine(t *testing.T) {
+	const (
+		name   = "testdata"
+		number = 199
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	ops := loaders.LoadDataDefinition(name, number)
+	if err := DockerCreateData(ops); err != nil {
+		t.Fatalf("expected data container created, got %v", err)
+	}
+
+	ops.Args = []string{"/bad/command/line"}
+	if err := DockerExecData(ops, nil); err == nil {
+		t.Fatalf("expected command line error, got nil")
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestRunServiceSimple(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 service container running, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 dependent data container, got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestRunServiceNoDataContainer(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Service.AutoData = false
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 service container running, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 0 {
+		t.Fatalf("expecting no dependent data containers, got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestRunServiceTwoServices(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv1, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("1. could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv1.Service, srv1.Operations); err != nil {
+		t.Fatalf("1. expected service container created, got %v", err)
+	}
+
+	srv2, err := loaders.LoadServiceDefinition(name, true, number+1)
+	if err != nil {
+		t.Fatalf("2. could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv2.Service, srv2.Operations); err == nil {
+		t.Fatalf("2. expected service failure due to occupied ports, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 service running, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 2 {
+		t.Fatalf("expecting 2 dependent data container, got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestRunServiceTwoServicesPublishedPorts(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv1, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("1. could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv1.Service, srv1.Operations); err != nil {
+		t.Fatalf("1. expected service container created, got %v", err)
+	}
+
+	srv2, err := loaders.LoadServiceDefinition(name, true, number+1)
+	if err != nil {
+		t.Fatalf("2. could not load service definition %v", err)
+	}
+
+	srv2.Operations.PublishAllPorts = true
+	if err := DockerRunService(srv2.Service, srv2.Operations); err != nil {
+		t.Fatalf("2. expected service container created, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 2 {
+		t.Fatalf("expecting 2 services running, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 2 {
+		t.Fatalf("expecting 2 dependent data container, got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestExecServiceSimple(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Operations.Interactive = true
+	srv.Operations.Args = []string{"uptime"}
+	if err := DockerExecService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 service container running, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 dependent data container, got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestExecServiceTwice(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Operations.Interactive = true
+	srv.Operations.Args = []string{"uptime"}
+	if err := DockerExecService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("1. expected service container created, got %v", err)
+	}
+
+	if err := DockerExecService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("2. expected service container created, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 service container running, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 dependent data container, got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestExecServiceTwiceWithoutData(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Service.AutoData = false
+	srv.Operations.Interactive = true
+	srv.Operations.Args = []string{"uptime"}
+	if err := DockerExecService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("1. expected service container created, got %v", err)
+	}
+
+	if err := DockerExecService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("2. expected service container created, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 service container running, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 dependent data containers, got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestExecServiceBadCommandLine(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Operations.Interactive = false
+	srv.Operations.Args = []string{"/bad/command/line"}
+	if err := DockerExecService(srv.Service, srv.Operations); err == nil {
+		t.Fatalf("expected failure, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 service container running, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 dependent data container, got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestExecServiceNonInteractive(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Operations.Interactive = false
+	srv.Operations.Args = []string{"uptime"}
+	if err := DockerExecService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 service container running, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 dependent data container, got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestExecServiceAfterRunService(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	srv.Operations.Interactive = true
+	srv.Operations.Args = []string{"uptime"}
+	if err := DockerExecService(srv.Service, srv.Operations); err == nil {
+		t.Fatalf("expected failure due to unpublished ports, got %v", err)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestExecServiceAfterRunServiceWithPublishedPorts1(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Operations.PublishAllPorts = true
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	srv.Operations.Interactive = true
+	srv.Operations.Args = []string{"uptime"}
+	if err := DockerExecService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected exec container created, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 service container running, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 dependent data container, got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestExecServiceAfterRunServiceWithPublishedPorts2(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	srv.Operations.PublishAllPorts = true
+	srv.Operations.Interactive = true
+	srv.Operations.Args = []string{"uptime"}
+	if err := DockerExecService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected exec container created, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 service container running, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 dependent data container, got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestContainerExistsSimple(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if _, exists := ContainerExists(srv.Operations); exists != true {
+		t.Fatalf("expecting service container existing, got false")
+	}
+
+	srv.Operations.SrvContainerName = srv.Operations.DataContainerName
+	if _, exists := ContainerExists(srv.Operations); exists != true {
+		t.Fatalf("expecting data container existing, got false")
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestContainerExistsBadName(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Operations.SrvContainerName = "some-random-name"
+	if _, exists := ContainerExists(srv.Operations); exists != false {
+		t.Fatalf("expecting service container not existing, got true")
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestContainerExistsAfterRemove(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if _, exists := ContainerExists(srv.Operations); exists == false {
+		t.Fatalf("expecting service container exists, got false")
+	}
+
+	tests.RemoveContainer(name, def.TypeService, number)
+
+	if _, exists := ContainerExists(srv.Operations); exists == true {
+		t.Fatalf("expecting service container not existing after remove, got true")
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestContainerRunningSimple(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if _, exists := ContainerRunning(srv.Operations); exists == false {
+		t.Fatalf("expecting service container running, got false")
+	}
+
+	srv.Operations.SrvContainerName = srv.Operations.DataContainerName
+	if _, exists := ContainerRunning(srv.Operations); exists == true {
+		t.Fatalf("expecting data container not running, got true")
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestContainerRunningBadName(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if _, exists := ContainerRunning(srv.Operations); exists == false {
+		t.Fatalf("expecting service container running, got false")
+	}
+
+	srv.Operations.SrvContainerName = "random-bad-name"
+	if _, exists := ContainerRunning(srv.Operations); exists == true {
+		t.Fatalf("expecting data container not running, got true")
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestContainerRunningAfterRemove(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if _, exists := ContainerRunning(srv.Operations); exists == false {
+		t.Fatalf("expecting service container exists, got false")
+	}
+
+	tests.RemoveContainer(name, def.TypeService, number)
+
+	if _, exists := ContainerRunning(srv.Operations); exists == true {
+		t.Fatalf("expecting service container not existing after remove, got true")
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestDataContainerExistsSimple(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	srv.Operations.SrvContainerName = srv.Operations.DataContainerName
+	if _, exists := DataContainerExists(srv.Operations); exists != true {
+		t.Fatalf("expecting data container existing, got false")
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestDataContainerExistsBadName(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Operations.SrvContainerName = "some-random-name"
+	if _, exists := DataContainerExists(srv.Operations); exists != false {
+		t.Fatalf("expecting service container not existing, got true")
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestDataContainerExistsAfterRemove(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	srv.Operations.SrvContainerName = srv.Operations.DataContainerName
+	if _, exists := DataContainerExists(srv.Operations); exists == false {
+		t.Fatalf("expecting service container exists, got false")
+	}
+
+	tests.RemoveContainer(name, def.TypeData, number)
+
+	if _, exists := DataContainerExists(srv.Operations); exists == true {
+		t.Fatalf("expecting service container not existing after remove, got true")
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestRemoveWithoutData(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if err := DockerStop(srv.Service, srv.Operations, 5); err != nil {
+		t.Fatal("expected service container stopped, got %v", err)
+	}
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 service container running (before removal), got %v", n)
+	}
+
+	if err := DockerRemove(srv.Service, srv.Operations, false, true); err != nil {
+		t.Fatal("expected service container removed, got %v", err)
+	}
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 service container running (after removal), got %v", n)
+	}
+
+	srv.Operations.SrvContainerName = srv.Operations.DataContainerName
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data container existing (before removal), got %v", n)
+	}
+
+	if err := DockerRemove(srv.Service, srv.Operations, false, true); err != nil {
+		t.Fatal("expected service container removed, got %v", err)
+	}
+
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 data container running (after removal), got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestRemoveWithData(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if err := DockerStop(srv.Service, srv.Operations, 5); err != nil {
+		t.Fatal("expected service container stopped, got %v", err)
+	}
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 service container existing (before removal), got %v", n)
+	}
+
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data container existing (before removal), got %v", n)
+	}
+
+	if err := DockerRemove(srv.Service, srv.Operations, true, true); err != nil {
+		t.Fatal("expected service container removed, got %v", err)
+	}
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 service container running (after removal), got %v", n)
+	}
+
+	if n := util.HowManyContainersExisting(name, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 data container running (after removal), got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestRemoveServiceWithoutStopping(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if err := DockerRemove(srv.Service, srv.Operations, true, true); err == nil {
+		t.Fatal("expected service remove to fail, got nil")
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestStopSimple(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 service containers running, got %v", n)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 service containers existing, got %v", n)
+	}
+
+	if err := DockerStop(srv.Service, srv.Operations, 5); err != nil {
+		t.Fatalf("expected service container to stop, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 service containers running (after stop), got %v", n)
+	}
+
+	if n := util.HowManyContainersRunning(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 1 service containers existing (after stop), got %v", n)
+	}
+
+	tests.RemoveAllContainers()
+}
+
+func TestStopDataContainer(t *testing.T) {
+	const (
+		name   = "ipfs"
+		number = 99
+	)
+
+	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 containers, got %v", n)
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	srv.Operations.SrvContainerName = srv.Operations.DataContainerName
+	if err := DockerStop(srv.Service, srv.Operations, 5); err == nil {
+		t.Fatalf("expected stop to fail, got %v", err)
+	}
+
+	tests.RemoveAllContainers()
+}

--- a/services/manage.go
+++ b/services/manage.go
@@ -174,7 +174,7 @@ func LogsService(do *definitions.Do) error {
 	if err != nil {
 		return err
 	}
-	return LogsServiceByService(service.Service, service.Operations, do.Follow, do.Tail)
+	return perform.DockerLogs(service.Service, service.Operations, do.Follow, do.Tail)
 }
 
 func ExportService(do *definitions.Do) error {

--- a/services/operate.go
+++ b/services/operate.go
@@ -116,7 +116,7 @@ func ExecService(do *definitions.Do) error {
 		service.Service.Links = do.Links
 	}
 
-	return StartServiceInteractiveByService(service.Service, service.Operations)
+	return perform.DockerExecService(service.Service, service.Operations)
 }
 
 // TODO: test this recursion and service deps generally
@@ -145,7 +145,7 @@ func StartGroup(group []*definitions.ServiceDefinition) error {
 	logger.Debugf("Starting services group =>\t%d Services\n", len(group))
 	for _, srv := range group {
 		logger.Debugf("Telling Docker to start srv =>\t%s\n", srv.Name)
-		if err := perform.DockerRun(srv.Service, srv.Operations); err != nil {
+		if err := perform.DockerRunService(srv.Service, srv.Operations); err != nil {
 			return fmt.Errorf("StartGroup. Err starting srv =>\t%s:%v\n", srv.Name, err)
 		}
 	}
@@ -198,22 +198,4 @@ func ConnectChainToService(chainFlag, chainNameAndOpts string, srv *definitions.
 
 	util.Merge(s.Operations, srv.Operations)
 	return s, nil
-}
-
-// ------------------------------------------------------------------------------------------
-// Wrappers we want to be able to call from Chains package (mostly)
-func StartServiceInteractiveByService(srvMain *definitions.Service, ops *definitions.Operation) error {
-	return perform.DockerRunInteractive(srvMain, ops)
-}
-
-func StartServiceByService(srvMain *definitions.Service, ops *definitions.Operation) error {
-	return perform.DockerRun(srvMain, ops)
-}
-
-func LogsServiceByService(srv *definitions.Service, ops *definitions.Operation, follow bool, tail string) error {
-	return perform.DockerLogs(srv, ops, follow, tail)
-}
-
-func KillServiceByService(srvMain *definitions.Service, ops *definitions.Operation, timeout uint) error {
-	return perform.DockerStop(srvMain, ops, timeout)
 }

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -10,7 +10,7 @@ import (
 	def "github.com/eris-ltd/eris-cli/definitions"
 	ini "github.com/eris-ltd/eris-cli/initialize"
 	"github.com/eris-ltd/eris-cli/loaders"
-	tests "github.com/eris-ltd/eris-cli/testings"
+	tests "github.com/eris-ltd/eris-cli/testutils"
 	"github.com/eris-ltd/eris-cli/util"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"

--- a/testutils/testing_utils.go
+++ b/testutils/testing_utils.go
@@ -6,17 +6,15 @@ import (
 	"path"
 	"strings"
 
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient"
 	"github.com/eris-ltd/eris-cli/config"
 	def "github.com/eris-ltd/eris-cli/definitions"
 	ini "github.com/eris-ltd/eris-cli/initialize"
 	"github.com/eris-ltd/eris-cli/util"
-
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
 )
 
-//var DEAD bool // XXX: don't double panic (TODO: Flushing twice blocks)
 var erisDir = path.Join(os.TempDir(), "eris")
-
 var logger = log.AddLogger("tests")
 
 //hold things...?
@@ -141,6 +139,26 @@ func TestExistAndRun(name, typ string, contNum int, toExist, toRun bool) bool {
 	return false
 }
 
+// Remove a container of some name, type, and number.
+func RemoveContainer(name string, t string, n int) error {
+	opts := docker.RemoveContainerOptions{
+		ID:            util.ContainersName(t, name, n),
+		RemoveVolumes: true,
+		Force:         true,
+	}
+
+	if err := util.DockerClient.RemoveContainer(opts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Remove everything Eris.
+func RemoveAllContainers() error {
+	return util.Clean(false, false, false, false)
+}
+
 // each pacakge will need its own custom stuff if need be
 // do it through a custom pre-process ifExit in each package that
 // calls tests.IfExit()
@@ -164,7 +182,6 @@ func IfExit(err error) {
 
 //------- helpers --------
 func checkIPFSnotRunning() {
-
 	//os.Setenv("ERIS_IPFS_HOST", "http://0.0.0.0") //conflicts with docker-machine
 	do := def.NowDo()
 	do.Known = false

--- a/testutils/testing_utils.go
+++ b/testutils/testing_utils.go
@@ -37,12 +37,8 @@ func TestsInit(testType string) error {
 	// run correctly.
 	config.ChangeErisDir(erisDir)
 
-	// init dockerClient
-	if testType == "chain" {
-		util.DockerConnect(false, "eris-test-nyc2-1.8.1") //hmm -> for local tests
-	} else {
-		util.DockerConnect(false, "eris")
-	}
+	// init dockerClient (for chains use "eris-test-nyc2-1.8.1"?)
+	util.DockerConnect(false, "eris")
 
 	// this dumps the ipfs service def into the temp dir which
 	// has been set as the erisRoot

--- a/util/migrate_dirs_test.go
+++ b/util/migrate_dirs_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 
 	logLevel = 0
 	// logLevel = 1
-	logLevel = 3
+	// logLevel = 3
 
 	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
 
@@ -131,8 +131,6 @@ func testsInit() error {
 	}
 	config.ChangeErisDir(erisDir)
 
-	// init dockerClient
-	DockerConnect(false, "eris")
 	return nil
 }
 


### PR DESCRIPTION
* Some refactorings and name changes of `perform` package's `Run` functions:

  * `DockerRunData` (was:   `DockerRunVolumesFromContainer`)
  * `DockerExecData` (was: `DockerRunVolumesFromContainer`, `ops.Interactive=true`)
  * `DockerRunService` (was: `DockerRun`)
  * `DockerExecService` (was:  `DockerRunInteractive`)
  * `DockerCreateData` (was: `DockerCreateDataContainer`)
  * `DataContainerExists` (was: `ContainerDataContainerExists`)

  The terminal related calls are moved to `startInteractiveContainer()` and now used by all `Exec` functions.
  
  (Tried merging the `DockerRunService` and `DockerExecService` functions into one: there are still a few differences between them (5) which lead to a number of `if Exec { }` statements, which look a bit ugly. Will try to clean them up a bit further.)
  
* Partial test coverage of `perform` package.

* Test utilities package named `testutils` and added a couple of helper functions to it.

Related to issue #257.