### PR TITLE
Ports command fixes and small improvements

### DIFF
--- a/commands/chains.go
+++ b/commands/chains.go
@@ -178,21 +178,22 @@ var chainsPlop = &cobra.Command{
 }
 
 var chainsPorts = &cobra.Command{
-	Use:   "ports",
-	Short: "Print the port mappings.",
-	Long: `Print the port mappings.
+	Use:   "ports NAME [PORT]...",
+	Short: "Print port mappings.",
+	Long: `Print port mappings.
 
-eris chains ports is mostly a developer convenience function.
-It returns a machine readable port mapping of a port which is
-exposed inside the container to what that port is mapped to
-on the host.
+The [eris chains ports] command is mostly a developer 
+convenience function. It returns a machine readable 
+port mapping of a port which is exposed inside the 
+container to what that port is mapped to on the host.
 
 This is useful when stitching together chain networks which
 need to know how to connect into a specific chain (perhaps
 with or without a container number) container.`,
 	Example: `$ eris chains ports myChain 1337 -- will display what port on the host is mapped to the eris:db API port
 $ eris chains ports myChain 46656 -- will display what port on the host is mapped to the eris:db peer port
-$ eris chains ports myChain 46657 -- will display what port on the host is mapped to the eris:db rpc port`,
+$ eris chains ports myChain 46657 -- will display what port on the host is mapped to the eris:db rpc port
+$ eris chains ports myChain -- will display all mappings`,
 	Run: PortsChain,
 }
 
@@ -526,7 +527,7 @@ func PlopChain(cmd *cobra.Command, args []string) {
 }
 
 func PortsChain(cmd *cobra.Command, args []string) {
-	IfExit(ArgCheck(2, "ge", cmd, args))
+	IfExit(ArgCheck(1, "ge", cmd, args))
 	do.Name = args[0]
 	do.Operations.Args = args[1:]
 	IfExit(chns.PortsChain(do))

--- a/commands/services.go
+++ b/commands/services.go
@@ -105,8 +105,8 @@ var servicesStart = &cobra.Command{
 	Long: `Start a service according to the service definition file which
 eris stores in the ~/.eris/services directory.
 
-The [eris services start NAME] command by default will put the 
-service into the background so its logs will not be viewable 
+The [eris services start NAME] command by default will put the
+service into the background so its logs will not be viewable
 from the command line.
 
 To stop the service use:      [eris services stop NAME].
@@ -129,10 +129,14 @@ $ eris services inspect ipfs host_config.binds -- will display only that value`,
 }
 
 var servicesPorts = &cobra.Command{
-	Use:   "ports PORT",
+	Use:   "ports NAME [PORT]...",
 	Short: "Print port mappings",
-	Long:  "Print port mappings",
-	Run:   PortsService,
+	Long: `Print port mappings.
+
+The [eris services ports] command displays published service ports.`,
+	Example: `$ eris services ports ipfs -- will display all IPFS ports
+$ eris services ports ipfs 4001 5001 -- will display specific IPFS ports`,
+	Run: PortsService,
 }
 
 var servicesExport = &cobra.Command{
@@ -334,7 +338,7 @@ func InspectService(cmd *cobra.Command, args []string) {
 }
 
 func PortsService(cmd *cobra.Command, args []string) {
-	IfExit(ArgCheck(2, "ge", cmd, args))
+	IfExit(ArgCheck(1, "ge", cmd, args))
 	do.Name = args[0]
 	do.Operations.Args = args[1:]
 	IfExit(srv.PortsService(do))

--- a/util/container_stats.go
+++ b/util/container_stats.go
@@ -119,6 +119,11 @@ func PrintPortMappings(id string, ports []string) error {
 
 	exposedPorts := cont.NetworkSettings.Ports
 
+	var minimalDisplay bool
+	if len(ports) == 1 {
+		minimalDisplay = true
+	}
+
 	// Display everything if no port's requested.
 	if len(ports) == 0 {
 		for exposed := range exposedPorts {
@@ -137,9 +142,22 @@ func PrintPortMappings(id string, ports []string) error {
 		}
 	}
 
+	// If only one port is requested, but there are more than one published port,
+	// don't use the minimal format.
+	if minimalDisplay && len(normalizedPorts) > 1 {
+		minimalDisplay = false
+	}
+
 	for _, port := range normalizedPorts {
 		for _, binding := range exposedPorts[docker.Port(port)] {
-			logger.Printf("%s -> %s\n", port, fmt.Sprintf("%s:%s", binding.HostIP, binding.HostPort))
+			hostAndPortBinding := fmt.Sprintf("%s:%s", binding.HostIP, binding.HostPort)
+
+			// If only one port request, display just the binding.
+			if minimalDisplay {
+				logger.Printf("%s\n", hostAndPortBinding)
+			} else {
+				logger.Printf("%s -> %s\n", port, hostAndPortBinding)
+			}
 		}
 	}
 

--- a/util/container_stats.go
+++ b/util/container_stats.go
@@ -128,17 +128,16 @@ func PrintPortMappings(id string, ports []string) error {
 
 	// Replace plain port numbers without suffixes with both "/tcp" and "/udp" suffixes.
 	// (For example, replace ["53"] in a slice with ["53/tcp", "53/udp"].)
-	for i, port := range ports {
+	normalizedPorts := []string{}
+	for _, port := range ports {
 		if !strings.HasSuffix(port, "/tcp") && !strings.HasSuffix(port, "/udp") {
-			// Delete an element mid-slice.
-			ports = append(ports[:i], ports[i+1:]...)
-
-			ports = append(ports, port+"/tcp")
-			ports = append(ports, port+"/udp")
+			normalizedPorts = append(normalizedPorts, port+"/tcp", port+"/udp")
+		} else {
+			normalizedPorts = append(normalizedPorts, port)
 		}
 	}
 
-	for _, port := range ports {
+	for _, port := range normalizedPorts {
 		for _, binding := range exposedPorts[docker.Port(port)] {
 			logger.Printf("%s -> %s\n", port, fmt.Sprintf("%s:%s", binding.HostIP, binding.HostPort))
 		}

--- a/util/container_stats.go
+++ b/util/container_stats.go
@@ -142,12 +142,6 @@ func PrintPortMappings(id string, ports []string) error {
 		}
 	}
 
-	// If only one port is requested, but there are more than one published port,
-	// don't use the minimal format.
-	if minimalDisplay && len(normalizedPorts) > 1 {
-		minimalDisplay = false
-	}
-
 	for _, port := range normalizedPorts {
 		for _, binding := range exposedPorts[docker.Port(port)] {
 			hostAndPortBinding := fmt.Sprintf("%s:%s", binding.HostIP, binding.HostPort)


### PR DESCRIPTION
* The `services ports` command doesn't fail:
  ```
	$ eris services start ipfs
	$ eris services ports ipfs 4001
	0.0.0.0:4001

	$ eris services ports ipfs 4001 5001
	4001/tcp -> 0.0.0.0:4001
	5001/tcp -> 0.0.0.0:5001
  ```

* The `chains ports` and `services ports` command output is now similar to `docker port output`:

  ```
	$ eris chains new ab
	$ eris chains ports ab
	1337/tcp -> 0.0.0.0:1337
	46656/tcp -> 0.0.0.0:46656
	46657/tcp -> 0.0.0.0:46657
	
	$ docker port eris_chain_ab_1
	1337/tcp -> 0.0.0.0:1337
	46656/tcp -> 0.0.0.0:46656
	46657/tcp -> 0.0.0.0:46657

	$ eris services start -p tinydns
	$ eris services ports tinydns
	53/tcp -> 0.0.0.0:32775
	53/udp -> 0.0.0.0:32769
	
	$ eris services ports tinydns 53
	0.0.0.0:32775
	0.0.0.0:32769

	$ eris services ports tinydns 53/udp
	0.0.0.0:32769
	
	$ docker port eris_service_tinydns_1
	53/tcp -> 0.0.0.0:32775
	53/udp -> 0.0.0.0:32769
	
	$ docker port eris_service_tinydns_1 53/udp
	0.0.0.0:32769
	
	$ eris services start toadserver --chain ab
	$ eris services ports toadserver
	11113/tcp -> 0.0.0.0:11113
  ```

This closes #342.