### PR TITLE
Integration tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    GOPATH: /home/ubuntu/.go_workspace
+    GOPATH: $HOME/.go_workspace
     REPO: ${GOPATH}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
     INTEGRATION_TESTS_PATH: $HOME/integration-tests
     INTEGRATION_TESTS_BRANCH: develop

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     GOPATH: $HOME/.go_workspace
     REPO: ${GOPATH}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
     INTEGRATION_TESTS_PATH: $HOME/integration-tests
-    INTEGRATION_TESTS_BRANCH: develop
+    INTEGRATION_TESTS_BRANCH: integration_tests
     BACKEND_TESTS_BRANCH: staging
   post:
     - git config --global user.email "billings@erisindustries.com"

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,8 @@ machine:
     GOPATH: /home/ubuntu/.go_workspace
     REPO: ${GOPATH}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
     INTEGRATION_TESTS_PATH: $HOME/integration-tests
-    INTEGRATION_TESTS_BRANCH: staging
+    INTEGRATION_TESTS_BRANCH: develop
+    BACKEND_TESTS_BRANCH: staging
   post:
     - git config --global user.email "billings@erisindustries.com"
     - git config --global user.name "Billings the Bot"
@@ -25,7 +26,6 @@ test:
         timeout: 900
     - git clone https://github.com/eris-ltd/integration-tests $INTEGRATION_TESTS_PATH
     - bash $INTEGRATION_TESTS_PATH/test.sh
-
 
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
     INTEGRATION_TESTS_PATH: $HOME/integration-tests
     INTEGRATION_TESTS_BRANCH: integration_tests
     BACKEND_TESTS_BRANCH: staging
+    TEST_MINT_CLIENT_BRANCH: staging
   post:
     - git config --global user.email "billings@erisindustries.com"
     - git config --global user.name "Billings the Bot"
@@ -22,10 +23,8 @@ dependencies:
 test:
   override:
     - "cd ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/cmd/eris && go install"
-    - "tests/test.sh | tee $CIRCLE_ARTIFACTS/output.log ; test ${PIPESTATUS[0]} -eq 0":
-        timeout: 900
     - git clone https://github.com/eris-ltd/integration-tests $INTEGRATION_TESTS_PATH
-    - bash $INTEGRATION_TESTS_PATH/test.sh $(cat $HOME/last_machine_used)
+    - bash $INTEGRATION_TESTS_PATH/test.sh eris-test-dca1-1.9.1
 
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ test:
     - "tests/test.sh | tee $CIRCLE_ARTIFACTS/output.log ; test ${PIPESTATUS[0]} -eq 0":
         timeout: 900
     - git clone https://github.com/eris-ltd/integration-tests $INTEGRATION_TESTS_PATH
-    - bash $INTEGRATION_TESTS_PATH/test.sh
+    - bash $INTEGRATION_TESTS_PATH/test.sh $(cat $HOME/last_machine_used)
 
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -3,9 +3,10 @@ machine:
     GOPATH: $HOME/.go_workspace
     REPO: ${GOPATH}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
     INTEGRATION_TESTS_PATH: $HOME/integration-tests
-    INTEGRATION_TESTS_BRANCH: integration_tests
+    INTEGRATION_TESTS_BRANCH: staging
     BACKEND_TESTS_BRANCH: staging
     TEST_MINT_CLIENT_BRANCH: staging
+    TEST_MINDY_BRANCH: staging
   post:
     - git config --global user.email "billings@erisindustries.com"
     - git config --global user.name "Billings the Bot"
@@ -23,8 +24,9 @@ dependencies:
 test:
   override:
     - "cd ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/cmd/eris && go install"
+    - tests/test.sh | tee $CIRCLE_ARTIFACTS/output.log ; test ${PIPESTATUS[0]} -eq 0
     - git clone https://github.com/eris-ltd/integration-tests $INTEGRATION_TESTS_PATH
-    - bash $INTEGRATION_TESTS_PATH/test.sh eris-test-dca1-1.9.1
+    - bash $INTEGRATION_TESTS_PATH/test.sh
 
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,9 @@
 machine:
+  environment:
+    GOPATH: /home/ubuntu/.go_workspace
+    REPO: ${GOPATH}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
+    INTEGRATION_TESTS_PATH: $HOME/integration-tests
+    INTEGRATION_TESTS_BRANCH: staging
   post:
     - git config --global user.email "billings@erisindustries.com"
     - git config --global user.name "Billings the Bot"
@@ -18,6 +23,9 @@ test:
     - "cd ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/cmd/eris && go install"
     - "tests/test.sh | tee $CIRCLE_ARTIFACTS/output.log ; test ${PIPESTATUS[0]} -eq 0":
         timeout: 900
+    - git clone https://github.com/eris-ltd/integration-tests $INTEGRATION_TESTS_PATH
+    - bash $INTEGRATION_TESTS_PATH/test.sh
+
 
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,8 @@ dependencies:
 test:
   override:
     - "cd ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/cmd/eris && go install"
-    - tests/test.sh | tee $CIRCLE_ARTIFACTS/output.log ; test ${PIPESTATUS[0]} -eq 0
+    - "tests/test.sh | tee $CIRCLE_ARTIFACTS/output.log ; test ${PIPESTATUS[0]} -eq 0":
+        timeout: 900
     - git clone https://github.com/eris-ltd/integration-tests $INTEGRATION_TESTS_PATH
     - bash $INTEGRATION_TESTS_PATH/test.sh
 
@@ -32,6 +33,7 @@ deployment:
   master:
     branch: master
     commands:
+      - docker rmi quay.io/eris/eris:master
       - docker push quay.io/eris/eris
       - docs/build.sh master
   develop:

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -21,16 +21,11 @@ var srv *def.ServiceDefinition
 var servName string = "ipfs"
 var hash string
 
-var DEAD bool // XXX: don't double panic (TODO: Flushing twice blocks)
-
 //[zr] is basically a weird version of ifExit ..?
 func fatal(t *testing.T, err error) {
-	if !DEAD {
-		log.Flush()
-		tests.TestsTearDown()
-		DEAD = true
-		panic(err)
-	}
+	log.Flush()
+	tests.TestsTearDown()
+	panic(err)
 }
 
 func TestMain(m *testing.M) {

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -21,13 +21,6 @@ var srv *def.ServiceDefinition
 var servName string = "ipfs"
 var hash string
 
-//[zr] is basically a weird version of ifExit ..?
-func fatal(t *testing.T, err error) {
-	log.Flush()
-	tests.TestsTearDown()
-	panic(err)
-}
-
 func TestMain(m *testing.M) {
 	var logLevel log.LogLevel
 
@@ -72,7 +65,7 @@ func TestLoadServiceDefinition(t *testing.T) {
 	srv, e = loaders.LoadServiceDefinition(servName, true, 1)
 	if e != nil {
 		logger.Errorln(e)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 
 	if srv.Name != servName {
@@ -81,17 +74,17 @@ func TestLoadServiceDefinition(t *testing.T) {
 
 	if srv.Service.Name != servName {
 		logger.Errorf("FAILURE: improper service name on LOAD. expected: %s\tgot: %s\n", servName, srv.Service.Name)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 
 	if !srv.Service.AutoData {
 		logger.Errorf("FAILURE: data_container not properly read on LOAD.\n")
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 
 	if srv.Operations.DataContainerName == "" {
 		logger.Errorf("FAILURE: data_container_name not set.\n")
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 }
 
@@ -112,7 +105,7 @@ func TestInspectService(t *testing.T) {
 	e := InspectService(do)
 	if e != nil {
 		logger.Infof("Error inspecting service =>\t%v\n", e)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 
 	do = def.NowDo()
@@ -123,7 +116,7 @@ func TestInspectService(t *testing.T) {
 	e = InspectService(do)
 	if e != nil {
 		logger.Infof("Error inspecting service =>\t%v\n", e)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 }
 
@@ -138,7 +131,7 @@ func TestLogsService(t *testing.T) {
 	e := LogsService(do)
 	if e != nil {
 		logger.Errorln(e)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 }
 
@@ -179,7 +172,7 @@ func TestUpdateService(t *testing.T) {
 	e := UpdateService(do)
 	if e != nil {
 		logger.Errorln(e)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 
 	testExistAndRun(t, servName, 1, true, true)
@@ -196,7 +189,7 @@ func TestKillRmService(t *testing.T) {
 	logger.Debugf("Stopping serv (via tests) =>\t%s\n", servName)
 	if e := KillService(do); e != nil {
 		logger.Errorln(e)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 
 	testExistAndRun(t, servName, 1, true, false)
@@ -215,7 +208,7 @@ func TestKillRmService(t *testing.T) {
 	logger.Debugf("Removing serv (via tests) =>\t%s\n", servName)
 	if e := RmService(do); e != nil {
 		logger.Errorln(e)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 
 	testExistAndRun(t, servName, 1, false, false)
@@ -246,7 +239,7 @@ func TestImportService(t *testing.T) {
 	if !passed {
 		// final time will throw
 		if err := ImportService(do); err != nil {
-			fatal(t, err)
+			tests.IfExit(err)
 		}
 	}
 
@@ -289,7 +282,7 @@ func TestNewService(t *testing.T) {
 	e := NewService(do)
 	if e != nil {
 		logger.Errorln(e)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 
 	do = def.NowDo()
@@ -300,7 +293,7 @@ func TestNewService(t *testing.T) {
 	e = StartService(do)
 	if e != nil {
 		logger.Errorln(e)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 
 	testExistAndRun(t, servName, 1, true, true)
@@ -321,8 +314,7 @@ func TestRenameService(t *testing.T) {
 	//do.Operations.ContainerNumber = 1
 	logger.Debugf("Renaming serv (via tests) =>\t%s:%v\n", do.Name, do.NewName)
 	if e := RenameService(do); e != nil {
-		logger.Errorf("Error (tests fail) =>\t\t%v\n", e)
-		fatal(t, nil)
+		tests.IfExit(fmt.Errorf("Error (tests fail) =>\t\t%v\n", e))
 	}
 
 	testExistAndRun(t, "syek", 1, true, true)
@@ -338,7 +330,7 @@ func TestRenameService(t *testing.T) {
 	logger.Debugf("Renaming serv (via tests) =>\t%s:%v\n", do.Name, do.NewName)
 	if e := RenameService(do); e != nil {
 		logger.Errorf("Error (tests fail) =>\t\t%v\n", e)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 
 	testExistAndRun(t, "keys", 1, true, true)
@@ -354,11 +346,11 @@ func TestCatService(t *testing.T) {
 	do := def.NowDo()
 	do.Name = "do_not_use"
 	if err := CatService(do); err != nil {
-		fatal(t, err)
+		tests.IfExit(err)
 	}
 
 	if do.Result != ini.DefaultIpfs2() {
-		fatal(t, fmt.Errorf("Cat Service on keys does not match DefaultKeys. Got %s \n Expected %s", do.Result, ini.DefaultIpfs2()))
+		tests.IfExit(fmt.Errorf("Cat Service on keys does not match DefaultKeys. Got %s \n Expected %s", do.Result, ini.DefaultIpfs2()))
 	}
 }
 
@@ -370,7 +362,7 @@ func TestStartKillServiceWithDependencies(t *testing.T) {
 	logger.Debugf("Starting service with deps =>\t%s:%s\n", servName, "keys")
 	if e := StartService(do); e != nil {
 		logger.Infof("Error starting service =>\t%v\n", e)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 
 	defer func() {
@@ -404,7 +396,7 @@ func testStartService(t *testing.T, serviceName string, publishAll bool) {
 	e := StartService(do)
 	if e != nil {
 		logger.Infof("Error starting service =>\t%v\n", e)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 
 	testExistAndRun(t, serviceName, 1, true, true)
@@ -424,7 +416,7 @@ func testKillService(t *testing.T, serviceName string, wipe bool) {
 	e := KillService(do)
 	if e != nil {
 		logger.Errorln(e)
-		fatal(t, e)
+		tests.IfExit(e)
 	}
 	testExistAndRun(t, serviceName, 1, !wipe, false)
 	testNumbersExistAndRun(t, serviceName, 0, 0)
@@ -432,7 +424,7 @@ func testKillService(t *testing.T, serviceName string, wipe bool) {
 
 func testExistAndRun(t *testing.T, servName string, containerNumber int, toExist, toRun bool) {
 	if tests.TestExistAndRun(servName, "services", containerNumber, toExist, toRun) {
-		fatal(t, nil)
+		tests.IfExit(nil)
 	}
 }
 
@@ -445,13 +437,11 @@ func testNumbersExistAndRun(t *testing.T, servName string, containerExist, conta
 	run := util.HowManyContainersRunning(servName, "service")
 
 	if exist != containerExist {
-		logger.Printf("Wrong number of containers existing for service (%s). Expected (%d). Got (%d).\n", servName, containerExist, exist)
-		fatal(t, nil)
+		tests.IfExit(fmt.Errorf("Wrong number of containers existing for service (%s). Expected (%d). Got (%d).\n", servName, containerExist, exist))
 	}
 
 	if run != containerRun {
-		logger.Printf("Wrong number of containers running for service (%s). Expected (%d). Got (%d).\n", servName, containerRun, run)
-		fatal(t, nil)
+		tests.IfExit(fmt.Errorf("Wrong number of containers running for service (%s). Expected (%d). Got (%d).\n", servName, containerRun, run))
 	}
 
 	logger.Infoln("All good.\n")

--- a/tests/build_tool.sh
+++ b/tests/build_tool.sh
@@ -22,6 +22,7 @@ then
   docker build -t $testimage:latest .
   docker tag -f $testimage:latest $testimage:$release_maj
   docker tag -f $testimage:latest $testimage:$release_min
+  docker tag -f $testimage:latest $testimage:master
 else
   docker build -t $testimage:docker18 -f tests/Dockerfile-1.8 .
   docker build -t $testimage:$branch .

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -23,7 +23,6 @@ branch=${branch/-/_}
 #   installs by default on Linux"
 declare -a docker_versions18=( "1.8.0" "1.8.1" "1.8.2" "1.8.3" )
 declare -a docker_versions19=( "1.9.0" "1.9.1" )
-declare -a docker_latest_versions=("1.8.3" "1.9.1") # versions we run against no matter what
 declare -a machine_results=()
 
 # Primary swarm of backend machines -- uncomment out second line to use the secondary swarm
@@ -211,10 +210,28 @@ else
 
 	  done
   else
-	  for ver in "${docker_latest_versions[@]}"
-	  do
-		  runTests $branch
-	  done
+	  # run the tests for the latest release of 1.8 and 1.9
+
+	  # latest 1.8
+	  ver=${docker_versions18[-1]}
+	  runTests "docker18"
+
+	  # latest 1.9
+	  ver=${docker_versions19[-1]}
+
+	    # Correct for docker build stuff
+	    if [[ "$branch" == "master" ]]
+	    then
+	      branch="latest"
+	    fi
+
+	    runTests $branch
+
+	    # Correct for docker build stuff
+	    if [[ "$branch" == "latest" ]]
+	    then
+	      branch="master"
+	    fi
   fi
 
 fi

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -218,7 +218,7 @@ else
 
 	  for ver in "${docker_versions19[@]}"
 	  do
-      runTests "latest"
+      runTests $branch
 	  done
   else
 	  # run the tests for only one of the docker versions at random
@@ -226,7 +226,7 @@ else
     runTests "docker18"
 
 	  ver=${docker_versions19[RANDOM%${#docker_versions19[@]}]}
-    runTests "latest"
+    runTests $branch
   fi
 fi
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -234,6 +234,10 @@ else
 	    fi
   fi
 
+  # so the integrations tester (which runs next) can attempt to reuse the machine
+  # ie. see the circle.yml
+  echo $machine > $HOME/last_machine_used
+
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,5 +1,30 @@
 #!/usr/bin/env bash
 
+# ---------------------------------------------------------------------------
+# PURPOSE
+
+# This script will test the eris. If it is given the "local" argument, then
+# it will run against the local docker backend. If it is not given the local
+# argument then it will run against a series of docker backends defined in
+# arrays at the top of the script.
+#
+# What this script will do is first it will define what should be run, then
+# it will make sure that it has access to the eris' test machine definition
+# image files necessary to connect into the backends. Then it will run the
+# test_tool and test_stack scripts against a set of backends. That set will
+# either be a random element of a given array for a major docker version, or
+# it will run against the entire suite of backends.
+
+# ---------------------------------------------------------------------------
+# REQUIREMENTS
+
+# Docker installed locally
+
+# ---------------------------------------------------------------------------
+# USAGE
+
+# test.sh [local]
+
 # ----------------------------------------------------------------------------
 # Set definitions and defaults
 
@@ -15,30 +40,26 @@ else
 fi
 branch=${CIRCLE_BRANCH:=master}
 branch=${branch/-/_}
+if [[ "$branch" == "" ]]
+then
+  # get from git
+  branch=`git rev-parse --abbrev-ref HEAD`
+fi
 
-# Docker Backend Versions Eris Tests Against -- Final element in this array is the definitive one.
-#   Circle passes or fails based on it. To speed testing uncomment out the second line to override
-#   the array and just test against the authoritative one. If testing against a specific backend
-#   then change the authoritative one to use that. We define "authoritative" to mean "what docker
-#   installs by default on Linux"
+# Docker Backend Versions Eris Tests Against -- Final element in the final array is the
+#   definitive one. Circle passes or fails based on it. We define "authoritative" to mean
+#   "what docker installs by default on Linux"
 declare -a docker_versions18=( "1.8.0" "1.8.1" "1.8.2" "1.8.3" )
 declare -a docker_versions19=( "1.9.0" "1.9.1" )
 declare -a machine_results=()
 
-# Primary swarm of backend machines -- uncomment out second line to use the secondary swarm
-#   if/when the primary swarm is either too slow or non-responsive. Swarms here are really
-#   data centers. These boxes are on Digital Ocean.
+# Primary and secondary swarm of backend machines. Swarms here are really data centers.
+#   These boxes are on AWS.
 swarm_prim="dca1"
 swarm_back="fra1"
 swarm=$swarm_prim
 
-if [[ $1 == "sec_swarm" ]]
-then
-  swarm=$swarm_back
-fi
-
 # Define now the tool tests within the Docker container will be booted from docker run
-host_docker="docker18"
 entrypoint="/home/eris/test_tool.sh"
 testimage=quay.io/eris/eris
 testuser=eris
@@ -49,10 +70,16 @@ machine_definitions=matDef
 # ----------------------------------------------------------------------------
 # Check swarm and machine stuff
 
+# Sets the name of the machine using eris box conventions
 set_machine() {
   echo "eris-test-$swarm-$ver"
 }
 
+# Checks whether the primary swarm for the current version of docker is running
+#   which indicates it is being used by a different test run. If the primary
+#   swarm for the current machine is running, then it will switch to using the
+#   secondary swarm for the same version of the version. If that box is also
+#   being used by another test run then that version will not be used.
 check_swarm() {
   machine=$(set_machine)
 
@@ -78,10 +105,13 @@ check_swarm() {
   fi
 }
 
+# Changes back to the primary swarm
 reset_swarm() {
   swarm=$swarm_prim
 }
 
+# Adds the results for a particular box to the machine_results array
+#   which is displayed at the end of the tests.
 log_results() {
   if [ "$test_exit" -eq 0 ]
   then
@@ -106,9 +136,9 @@ runTests(){
     then
       if [[ $(uname -s) == "Linux" ]]
       then
-        docker run --rm --volumes-from $machine_definitions --entrypoint $entrypoint -e MACHINE_NAME=$machine -e SWARM=$swarm -e APIVERSION=$ver -v $localsocket:$localsocket --user $testuser $testimage:$host_docker
+        docker run --rm --volumes-from $machine_definitions --entrypoint $entrypoint -e MACHINE_NAME=$machine -e SWARM=$swarm -e APIVERSION=$ver -v $localsocket:$localsocket --user $testuser $testimage:$1
       else
-        docker run --rm --volumes-from $machine_definitions --entrypoint $entrypoint -e MACHINE_NAME=$machine -e SWARM=$swarm -e APIVERSION=$ver -p $remotesocket --user $testuser $testimage:$host_docker
+        docker run --rm --volumes-from $machine_definitions --entrypoint $entrypoint -e MACHINE_NAME=$machine -e SWARM=$swarm -e APIVERSION=$ver -p $remotesocket --user $testuser $testimage:$1
       fi
     else
       echo "Don't run local in Circle environment."
@@ -178,14 +208,9 @@ if [[ $1 == "local" ]]
 then
   runTests "local"
 else
-  if [[ $1 == "all" ]]
+  # we only run against all backends on a few branches
+  if [[ "$branch" == "$BACKEND_TESTS_BRANCH" || "$branch" == "master" ]]
   then
-    runTests "local"
-  fi
-
-  # we only run against all backends on a special branch
-  BRANCH=`git rev-parse --abbrev-ref HEAD`
-  if [[ "$BRANCH" == "$BACKEND_TESTS_BRANCH" || "$BRANCH" == "master" ]]; then
 	  for ver in "${docker_versions18[@]}"
 	  do
 	    runTests "docker18"
@@ -193,51 +218,16 @@ else
 
 	  for ver in "${docker_versions19[@]}"
 	  do
-
-	    # Correct for docker build stuff
-	    if [[ "$branch" == "master" ]]
-	    then
-	      branch="latest"
-	    fi
-
-	    runTests $branch
-
-	    # Correct for docker build stuff
-	    if [[ "$branch" == "latest" ]]
-	    then
-	      branch="master"
-	    fi
-
+      runTests "latest"
 	  done
   else
-	  # run the tests for the latest release of 1.8 and 1.9
+	  # run the tests for only one of the docker versions at random
+    ver=${docker_versions18[RANDOM%${#docker_versions18[@]}]}
+    runTests "docker18"
 
-	  # latest 1.8
-	  ver=${docker_versions18[-1]}
-	  runTests "docker18"
-
-	  # latest 1.9
-	  ver=${docker_versions19[-1]}
-
-	    # Correct for docker build stuff
-	    if [[ "$branch" == "master" ]]
-	    then
-	      branch="latest"
-	    fi
-
-	    runTests $branch
-
-	    # Correct for docker build stuff
-	    if [[ "$branch" == "latest" ]]
-	    then
-	      branch="master"
-	    fi
+	  ver=${docker_versions19[RANDOM%${#docker_versions19[@]}]}
+    runTests "latest"
   fi
-
-  # so the integrations tester (which runs next) can attempt to reuse the machine
-  # ie. see the circle.yml
-  echo $machine > $HOME/last_machine_used
-
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -23,6 +23,7 @@ branch=${branch/-/_}
 #   installs by default on Linux"
 declare -a docker_versions18=( "1.8.0" "1.8.1" "1.8.2" "1.8.3" )
 declare -a docker_versions19=( "1.9.0" "1.9.1" )
+declare -a docker_latest_versions=("1.8.3" "1.9.1") # versions we run against no matter what
 declare -a machine_results=()
 
 # Primary swarm of backend machines -- uncomment out second line to use the secondary swarm
@@ -183,29 +184,38 @@ else
     runTests "local"
   fi
 
-  for ver in "${docker_versions18[@]}"
-  do
-    runTests "docker18"
-  done
+  # we only run against all backends on a special branch
+  BRANCH=`git rev-parse --abbrev-ref HEAD`
+  if [[ "$BRANCH" == "$BACKEND_TESTS_BRANCH" || "$BRANCH" == "master" ]]; then
+	  for ver in "${docker_versions18[@]}"
+	  do
+	    runTests "docker18"
+	  done
 
-  for ver in "${docker_versions19[@]}"
-  do
+	  for ver in "${docker_versions19[@]}"
+	  do
 
-    # Correct for docker build stuff
-    if [[ "$branch" == "master" ]]
-    then
-      branch="latest"
-    fi
+	    # Correct for docker build stuff
+	    if [[ "$branch" == "master" ]]
+	    then
+	      branch="latest"
+	    fi
 
-    runTests $branch
+	    runTests $branch
 
-    # Correct for docker build stuff
-    if [[ "$branch" == "latest" ]]
-    then
-      branch="master"
-    fi
+	    # Correct for docker build stuff
+	    if [[ "$branch" == "latest" ]]
+	    then
+	      branch="master"
+	    fi
 
-  done
+	  done
+  else
+	  for ver in "${docker_latest_versions[@]}"
+	  do
+		  runTests $branch
+	  done
+  fi
 
 fi
 

--- a/tests/test_stack.sh
+++ b/tests/test_stack.sh
@@ -1,9 +1,29 @@
 #!/usr/bin/env bash
 
+# ---------------------------------------------------------------------------
+# PURPOSE
+
+# This script will test the eris stack and the connection between eris cli
+# and eris pm. **Generally, it should not be used in isolation.**
+
+# ---------------------------------------------------------------------------
+# REQUIREMENTS
+
+# Docker installed locally
+# Docker-Machine installed locally (if using remote boxes)
+# eris' test_machines image (if testing against eris' test boxes)
+# Eris installed locally
+
+# ---------------------------------------------------------------------------
+# USAGE
+
+# test_stack.sh
+
 # ----------------------------------------------------------------------------
 # Set definitions and defaults
 
 # Where are the Things
+start=`pwd`
 base=github.com/eris-ltd/eris-cli
 if [ "$CIRCLE_BRANCH" ]
 then
@@ -13,27 +33,30 @@ else
   repo=$GOPATH/src/$base
   circle=false
 fi
-branch=${CIRCLE_BRANCH:=master}
-branch=${branch/-/_}
+
+epm_dir=$repo/../eris-pm
 epm_test_dir=$repo/../eris-pm/tests
-epm_branch="master"
+epm_branch=${EPM_BRANCH:=master}
 
-start=`pwd`
-
-cd $repo
+# ----------------------------------------------------------------------------
+# Get EPM
 
 if [ -d "$epm_test_dir" ]; then
   cd $epm_test_dir
 else
-  cd ..
-  git clone https://github.com/eris-ltd/eris-pm.git 1>/dev/null
-  cd eris-pm
+  git clone https://github.com/eris-ltd/eris-pm.git $epm_dir 1>/dev/null
+  cd $epm_test_dir 1>/dev/null
   git checkout origin/$epm_branch &>/dev/null
-  cd $epm_test_dir
 fi
+
+# ----------------------------------------------------------------------------
+# Run EPM tests
 
 ./test.sh
 test_exit=$?
+
+# ----------------------------------------------------------------------------
+# Cleanup
 
 cd $start
 exit $test_exit


### PR DESCRIPTION
some modifications to Ethan's original work.

will run the backend tests against a random backend among each of the major docker versions we test against rather than only the latest in order to add some spread to the boxes we're using.

will run the cli tests first.

then on integration branches (staging|master) will run the full backends as well as the full suite of integration tests. 

includes some test fixes to use tests.IfExit function for DRY-ness