### PR TITLE
Chain-to-service linking fix

### DIFF
--- a/services/operate.go
+++ b/services/operate.go
@@ -196,6 +196,5 @@ func ConnectChainToService(chainFlag, chainNameAndOpts string, srv *definitions.
 	// XXX: we may have name collision here if we're not careful.
 	loaders.ConnectToAChain(srv.Service, srv.Operations, chainName, internalName, link, mount)
 
-	util.Merge(s.Operations, srv.Operations)
 	return s, nil
 }


### PR DESCRIPTION
Fixes issue #350 

```
$ eris chains new ab
$ eris services start mindy --chain=ab
```

The Mindy test (https://github.com/eris-ltd/mindy/blob/master/test/porcelain/build.sh) passed.