### PR TITLE
Fix container searching functions

### DIFF
--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -865,7 +865,7 @@ func testKillChain(t *testing.T, chain string) {
 
 func testExistAndRun(t *testing.T, chainName string, toExist, toRun bool) {
 	if tests.TestExistAndRun(chainName, "chains", 1, toExist, toRun) {
-		tests.IfExit(fmt.Errorf("TestExistAndRun %q exist=%t run=%t check failed", chainName, toExist, toRun))
+		tests.IfExit(nil)
 	}
 }
 

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -126,6 +126,28 @@ func TestStartKillChain(t *testing.T) {
 	testKillChain(t, chainName)
 }
 
+func TestRestartChain(t *testing.T) {
+	testNewChain(chainName)
+	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 1 {
+		t.Fatalf("start, expected chain container running")
+	}
+
+	testKillChain(t, chainName)
+	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 0 {
+		t.Fatalf("start, expected chain container not running")
+	}
+	if n := util.HowManyContainersExisting(chainName, def.TypeChain); n != 1 {
+		t.Fatalf("start, expected chain container existing")
+	}
+
+	testStartChain(t, chainName)
+	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 1 {
+		t.Fatalf("start, expected chain container running")
+	}
+
+	testKillChain(t, chainName)
+}
+
 // TODO: this isn't actually testing much!
 func TestExecChain(t *testing.T) {
 	/*	if os.Getenv("TEST_IN_CIRCLE") == "true" {

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -128,23 +128,10 @@ func TestStartKillChain(t *testing.T) {
 
 func TestRestartChain(t *testing.T) {
 	testNewChain(chainName)
-	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 1 {
-		t.Fatalf("start, expected chain container running")
-	}
+	defer testKillChain(t, chainName)
 
 	testKillChain(t, chainName)
-	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 0 {
-		t.Fatalf("start, expected chain container not running")
-	}
-	if n := util.HowManyContainersExisting(chainName, def.TypeChain); n != 1 {
-		t.Fatalf("start, expected chain container existing")
-	}
-
 	testStartChain(t, chainName)
-	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 1 {
-		t.Fatalf("start, expected chain container running")
-	}
-
 	testKillChain(t, chainName)
 }
 
@@ -878,7 +865,7 @@ func testKillChain(t *testing.T, chain string) {
 
 func testExistAndRun(t *testing.T, chainName string, toExist, toRun bool) {
 	if tests.TestExistAndRun(chainName, "chains", 1, toExist, toRun) {
-		tests.IfExit(nil) //error thrown in func (logger.Errorln)
+		tests.IfExit(fmt.Errorf("TestExistAndRun %q exist=%t run=%t check failed", chainName, toExist, toRun))
 	}
 }
 


### PR DESCRIPTION
Make the `ContainerRunning()` and `ContainerExists()` functions discard the container links while searching for a container:

```
Parsing Containers =>    eris_chain_test_1:running
=> /eris_service_tinydns_1
=> /eris_chain_test_1/keys
```
The **/eris_chain_test_1/keys** in the above is not a container name. This case is not caught by the tests.

Fixes the issue #397.