### PR TITLE
Logrus logger

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -117,6 +117,10 @@
 		{
 			"ImportPath": "gopkg.in/yaml.v2",
 			"Rev": "5d6f7e02b7cdad63b06ab3877915532cd30073b4"
+		},
+		{
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Rev": "ad63b06ab3877915532cd30073b45d6f7e02b7cd"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/.travis.yml
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+go:
+  - 1.3
+  - 1.4
+  - tip
+install:
+  - go get -t ./...

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/CHANGELOG.md
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/CHANGELOG.md
@@ -1,0 +1,55 @@
+# 0.9.0 (Unreleased)
+
+* logrus/text_formatter: don't emit empty msg
+* logrus/hooks/airbrake: move out of main repository
+* logrus/hooks/sentry: move out of main repository
+* logrus/hooks/papertrail: move out of main repository
+* logrus/hooks/bugsnag: move out of main repository
+
+# 0.8.7
+
+* logrus/core: fix possible race (#216)
+* logrus/doc: small typo fixes and doc improvements
+
+
+# 0.8.6
+
+* hooks/raven: allow passing an initialized client
+
+# 0.8.5
+
+* logrus/core: revert #208
+
+# 0.8.4
+
+* formatter/text: fix data race (#218)
+
+# 0.8.3
+
+* logrus/core: fix entry log level (#208)
+* logrus/core: improve performance of text formatter by 40%
+* logrus/core: expose `LevelHooks` type
+* logrus/core: add support for DragonflyBSD and NetBSD
+* formatter/text: print structs more verbosely
+
+# 0.8.2
+
+* logrus: fix more Fatal family functions
+
+# 0.8.1
+
+* logrus: fix not exiting on `Fatalf` and `Fatalln`
+
+# 0.8.0
+
+* logrus: defaults to stderr instead of stdout
+* hooks/sentry: add special field for `*http.Request`
+* formatter/text: ignore Windows for colors
+
+# 0.7.3
+
+* formatter/\*: allow configuration of timestamp layout
+
+# 0.7.2
+
+* formatter/text: Add configuration option for time format (#158)

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/LICENSE
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Simon Eskildsen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/README.md
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/README.md
@@ -1,0 +1,365 @@
+# Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>&nbsp;[![Build Status](https://travis-ci.org/Sirupsen/logrus.svg?branch=master)](https://travis-ci.org/Sirupsen/logrus)&nbsp;[![godoc reference](https://godoc.org/github.com/Sirupsen/logrus?status.png)][godoc]
+
+Logrus is a structured logger for Go (golang), completely API compatible with
+the standard library logger. [Godoc][godoc]. **Please note the Logrus API is not
+yet stable (pre 1.0). Logrus itself is completely stable and has been used in
+many large deployments. The core API is unlikely to change much but please
+version control your Logrus to make sure you aren't fetching latest `master` on
+every build.**
+
+Nicely color-coded in development (when a TTY is attached, otherwise just
+plain text):
+
+![Colored](http://i.imgur.com/PY7qMwd.png)
+
+With `log.Formatter = new(logrus.JSONFormatter)`, for easy parsing by logstash
+or Splunk:
+
+```json
+{"animal":"walrus","level":"info","msg":"A group of walrus emerges from the
+ocean","size":10,"time":"2014-03-10 19:57:38.562264131 -0400 EDT"}
+
+{"level":"warning","msg":"The group's number increased tremendously!",
+"number":122,"omg":true,"time":"2014-03-10 19:57:38.562471297 -0400 EDT"}
+
+{"animal":"walrus","level":"info","msg":"A giant walrus appears!",
+"size":10,"time":"2014-03-10 19:57:38.562500591 -0400 EDT"}
+
+{"animal":"walrus","level":"info","msg":"Tremendously sized cow enters the ocean.",
+"size":9,"time":"2014-03-10 19:57:38.562527896 -0400 EDT"}
+
+{"level":"fatal","msg":"The ice breaks!","number":100,"omg":true,
+"time":"2014-03-10 19:57:38.562543128 -0400 EDT"}
+```
+
+With the default `log.Formatter = new(&log.TextFormatter{})` when a TTY is not
+attached, the output is compatible with the
+[logfmt](http://godoc.org/github.com/kr/logfmt) format:
+
+```text
+time="2015-03-26T01:27:38-04:00" level=debug msg="Started observing beach" animal=walrus number=8
+time="2015-03-26T01:27:38-04:00" level=info msg="A group of walrus emerges from the ocean" animal=walrus size=10
+time="2015-03-26T01:27:38-04:00" level=warning msg="The group's number increased tremendously!" number=122 omg=true
+time="2015-03-26T01:27:38-04:00" level=debug msg="Temperature changes" temperature=-4
+time="2015-03-26T01:27:38-04:00" level=panic msg="It's over 9000!" animal=orca size=9009
+time="2015-03-26T01:27:38-04:00" level=fatal msg="The ice breaks!" err=&{0x2082280c0 map[animal:orca size:9009] 2015-03-26 01:27:38.441574009 -0400 EDT panic It's over 9000!} number=100 omg=true
+exit status 1
+```
+
+#### Example
+
+The simplest way to use Logrus is simply the package-level exported logger:
+
+```go
+package main
+
+import (
+  log "github.com/Sirupsen/logrus"
+)
+
+func main() {
+  log.WithFields(log.Fields{
+    "animal": "walrus",
+  }).Info("A walrus appears")
+}
+```
+
+Note that it's completely api-compatible with the stdlib logger, so you can
+replace your `log` imports everywhere with `log "github.com/Sirupsen/logrus"`
+and you'll now have the flexibility of Logrus. You can customize it all you
+want:
+
+```go
+package main
+
+import (
+  "os"
+  log "github.com/Sirupsen/logrus"
+)
+
+func init() {
+  // Log as JSON instead of the default ASCII formatter.
+  log.SetFormatter(&log.JSONFormatter{})
+
+  // Output to stderr instead of stdout, could also be a file.
+  log.SetOutput(os.Stderr)
+
+  // Only log the warning severity or above.
+  log.SetLevel(log.WarnLevel)
+}
+
+func main() {
+  log.WithFields(log.Fields{
+    "animal": "walrus",
+    "size":   10,
+  }).Info("A group of walrus emerges from the ocean")
+
+  log.WithFields(log.Fields{
+    "omg":    true,
+    "number": 122,
+  }).Warn("The group's number increased tremendously!")
+
+  log.WithFields(log.Fields{
+    "omg":    true,
+    "number": 100,
+  }).Fatal("The ice breaks!")
+
+  // A common pattern is to re-use fields between logging statements by re-using
+  // the logrus.Entry returned from WithFields()
+  contextLogger := log.WithFields(log.Fields{
+    "common": "this is a common field",
+    "other": "I also should be logged always",
+  })
+
+  contextLogger.Info("I'll be logged with common and other field")
+  contextLogger.Info("Me too")
+}
+```
+
+For more advanced usage such as logging to multiple locations from the same
+application, you can also create an instance of the `logrus` Logger:
+
+```go
+package main
+
+import (
+  "github.com/Sirupsen/logrus"
+)
+
+// Create a new instance of the logger. You can have any number of instances.
+var log = logrus.New()
+
+func main() {
+  // The API for setting attributes is a little different than the package level
+  // exported logger. See Godoc.
+  log.Out = os.Stderr
+
+  log.WithFields(logrus.Fields{
+    "animal": "walrus",
+    "size":   10,
+  }).Info("A group of walrus emerges from the ocean")
+}
+```
+
+#### Fields
+
+Logrus encourages careful, structured logging though logging fields instead of
+long, unparseable error messages. For example, instead of: `log.Fatalf("Failed
+to send event %s to topic %s with key %d")`, you should log the much more
+discoverable:
+
+```go
+log.WithFields(log.Fields{
+  "event": event,
+  "topic": topic,
+  "key": key,
+}).Fatal("Failed to send event")
+```
+
+We've found this API forces you to think about logging in a way that produces
+much more useful logging messages. We've been in countless situations where just
+a single added field to a log statement that was already there would've saved us
+hours. The `WithFields` call is optional.
+
+In general, with Logrus using any of the `printf`-family functions should be
+seen as a hint you should add a field, however, you can still use the
+`printf`-family functions with Logrus.
+
+#### Hooks
+
+You can add hooks for logging levels. For example to send errors to an exception
+tracking service on `Error`, `Fatal` and `Panic`, info to StatsD or log to
+multiple places simultaneously, e.g. syslog.
+
+Logrus comes with [built-in hooks](hooks/). Add those, or your custom hook, in
+`init`:
+
+```go
+import (
+  log "github.com/Sirupsen/logrus"
+  "gopkg.in/gemnasium/logrus-airbrake-hook.v2" // the package is named "aibrake"
+  logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+  "log/syslog"
+)
+
+func init() {
+
+  // Use the Airbrake hook to report errors that have Error severity or above to
+  // an exception tracker. You can create custom hooks, see the Hooks section.
+  log.AddHook(airbrake.NewHook(123, "xyz", "production"))
+
+  hook, err := logrus_syslog.NewSyslogHook("udp", "localhost:514", syslog.LOG_INFO, "")
+  if err != nil {
+    log.Error("Unable to connect to local syslog daemon")
+  } else {
+    log.AddHook(hook)
+  }
+}
+```
+Note: Syslog hook also support connecting to local syslog (Ex. "/dev/log" or "/var/run/syslog" or "/var/run/log"). For the detail, please check the [syslog hook README](hooks/syslog/README.md).
+
+| Hook  | Description |
+| ----- | ----------- |
+| [Airbrake](https://github.com/gemnasium/logrus-airbrake-hook) | Send errors to the Airbrake API V3. Uses the official [`gobrake`](https://github.com/airbrake/gobrake) behind the scenes. |
+| [Airbrake "legacy"](https://github.com/gemnasium/logrus-airbrake-legacy-hook) | Send errors to an exception tracking service compatible with the Airbrake API V2. Uses [`airbrake-go`](https://github.com/tobi/airbrake-go) behind the scenes. |
+| [Papertrail](https://github.com/polds/logrus-papertrail-hook) | Send errors to the [Papertrail](https://papertrailapp.com) hosted logging service via UDP. |
+| [Syslog](https://github.com/Sirupsen/logrus/blob/master/hooks/syslog/syslog.go) | Send errors to remote syslog server. Uses standard library `log/syslog` behind the scenes. |
+| [Bugsnag](https://github.com/Shopify/logrus-bugsnag/blob/master/bugsnag.go) | Send errors to the Bugsnag exception tracking service. |
+| [Sentry](https://github.com/evalphobia/logrus_sentry) | Send errors to the Sentry error logging and aggregation service. |
+| [Hiprus](https://github.com/nubo/hiprus) | Send errors to a channel in hipchat. |
+| [Logrusly](https://github.com/sebest/logrusly) | Send logs to [Loggly](https://www.loggly.com/) |
+| [Slackrus](https://github.com/johntdyer/slackrus) | Hook for Slack chat. |
+| [Journalhook](https://github.com/wercker/journalhook) | Hook for logging to `systemd-journald` |
+| [Graylog](https://github.com/gemnasium/logrus-graylog-hook) | Hook for logging to [Graylog](http://graylog2.org/) |
+| [Raygun](https://github.com/squirkle/logrus-raygun-hook) | Hook for logging to [Raygun.io](http://raygun.io/) |
+| [LFShook](https://github.com/rifflock/lfshook) | Hook for logging to the local filesystem |
+| [Honeybadger](https://github.com/agonzalezro/logrus_honeybadger) | Hook for sending exceptions to Honeybadger |
+| [Mail](https://github.com/zbindenren/logrus_mail) | Hook for sending exceptions via mail |
+| [Rollrus](https://github.com/heroku/rollrus) | Hook for sending errors to rollbar |
+| [Fluentd](https://github.com/evalphobia/logrus_fluent) | Hook for logging to fluentd |
+| [Mongodb](https://github.com/weekface/mgorus) | Hook for logging to mongodb |
+| [InfluxDB](https://github.com/Abramovic/logrus_influxdb) | Hook for logging to influxdb |
+| [Octokit](https://github.com/dorajistyle/logrus-octokit-hook) | Hook for logging to github via octokit |
+| [DeferPanic](https://github.com/deferpanic/dp-logrus) | Hook for logging to DeferPanic |
+
+#### Level logging
+
+Logrus has six logging levels: Debug, Info, Warning, Error, Fatal and Panic.
+
+```go
+log.Debug("Useful debugging information.")
+log.Info("Something noteworthy happened!")
+log.Warn("You should probably take a look at this.")
+log.Error("Something failed but I'm not quitting.")
+// Calls os.Exit(1) after logging
+log.Fatal("Bye.")
+// Calls panic() after logging
+log.Panic("I'm bailing.")
+```
+
+You can set the logging level on a `Logger`, then it will only log entries with
+that severity or anything above it:
+
+```go
+// Will log anything that is info or above (warn, error, fatal, panic). Default.
+log.SetLevel(log.InfoLevel)
+```
+
+It may be useful to set `log.Level = logrus.DebugLevel` in a debug or verbose
+environment if your application has that.
+
+#### Entries
+
+Besides the fields added with `WithField` or `WithFields` some fields are
+automatically added to all logging events:
+
+1. `time`. The timestamp when the entry was created.
+2. `msg`. The logging message passed to `{Info,Warn,Error,Fatal,Panic}` after
+   the `AddFields` call. E.g. `Failed to send event.`
+3. `level`. The logging level. E.g. `info`.
+
+#### Environments
+
+Logrus has no notion of environment.
+
+If you wish for hooks and formatters to only be used in specific environments,
+you should handle that yourself. For example, if your application has a global
+variable `Environment`, which is a string representation of the environment you
+could do:
+
+```go
+import (
+  log "github.com/Sirupsen/logrus"
+)
+
+init() {
+  // do something here to set environment depending on an environment variable
+  // or command-line flag
+  if Environment == "production" {
+    log.SetFormatter(&log.JSONFormatter{})
+  } else {
+    // The TextFormatter is default, you don't actually have to do this.
+    log.SetFormatter(&log.TextFormatter{})
+  }
+}
+```
+
+This configuration is how `logrus` was intended to be used, but JSON in
+production is mostly only useful if you do log aggregation with tools like
+Splunk or Logstash.
+
+#### Formatters
+
+The built-in logging formatters are:
+
+* `logrus.TextFormatter`. Logs the event in colors if stdout is a tty, otherwise
+  without colors.
+  * *Note:* to force colored output when there is no TTY, set the `ForceColors`
+    field to `true`.  To force no colored output even if there is a TTY  set the
+    `DisableColors` field to `true`
+* `logrus.JSONFormatter`. Logs fields as JSON.
+* `logrus/formatters/logstash.LogstashFormatter`. Logs fields as [Logstash](http://logstash.net) Events.
+
+    ```go
+      logrus.SetFormatter(&logstash.LogstashFormatter{Type: "application_name"})
+    ```
+
+Third party logging formatters:
+
+* [`prefixed`](https://github.com/x-cray/logrus-prefixed-formatter). Displays log entry source along with alternative layout.
+* [`zalgo`](https://github.com/aybabtme/logzalgo). Invoking the P͉̫o̳̼̊w̖͈̰͎e̬͔̭͂r͚̼̹̲ ̫͓͉̳͈ō̠͕͖̚f̝͍̠ ͕̲̞͖͑Z̖̫̤̫ͪa͉̬͈̗l͖͎g̳̥o̰̥̅!̣͔̲̻͊̄ ̙̘̦̹̦.
+
+You can define your formatter by implementing the `Formatter` interface,
+requiring a `Format` method. `Format` takes an `*Entry`. `entry.Data` is a
+`Fields` type (`map[string]interface{}`) with all your fields as well as the
+default ones (see Entries section above):
+
+```go
+type MyJSONFormatter struct {
+}
+
+log.SetFormatter(new(MyJSONFormatter))
+
+func (f *MyJSONFormatter) Format(entry *Entry) ([]byte, error) {
+  // Note this doesn't include Time, Level and Message which are available on
+  // the Entry. Consult `godoc` on information about those fields or read the
+  // source of the official loggers.
+  serialized, err := json.Marshal(entry.Data)
+    if err != nil {
+      return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+    }
+  return append(serialized, '\n'), nil
+}
+```
+
+#### Logger as an `io.Writer`
+
+Logrus can be transformed into an `io.Writer`. That writer is the end of an `io.Pipe` and it is your responsibility to close it.
+
+```go
+w := logger.Writer()
+defer w.Close()
+
+srv := http.Server{
+    // create a stdlib log.Logger that writes to
+    // logrus.Logger.
+    ErrorLog: log.New(w, "", 0),
+}
+```
+
+Each line written to that writer will be printed the usual way, using formatters
+and hooks. The level for those entries is `info`.
+
+#### Rotation
+
+Log rotation is not provided with Logrus. Log rotation should be done by an
+external program (like `logrotate(8)`) that can compress and delete old log
+entries. It should not be a feature of the application-level logger.
+
+#### Tools
+
+| Tool | Description |
+| ---- | ----------- |
+|[Logrus Mate](https://github.com/gogap/logrus_mate)|Logrus mate is a tool for Logrus to manage loggers, you can initial logger's level, hook and formatter by config file, the logger will generated with different config at different environment.|
+
+[godoc]: https://godoc.org/github.com/Sirupsen/logrus

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/doc.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/doc.go
@@ -1,0 +1,26 @@
+/*
+Package logrus is a structured logger for Go, completely API compatible with the standard library logger.
+
+
+The simplest way to use Logrus is simply the package-level exported logger:
+
+  package main
+
+  import (
+    log "github.com/Sirupsen/logrus"
+  )
+
+  func main() {
+    log.WithFields(log.Fields{
+      "animal": "walrus",
+      "number": 1,
+      "size":   10,
+    }).Info("A walrus appears")
+  }
+
+Output:
+  time="2015-09-07T08:48:33Z" level=info msg="A walrus appears" animal=walrus number=1 size=10
+
+For a full guide visit https://github.com/Sirupsen/logrus
+*/
+package logrus

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/entry.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/entry.go
@@ -1,0 +1,264 @@
+package logrus
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// Defines the key when adding errors using WithError.
+var ErrorKey = "error"
+
+// An entry is the final or intermediate Logrus logging entry. It contains all
+// the fields passed with WithField{,s}. It's finally logged when Debug, Info,
+// Warn, Error, Fatal or Panic is called on it. These objects can be reused and
+// passed around as much as you wish to avoid field duplication.
+type Entry struct {
+	Logger *Logger
+
+	// Contains all the fields set by the user.
+	Data Fields
+
+	// Time at which the log entry was created
+	Time time.Time
+
+	// Level the log entry was logged at: Debug, Info, Warn, Error, Fatal or Panic
+	Level Level
+
+	// Message passed to Debug, Info, Warn, Error, Fatal or Panic
+	Message string
+}
+
+func NewEntry(logger *Logger) *Entry {
+	return &Entry{
+		Logger: logger,
+		// Default is three fields, give a little extra room
+		Data: make(Fields, 5),
+	}
+}
+
+// Returns a reader for the entry, which is a proxy to the formatter.
+func (entry *Entry) Reader() (*bytes.Buffer, error) {
+	serialized, err := entry.Logger.Formatter.Format(entry)
+	return bytes.NewBuffer(serialized), err
+}
+
+// Returns the string representation from the reader and ultimately the
+// formatter.
+func (entry *Entry) String() (string, error) {
+	reader, err := entry.Reader()
+	if err != nil {
+		return "", err
+	}
+
+	return reader.String(), err
+}
+
+// Add an error as single field (using the key defined in ErrorKey) to the Entry.
+func (entry *Entry) WithError(err error) *Entry {
+	return entry.WithField(ErrorKey, err)
+}
+
+// Add a single field to the Entry.
+func (entry *Entry) WithField(key string, value interface{}) *Entry {
+	return entry.WithFields(Fields{key: value})
+}
+
+// Add a map of fields to the Entry.
+func (entry *Entry) WithFields(fields Fields) *Entry {
+	data := Fields{}
+	for k, v := range entry.Data {
+		data[k] = v
+	}
+	for k, v := range fields {
+		data[k] = v
+	}
+	return &Entry{Logger: entry.Logger, Data: data}
+}
+
+// This function is not declared with a pointer value because otherwise
+// race conditions will occur when using multiple goroutines
+func (entry Entry) log(level Level, msg string) {
+	entry.Time = time.Now()
+	entry.Level = level
+	entry.Message = msg
+
+	if err := entry.Logger.Hooks.Fire(level, &entry); err != nil {
+		entry.Logger.mu.Lock()
+		fmt.Fprintf(os.Stderr, "Failed to fire hook: %v\n", err)
+		entry.Logger.mu.Unlock()
+	}
+
+	reader, err := entry.Reader()
+	if err != nil {
+		entry.Logger.mu.Lock()
+		fmt.Fprintf(os.Stderr, "Failed to obtain reader, %v\n", err)
+		entry.Logger.mu.Unlock()
+	}
+
+	entry.Logger.mu.Lock()
+	defer entry.Logger.mu.Unlock()
+
+	_, err = io.Copy(entry.Logger.Out, reader)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to write to log, %v\n", err)
+	}
+
+	// To avoid Entry#log() returning a value that only would make sense for
+	// panic() to use in Entry#Panic(), we avoid the allocation by checking
+	// directly here.
+	if level <= PanicLevel {
+		panic(&entry)
+	}
+}
+
+func (entry *Entry) Debug(args ...interface{}) {
+	if entry.Logger.Level >= DebugLevel {
+		entry.log(DebugLevel, fmt.Sprint(args...))
+	}
+}
+
+func (entry *Entry) Print(args ...interface{}) {
+	entry.Info(args...)
+}
+
+func (entry *Entry) Info(args ...interface{}) {
+	if entry.Logger.Level >= InfoLevel {
+		entry.log(InfoLevel, fmt.Sprint(args...))
+	}
+}
+
+func (entry *Entry) Warn(args ...interface{}) {
+	if entry.Logger.Level >= WarnLevel {
+		entry.log(WarnLevel, fmt.Sprint(args...))
+	}
+}
+
+func (entry *Entry) Warning(args ...interface{}) {
+	entry.Warn(args...)
+}
+
+func (entry *Entry) Error(args ...interface{}) {
+	if entry.Logger.Level >= ErrorLevel {
+		entry.log(ErrorLevel, fmt.Sprint(args...))
+	}
+}
+
+func (entry *Entry) Fatal(args ...interface{}) {
+	if entry.Logger.Level >= FatalLevel {
+		entry.log(FatalLevel, fmt.Sprint(args...))
+	}
+	os.Exit(1)
+}
+
+func (entry *Entry) Panic(args ...interface{}) {
+	if entry.Logger.Level >= PanicLevel {
+		entry.log(PanicLevel, fmt.Sprint(args...))
+	}
+	panic(fmt.Sprint(args...))
+}
+
+// Entry Printf family functions
+
+func (entry *Entry) Debugf(format string, args ...interface{}) {
+	if entry.Logger.Level >= DebugLevel {
+		entry.Debug(fmt.Sprintf(format, args...))
+	}
+}
+
+func (entry *Entry) Infof(format string, args ...interface{}) {
+	if entry.Logger.Level >= InfoLevel {
+		entry.Info(fmt.Sprintf(format, args...))
+	}
+}
+
+func (entry *Entry) Printf(format string, args ...interface{}) {
+	entry.Infof(format, args...)
+}
+
+func (entry *Entry) Warnf(format string, args ...interface{}) {
+	if entry.Logger.Level >= WarnLevel {
+		entry.Warn(fmt.Sprintf(format, args...))
+	}
+}
+
+func (entry *Entry) Warningf(format string, args ...interface{}) {
+	entry.Warnf(format, args...)
+}
+
+func (entry *Entry) Errorf(format string, args ...interface{}) {
+	if entry.Logger.Level >= ErrorLevel {
+		entry.Error(fmt.Sprintf(format, args...))
+	}
+}
+
+func (entry *Entry) Fatalf(format string, args ...interface{}) {
+	if entry.Logger.Level >= FatalLevel {
+		entry.Fatal(fmt.Sprintf(format, args...))
+	}
+	os.Exit(1)
+}
+
+func (entry *Entry) Panicf(format string, args ...interface{}) {
+	if entry.Logger.Level >= PanicLevel {
+		entry.Panic(fmt.Sprintf(format, args...))
+	}
+}
+
+// Entry Println family functions
+
+func (entry *Entry) Debugln(args ...interface{}) {
+	if entry.Logger.Level >= DebugLevel {
+		entry.Debug(entry.sprintlnn(args...))
+	}
+}
+
+func (entry *Entry) Infoln(args ...interface{}) {
+	if entry.Logger.Level >= InfoLevel {
+		entry.Info(entry.sprintlnn(args...))
+	}
+}
+
+func (entry *Entry) Println(args ...interface{}) {
+	entry.Infoln(args...)
+}
+
+func (entry *Entry) Warnln(args ...interface{}) {
+	if entry.Logger.Level >= WarnLevel {
+		entry.Warn(entry.sprintlnn(args...))
+	}
+}
+
+func (entry *Entry) Warningln(args ...interface{}) {
+	entry.Warnln(args...)
+}
+
+func (entry *Entry) Errorln(args ...interface{}) {
+	if entry.Logger.Level >= ErrorLevel {
+		entry.Error(entry.sprintlnn(args...))
+	}
+}
+
+func (entry *Entry) Fatalln(args ...interface{}) {
+	if entry.Logger.Level >= FatalLevel {
+		entry.Fatal(entry.sprintlnn(args...))
+	}
+	os.Exit(1)
+}
+
+func (entry *Entry) Panicln(args ...interface{}) {
+	if entry.Logger.Level >= PanicLevel {
+		entry.Panic(entry.sprintlnn(args...))
+	}
+}
+
+// Sprintlnn => Sprint no newline. This is to get the behavior of how
+// fmt.Sprintln where spaces are always added between operands, regardless of
+// their type. Instead of vendoring the Sprintln implementation to spare a
+// string allocation, we do the simplest thing.
+func (entry *Entry) sprintlnn(args ...interface{}) string {
+	msg := fmt.Sprintln(args...)
+	return msg[:len(msg)-1]
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/entry_test.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/entry_test.go
@@ -1,0 +1,77 @@
+package logrus
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEntryWithError(t *testing.T) {
+
+	assert := assert.New(t)
+
+	defer func() {
+		ErrorKey = "error"
+	}()
+
+	err := fmt.Errorf("kaboom at layer %d", 4711)
+
+	assert.Equal(err, WithError(err).Data["error"])
+
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	entry := NewEntry(logger)
+
+	assert.Equal(err, entry.WithError(err).Data["error"])
+
+	ErrorKey = "err"
+
+	assert.Equal(err, entry.WithError(err).Data["err"])
+
+}
+
+func TestEntryPanicln(t *testing.T) {
+	errBoom := fmt.Errorf("boom time")
+
+	defer func() {
+		p := recover()
+		assert.NotNil(t, p)
+
+		switch pVal := p.(type) {
+		case *Entry:
+			assert.Equal(t, "kaboom", pVal.Message)
+			assert.Equal(t, errBoom, pVal.Data["err"])
+		default:
+			t.Fatalf("want type *Entry, got %T: %#v", pVal, pVal)
+		}
+	}()
+
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	entry := NewEntry(logger)
+	entry.WithField("err", errBoom).Panicln("kaboom")
+}
+
+func TestEntryPanicf(t *testing.T) {
+	errBoom := fmt.Errorf("boom again")
+
+	defer func() {
+		p := recover()
+		assert.NotNil(t, p)
+
+		switch pVal := p.(type) {
+		case *Entry:
+			assert.Equal(t, "kaboom true", pVal.Message)
+			assert.Equal(t, errBoom, pVal.Data["err"])
+		default:
+			t.Fatalf("want type *Entry, got %T: %#v", pVal, pVal)
+		}
+	}()
+
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	entry := NewEntry(logger)
+	entry.WithField("err", errBoom).Panicf("kaboom %v", true)
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/exported.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/exported.go
@@ -1,0 +1,193 @@
+package logrus
+
+import (
+	"io"
+)
+
+var (
+	// std is the name of the standard logger in stdlib `log`
+	std = New()
+)
+
+func StandardLogger() *Logger {
+	return std
+}
+
+// SetOutput sets the standard logger output.
+func SetOutput(out io.Writer) {
+	std.mu.Lock()
+	defer std.mu.Unlock()
+	std.Out = out
+}
+
+// SetFormatter sets the standard logger formatter.
+func SetFormatter(formatter Formatter) {
+	std.mu.Lock()
+	defer std.mu.Unlock()
+	std.Formatter = formatter
+}
+
+// SetLevel sets the standard logger level.
+func SetLevel(level Level) {
+	std.mu.Lock()
+	defer std.mu.Unlock()
+	std.Level = level
+}
+
+// GetLevel returns the standard logger level.
+func GetLevel() Level {
+	std.mu.Lock()
+	defer std.mu.Unlock()
+	return std.Level
+}
+
+// AddHook adds a hook to the standard logger hooks.
+func AddHook(hook Hook) {
+	std.mu.Lock()
+	defer std.mu.Unlock()
+	std.Hooks.Add(hook)
+}
+
+// WithError creates an entry from the standard logger and adds an error to it, using the value defined in ErrorKey as key.
+func WithError(err error) *Entry {
+	return std.WithField(ErrorKey, err)
+}
+
+// WithField creates an entry from the standard logger and adds a field to
+// it. If you want multiple fields, use `WithFields`.
+//
+// Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal
+// or Panic on the Entry it returns.
+func WithField(key string, value interface{}) *Entry {
+	return std.WithField(key, value)
+}
+
+// WithFields creates an entry from the standard logger and adds multiple
+// fields to it. This is simply a helper for `WithField`, invoking it
+// once for each field.
+//
+// Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal
+// or Panic on the Entry it returns.
+func WithFields(fields Fields) *Entry {
+	return std.WithFields(fields)
+}
+
+// Debug logs a message at level Debug on the standard logger.
+func Debug(args ...interface{}) {
+	std.Debug(args...)
+}
+
+// Print logs a message at level Info on the standard logger.
+func Print(args ...interface{}) {
+	std.Print(args...)
+}
+
+// Info logs a message at level Info on the standard logger.
+func Info(args ...interface{}) {
+	std.Info(args...)
+}
+
+// Warn logs a message at level Warn on the standard logger.
+func Warn(args ...interface{}) {
+	std.Warn(args...)
+}
+
+// Warning logs a message at level Warn on the standard logger.
+func Warning(args ...interface{}) {
+	std.Warning(args...)
+}
+
+// Error logs a message at level Error on the standard logger.
+func Error(args ...interface{}) {
+	std.Error(args...)
+}
+
+// Panic logs a message at level Panic on the standard logger.
+func Panic(args ...interface{}) {
+	std.Panic(args...)
+}
+
+// Fatal logs a message at level Fatal on the standard logger.
+func Fatal(args ...interface{}) {
+	std.Fatal(args...)
+}
+
+// Debugf logs a message at level Debug on the standard logger.
+func Debugf(format string, args ...interface{}) {
+	std.Debugf(format, args...)
+}
+
+// Printf logs a message at level Info on the standard logger.
+func Printf(format string, args ...interface{}) {
+	std.Printf(format, args...)
+}
+
+// Infof logs a message at level Info on the standard logger.
+func Infof(format string, args ...interface{}) {
+	std.Infof(format, args...)
+}
+
+// Warnf logs a message at level Warn on the standard logger.
+func Warnf(format string, args ...interface{}) {
+	std.Warnf(format, args...)
+}
+
+// Warningf logs a message at level Warn on the standard logger.
+func Warningf(format string, args ...interface{}) {
+	std.Warningf(format, args...)
+}
+
+// Errorf logs a message at level Error on the standard logger.
+func Errorf(format string, args ...interface{}) {
+	std.Errorf(format, args...)
+}
+
+// Panicf logs a message at level Panic on the standard logger.
+func Panicf(format string, args ...interface{}) {
+	std.Panicf(format, args...)
+}
+
+// Fatalf logs a message at level Fatal on the standard logger.
+func Fatalf(format string, args ...interface{}) {
+	std.Fatalf(format, args...)
+}
+
+// Debugln logs a message at level Debug on the standard logger.
+func Debugln(args ...interface{}) {
+	std.Debugln(args...)
+}
+
+// Println logs a message at level Info on the standard logger.
+func Println(args ...interface{}) {
+	std.Println(args...)
+}
+
+// Infoln logs a message at level Info on the standard logger.
+func Infoln(args ...interface{}) {
+	std.Infoln(args...)
+}
+
+// Warnln logs a message at level Warn on the standard logger.
+func Warnln(args ...interface{}) {
+	std.Warnln(args...)
+}
+
+// Warningln logs a message at level Warn on the standard logger.
+func Warningln(args ...interface{}) {
+	std.Warningln(args...)
+}
+
+// Errorln logs a message at level Error on the standard logger.
+func Errorln(args ...interface{}) {
+	std.Errorln(args...)
+}
+
+// Panicln logs a message at level Panic on the standard logger.
+func Panicln(args ...interface{}) {
+	std.Panicln(args...)
+}
+
+// Fatalln logs a message at level Fatal on the standard logger.
+func Fatalln(args ...interface{}) {
+	std.Fatalln(args...)
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/formatter.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/formatter.go
@@ -1,0 +1,48 @@
+package logrus
+
+import "time"
+
+const DefaultTimestampFormat = time.RFC3339
+
+// The Formatter interface is used to implement a custom Formatter. It takes an
+// `Entry`. It exposes all the fields, including the default ones:
+//
+// * `entry.Data["msg"]`. The message passed from Info, Warn, Error ..
+// * `entry.Data["time"]`. The timestamp.
+// * `entry.Data["level"]. The level the entry was logged at.
+//
+// Any additional fields added with `WithField` or `WithFields` are also in
+// `entry.Data`. Format is expected to return an array of bytes which are then
+// logged to `logger.Out`.
+type Formatter interface {
+	Format(*Entry) ([]byte, error)
+}
+
+// This is to not silently overwrite `time`, `msg` and `level` fields when
+// dumping it. If this code wasn't there doing:
+//
+//  logrus.WithField("level", 1).Info("hello")
+//
+// Would just silently drop the user provided level. Instead with this code
+// it'll logged as:
+//
+//  {"level": "info", "fields.level": 1, "msg": "hello", "time": "..."}
+//
+// It's not exported because it's still using Data in an opinionated way. It's to
+// avoid code duplication between the two default formatters.
+func prefixFieldClashes(data Fields) {
+	_, ok := data["time"]
+	if ok {
+		data["fields.time"] = data["time"]
+	}
+
+	_, ok = data["msg"]
+	if ok {
+		data["fields.msg"] = data["msg"]
+	}
+
+	_, ok = data["level"]
+	if ok {
+		data["fields.level"] = data["level"]
+	}
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/formatter_bench_test.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/formatter_bench_test.go
@@ -1,0 +1,98 @@
+package logrus
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// smallFields is a small size data set for benchmarking
+var smallFields = Fields{
+	"foo":   "bar",
+	"baz":   "qux",
+	"one":   "two",
+	"three": "four",
+}
+
+// largeFields is a large size data set for benchmarking
+var largeFields = Fields{
+	"foo":       "bar",
+	"baz":       "qux",
+	"one":       "two",
+	"three":     "four",
+	"five":      "six",
+	"seven":     "eight",
+	"nine":      "ten",
+	"eleven":    "twelve",
+	"thirteen":  "fourteen",
+	"fifteen":   "sixteen",
+	"seventeen": "eighteen",
+	"nineteen":  "twenty",
+	"a":         "b",
+	"c":         "d",
+	"e":         "f",
+	"g":         "h",
+	"i":         "j",
+	"k":         "l",
+	"m":         "n",
+	"o":         "p",
+	"q":         "r",
+	"s":         "t",
+	"u":         "v",
+	"w":         "x",
+	"y":         "z",
+	"this":      "will",
+	"make":      "thirty",
+	"entries":   "yeah",
+}
+
+var errorFields = Fields{
+	"foo": fmt.Errorf("bar"),
+	"baz": fmt.Errorf("qux"),
+}
+
+func BenchmarkErrorTextFormatter(b *testing.B) {
+	doBenchmark(b, &TextFormatter{DisableColors: true}, errorFields)
+}
+
+func BenchmarkSmallTextFormatter(b *testing.B) {
+	doBenchmark(b, &TextFormatter{DisableColors: true}, smallFields)
+}
+
+func BenchmarkLargeTextFormatter(b *testing.B) {
+	doBenchmark(b, &TextFormatter{DisableColors: true}, largeFields)
+}
+
+func BenchmarkSmallColoredTextFormatter(b *testing.B) {
+	doBenchmark(b, &TextFormatter{ForceColors: true}, smallFields)
+}
+
+func BenchmarkLargeColoredTextFormatter(b *testing.B) {
+	doBenchmark(b, &TextFormatter{ForceColors: true}, largeFields)
+}
+
+func BenchmarkSmallJSONFormatter(b *testing.B) {
+	doBenchmark(b, &JSONFormatter{}, smallFields)
+}
+
+func BenchmarkLargeJSONFormatter(b *testing.B) {
+	doBenchmark(b, &JSONFormatter{}, largeFields)
+}
+
+func doBenchmark(b *testing.B, formatter Formatter, fields Fields) {
+	entry := &Entry{
+		Time:    time.Time{},
+		Level:   InfoLevel,
+		Message: "message",
+		Data:    fields,
+	}
+	var d []byte
+	var err error
+	for i := 0; i < b.N; i++ {
+		d, err = formatter.Format(entry)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.SetBytes(int64(len(d)))
+	}
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/hook_test.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/hook_test.go
@@ -1,0 +1,122 @@
+package logrus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestHook struct {
+	Fired bool
+}
+
+func (hook *TestHook) Fire(entry *Entry) error {
+	hook.Fired = true
+	return nil
+}
+
+func (hook *TestHook) Levels() []Level {
+	return []Level{
+		DebugLevel,
+		InfoLevel,
+		WarnLevel,
+		ErrorLevel,
+		FatalLevel,
+		PanicLevel,
+	}
+}
+
+func TestHookFires(t *testing.T) {
+	hook := new(TestHook)
+
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Hooks.Add(hook)
+		assert.Equal(t, hook.Fired, false)
+
+		log.Print("test")
+	}, func(fields Fields) {
+		assert.Equal(t, hook.Fired, true)
+	})
+}
+
+type ModifyHook struct {
+}
+
+func (hook *ModifyHook) Fire(entry *Entry) error {
+	entry.Data["wow"] = "whale"
+	return nil
+}
+
+func (hook *ModifyHook) Levels() []Level {
+	return []Level{
+		DebugLevel,
+		InfoLevel,
+		WarnLevel,
+		ErrorLevel,
+		FatalLevel,
+		PanicLevel,
+	}
+}
+
+func TestHookCanModifyEntry(t *testing.T) {
+	hook := new(ModifyHook)
+
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Hooks.Add(hook)
+		log.WithField("wow", "elephant").Print("test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["wow"], "whale")
+	})
+}
+
+func TestCanFireMultipleHooks(t *testing.T) {
+	hook1 := new(ModifyHook)
+	hook2 := new(TestHook)
+
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Hooks.Add(hook1)
+		log.Hooks.Add(hook2)
+
+		log.WithField("wow", "elephant").Print("test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["wow"], "whale")
+		assert.Equal(t, hook2.Fired, true)
+	})
+}
+
+type ErrorHook struct {
+	Fired bool
+}
+
+func (hook *ErrorHook) Fire(entry *Entry) error {
+	hook.Fired = true
+	return nil
+}
+
+func (hook *ErrorHook) Levels() []Level {
+	return []Level{
+		ErrorLevel,
+	}
+}
+
+func TestErrorHookShouldntFireOnInfo(t *testing.T) {
+	hook := new(ErrorHook)
+
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Hooks.Add(hook)
+		log.Info("test")
+	}, func(fields Fields) {
+		assert.Equal(t, hook.Fired, false)
+	})
+}
+
+func TestErrorHookShouldFireOnError(t *testing.T) {
+	hook := new(ErrorHook)
+
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Hooks.Add(hook)
+		log.Error("test")
+	}, func(fields Fields) {
+		assert.Equal(t, hook.Fired, true)
+	})
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/hooks.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/hooks.go
@@ -1,0 +1,34 @@
+package logrus
+
+// A hook to be fired when logging on the logging levels returned from
+// `Levels()` on your implementation of the interface. Note that this is not
+// fired in a goroutine or a channel with workers, you should handle such
+// functionality yourself if your call is non-blocking and you don't wish for
+// the logging calls for levels returned from `Levels()` to block.
+type Hook interface {
+	Levels() []Level
+	Fire(*Entry) error
+}
+
+// Internal type for storing the hooks on a logger instance.
+type LevelHooks map[Level][]Hook
+
+// Add a hook to an instance of logger. This is called with
+// `log.Hooks.Add(new(MyHook))` where `MyHook` implements the `Hook` interface.
+func (hooks LevelHooks) Add(hook Hook) {
+	for _, level := range hook.Levels() {
+		hooks[level] = append(hooks[level], hook)
+	}
+}
+
+// Fire all the hooks for the passed level. Used by `entry.log` to fire
+// appropriate hooks for a log entry.
+func (hooks LevelHooks) Fire(level Level, entry *Entry) error {
+	for _, hook := range hooks[level] {
+		if err := hook.Fire(entry); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/json_formatter.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/json_formatter.go
@@ -1,0 +1,41 @@
+package logrus
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type JSONFormatter struct {
+	// TimestampFormat sets the format used for marshaling timestamps.
+	TimestampFormat string
+}
+
+func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
+	data := make(Fields, len(entry.Data)+3)
+	for k, v := range entry.Data {
+		switch v := v.(type) {
+		case error:
+			// Otherwise errors are ignored by `encoding/json`
+			// https://github.com/Sirupsen/logrus/issues/137
+			data[k] = v.Error()
+		default:
+			data[k] = v
+		}
+	}
+	prefixFieldClashes(data)
+
+	timestampFormat := f.TimestampFormat
+	if timestampFormat == "" {
+		timestampFormat = DefaultTimestampFormat
+	}
+
+	data["time"] = entry.Time.Format(timestampFormat)
+	data["msg"] = entry.Message
+	data["level"] = entry.Level.String()
+
+	serialized, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+	}
+	return append(serialized, '\n'), nil
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/json_formatter_test.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/json_formatter_test.go
@@ -1,0 +1,120 @@
+package logrus
+
+import (
+	"encoding/json"
+	"errors"
+
+	"testing"
+)
+
+func TestErrorNotLost(t *testing.T) {
+	formatter := &JSONFormatter{}
+
+	b, err := formatter.Format(WithField("error", errors.New("wild walrus")))
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	entry := make(map[string]interface{})
+	err = json.Unmarshal(b, &entry)
+	if err != nil {
+		t.Fatal("Unable to unmarshal formatted entry: ", err)
+	}
+
+	if entry["error"] != "wild walrus" {
+		t.Fatal("Error field not set")
+	}
+}
+
+func TestErrorNotLostOnFieldNotNamedError(t *testing.T) {
+	formatter := &JSONFormatter{}
+
+	b, err := formatter.Format(WithField("omg", errors.New("wild walrus")))
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	entry := make(map[string]interface{})
+	err = json.Unmarshal(b, &entry)
+	if err != nil {
+		t.Fatal("Unable to unmarshal formatted entry: ", err)
+	}
+
+	if entry["omg"] != "wild walrus" {
+		t.Fatal("Error field not set")
+	}
+}
+
+func TestFieldClashWithTime(t *testing.T) {
+	formatter := &JSONFormatter{}
+
+	b, err := formatter.Format(WithField("time", "right now!"))
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	entry := make(map[string]interface{})
+	err = json.Unmarshal(b, &entry)
+	if err != nil {
+		t.Fatal("Unable to unmarshal formatted entry: ", err)
+	}
+
+	if entry["fields.time"] != "right now!" {
+		t.Fatal("fields.time not set to original time field")
+	}
+
+	if entry["time"] != "0001-01-01T00:00:00Z" {
+		t.Fatal("time field not set to current time, was: ", entry["time"])
+	}
+}
+
+func TestFieldClashWithMsg(t *testing.T) {
+	formatter := &JSONFormatter{}
+
+	b, err := formatter.Format(WithField("msg", "something"))
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	entry := make(map[string]interface{})
+	err = json.Unmarshal(b, &entry)
+	if err != nil {
+		t.Fatal("Unable to unmarshal formatted entry: ", err)
+	}
+
+	if entry["fields.msg"] != "something" {
+		t.Fatal("fields.msg not set to original msg field")
+	}
+}
+
+func TestFieldClashWithLevel(t *testing.T) {
+	formatter := &JSONFormatter{}
+
+	b, err := formatter.Format(WithField("level", "something"))
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	entry := make(map[string]interface{})
+	err = json.Unmarshal(b, &entry)
+	if err != nil {
+		t.Fatal("Unable to unmarshal formatted entry: ", err)
+	}
+
+	if entry["fields.level"] != "something" {
+		t.Fatal("fields.level not set to original level field")
+	}
+}
+
+func TestJSONEntryEndsWithNewline(t *testing.T) {
+	formatter := &JSONFormatter{}
+
+	b, err := formatter.Format(WithField("level", "something"))
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	if b[len(b)-1] != '\n' {
+		t.Fatal("Expected JSON log entry to end with a newline")
+	}
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/logger.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/logger.go
@@ -1,0 +1,212 @@
+package logrus
+
+import (
+	"io"
+	"os"
+	"sync"
+)
+
+type Logger struct {
+	// The logs are `io.Copy`'d to this in a mutex. It's common to set this to a
+	// file, or leave it default which is `os.Stderr`. You can also set this to
+	// something more adventorous, such as logging to Kafka.
+	Out io.Writer
+	// Hooks for the logger instance. These allow firing events based on logging
+	// levels and log entries. For example, to send errors to an error tracking
+	// service, log to StatsD or dump the core on fatal errors.
+	Hooks LevelHooks
+	// All log entries pass through the formatter before logged to Out. The
+	// included formatters are `TextFormatter` and `JSONFormatter` for which
+	// TextFormatter is the default. In development (when a TTY is attached) it
+	// logs with colors, but to a file it wouldn't. You can easily implement your
+	// own that implements the `Formatter` interface, see the `README` or included
+	// formatters for examples.
+	Formatter Formatter
+	// The logging level the logger should log at. This is typically (and defaults
+	// to) `logrus.Info`, which allows Info(), Warn(), Error() and Fatal() to be
+	// logged. `logrus.Debug` is useful in
+	Level Level
+	// Used to sync writing to the log.
+	mu sync.Mutex
+}
+
+// Creates a new logger. Configuration should be set by changing `Formatter`,
+// `Out` and `Hooks` directly on the default logger instance. You can also just
+// instantiate your own:
+//
+//    var log = &Logger{
+//      Out: os.Stderr,
+//      Formatter: new(JSONFormatter),
+//      Hooks: make(LevelHooks),
+//      Level: logrus.DebugLevel,
+//    }
+//
+// It's recommended to make this a global instance called `log`.
+func New() *Logger {
+	return &Logger{
+		Out:       os.Stderr,
+		Formatter: new(TextFormatter),
+		Hooks:     make(LevelHooks),
+		Level:     InfoLevel,
+	}
+}
+
+// Adds a field to the log entry, note that you it doesn't log until you call
+// Debug, Print, Info, Warn, Fatal or Panic. It only creates a log entry.
+// If you want multiple fields, use `WithFields`.
+func (logger *Logger) WithField(key string, value interface{}) *Entry {
+	return NewEntry(logger).WithField(key, value)
+}
+
+// Adds a struct of fields to the log entry. All it does is call `WithField` for
+// each `Field`.
+func (logger *Logger) WithFields(fields Fields) *Entry {
+	return NewEntry(logger).WithFields(fields)
+}
+
+// Add an error as single field to the log entry.  All it does is call
+// `WithError` for the given `error`.
+func (logger *Logger) WithError(err error) *Entry {
+	return NewEntry(logger).WithError(err)
+}
+
+func (logger *Logger) Debugf(format string, args ...interface{}) {
+	if logger.Level >= DebugLevel {
+		NewEntry(logger).Debugf(format, args...)
+	}
+}
+
+func (logger *Logger) Infof(format string, args ...interface{}) {
+	if logger.Level >= InfoLevel {
+		NewEntry(logger).Infof(format, args...)
+	}
+}
+
+func (logger *Logger) Printf(format string, args ...interface{}) {
+	NewEntry(logger).Printf(format, args...)
+}
+
+func (logger *Logger) Warnf(format string, args ...interface{}) {
+	if logger.Level >= WarnLevel {
+		NewEntry(logger).Warnf(format, args...)
+	}
+}
+
+func (logger *Logger) Warningf(format string, args ...interface{}) {
+	if logger.Level >= WarnLevel {
+		NewEntry(logger).Warnf(format, args...)
+	}
+}
+
+func (logger *Logger) Errorf(format string, args ...interface{}) {
+	if logger.Level >= ErrorLevel {
+		NewEntry(logger).Errorf(format, args...)
+	}
+}
+
+func (logger *Logger) Fatalf(format string, args ...interface{}) {
+	if logger.Level >= FatalLevel {
+		NewEntry(logger).Fatalf(format, args...)
+	}
+	os.Exit(1)
+}
+
+func (logger *Logger) Panicf(format string, args ...interface{}) {
+	if logger.Level >= PanicLevel {
+		NewEntry(logger).Panicf(format, args...)
+	}
+}
+
+func (logger *Logger) Debug(args ...interface{}) {
+	if logger.Level >= DebugLevel {
+		NewEntry(logger).Debug(args...)
+	}
+}
+
+func (logger *Logger) Info(args ...interface{}) {
+	if logger.Level >= InfoLevel {
+		NewEntry(logger).Info(args...)
+	}
+}
+
+func (logger *Logger) Print(args ...interface{}) {
+	NewEntry(logger).Info(args...)
+}
+
+func (logger *Logger) Warn(args ...interface{}) {
+	if logger.Level >= WarnLevel {
+		NewEntry(logger).Warn(args...)
+	}
+}
+
+func (logger *Logger) Warning(args ...interface{}) {
+	if logger.Level >= WarnLevel {
+		NewEntry(logger).Warn(args...)
+	}
+}
+
+func (logger *Logger) Error(args ...interface{}) {
+	if logger.Level >= ErrorLevel {
+		NewEntry(logger).Error(args...)
+	}
+}
+
+func (logger *Logger) Fatal(args ...interface{}) {
+	if logger.Level >= FatalLevel {
+		NewEntry(logger).Fatal(args...)
+	}
+	os.Exit(1)
+}
+
+func (logger *Logger) Panic(args ...interface{}) {
+	if logger.Level >= PanicLevel {
+		NewEntry(logger).Panic(args...)
+	}
+}
+
+func (logger *Logger) Debugln(args ...interface{}) {
+	if logger.Level >= DebugLevel {
+		NewEntry(logger).Debugln(args...)
+	}
+}
+
+func (logger *Logger) Infoln(args ...interface{}) {
+	if logger.Level >= InfoLevel {
+		NewEntry(logger).Infoln(args...)
+	}
+}
+
+func (logger *Logger) Println(args ...interface{}) {
+	NewEntry(logger).Println(args...)
+}
+
+func (logger *Logger) Warnln(args ...interface{}) {
+	if logger.Level >= WarnLevel {
+		NewEntry(logger).Warnln(args...)
+	}
+}
+
+func (logger *Logger) Warningln(args ...interface{}) {
+	if logger.Level >= WarnLevel {
+		NewEntry(logger).Warnln(args...)
+	}
+}
+
+func (logger *Logger) Errorln(args ...interface{}) {
+	if logger.Level >= ErrorLevel {
+		NewEntry(logger).Errorln(args...)
+	}
+}
+
+func (logger *Logger) Fatalln(args ...interface{}) {
+	if logger.Level >= FatalLevel {
+		NewEntry(logger).Fatalln(args...)
+	}
+	os.Exit(1)
+}
+
+func (logger *Logger) Panicln(args ...interface{}) {
+	if logger.Level >= PanicLevel {
+		NewEntry(logger).Panicln(args...)
+	}
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/logrus.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/logrus.go
@@ -1,0 +1,98 @@
+package logrus
+
+import (
+	"fmt"
+	"log"
+)
+
+// Fields type, used to pass to `WithFields`.
+type Fields map[string]interface{}
+
+// Level type
+type Level uint8
+
+// Convert the Level to a string. E.g. PanicLevel becomes "panic".
+func (level Level) String() string {
+	switch level {
+	case DebugLevel:
+		return "debug"
+	case InfoLevel:
+		return "info"
+	case WarnLevel:
+		return "warning"
+	case ErrorLevel:
+		return "error"
+	case FatalLevel:
+		return "fatal"
+	case PanicLevel:
+		return "panic"
+	}
+
+	return "unknown"
+}
+
+// ParseLevel takes a string level and returns the Logrus log level constant.
+func ParseLevel(lvl string) (Level, error) {
+	switch lvl {
+	case "panic":
+		return PanicLevel, nil
+	case "fatal":
+		return FatalLevel, nil
+	case "error":
+		return ErrorLevel, nil
+	case "warn", "warning":
+		return WarnLevel, nil
+	case "info":
+		return InfoLevel, nil
+	case "debug":
+		return DebugLevel, nil
+	}
+
+	var l Level
+	return l, fmt.Errorf("not a valid logrus Level: %q", lvl)
+}
+
+// These are the different logging levels. You can set the logging level to log
+// on your instance of logger, obtained with `logrus.New()`.
+const (
+	// PanicLevel level, highest level of severity. Logs and then calls panic with the
+	// message passed to Debug, Info, ...
+	PanicLevel Level = iota
+	// FatalLevel level. Logs and then calls `os.Exit(1)`. It will exit even if the
+	// logging level is set to Panic.
+	FatalLevel
+	// ErrorLevel level. Logs. Used for errors that should definitely be noted.
+	// Commonly used for hooks to send errors to an error tracking service.
+	ErrorLevel
+	// WarnLevel level. Non-critical entries that deserve eyes.
+	WarnLevel
+	// InfoLevel level. General operational entries about what's going on inside the
+	// application.
+	InfoLevel
+	// DebugLevel level. Usually only enabled when debugging. Very verbose logging.
+	DebugLevel
+)
+
+// Won't compile if StdLogger can't be realized by a log.Logger
+var (
+	_ StdLogger = &log.Logger{}
+	_ StdLogger = &Entry{}
+	_ StdLogger = &Logger{}
+)
+
+// StdLogger is what your logrus-enabled library should take, that way
+// it'll accept a stdlib logger and a logrus logger. There's no standard
+// interface, this is the closest we get, unfortunately.
+type StdLogger interface {
+	Print(...interface{})
+	Printf(string, ...interface{})
+	Println(...interface{})
+
+	Fatal(...interface{})
+	Fatalf(string, ...interface{})
+	Fatalln(...interface{})
+
+	Panic(...interface{})
+	Panicf(string, ...interface{})
+	Panicln(...interface{})
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/logrus_test.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/logrus_test.go
@@ -1,0 +1,301 @@
+package logrus
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func LogAndAssertJSON(t *testing.T, log func(*Logger), assertions func(fields Fields)) {
+	var buffer bytes.Buffer
+	var fields Fields
+
+	logger := New()
+	logger.Out = &buffer
+	logger.Formatter = new(JSONFormatter)
+
+	log(logger)
+
+	err := json.Unmarshal(buffer.Bytes(), &fields)
+	assert.Nil(t, err)
+
+	assertions(fields)
+}
+
+func LogAndAssertText(t *testing.T, log func(*Logger), assertions func(fields map[string]string)) {
+	var buffer bytes.Buffer
+
+	logger := New()
+	logger.Out = &buffer
+	logger.Formatter = &TextFormatter{
+		DisableColors: true,
+	}
+
+	log(logger)
+
+	fields := make(map[string]string)
+	for _, kv := range strings.Split(buffer.String(), " ") {
+		if !strings.Contains(kv, "=") {
+			continue
+		}
+		kvArr := strings.Split(kv, "=")
+		key := strings.TrimSpace(kvArr[0])
+		val := kvArr[1]
+		if kvArr[1][0] == '"' {
+			var err error
+			val, err = strconv.Unquote(val)
+			assert.NoError(t, err)
+		}
+		fields[key] = val
+	}
+	assertions(fields)
+}
+
+func TestPrint(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Print("test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["msg"], "test")
+		assert.Equal(t, fields["level"], "info")
+	})
+}
+
+func TestInfo(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Info("test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["msg"], "test")
+		assert.Equal(t, fields["level"], "info")
+	})
+}
+
+func TestWarn(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Warn("test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["msg"], "test")
+		assert.Equal(t, fields["level"], "warning")
+	})
+}
+
+func TestInfolnShouldAddSpacesBetweenStrings(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Infoln("test", "test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["msg"], "test test")
+	})
+}
+
+func TestInfolnShouldAddSpacesBetweenStringAndNonstring(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Infoln("test", 10)
+	}, func(fields Fields) {
+		assert.Equal(t, fields["msg"], "test 10")
+	})
+}
+
+func TestInfolnShouldAddSpacesBetweenTwoNonStrings(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Infoln(10, 10)
+	}, func(fields Fields) {
+		assert.Equal(t, fields["msg"], "10 10")
+	})
+}
+
+func TestInfoShouldAddSpacesBetweenTwoNonStrings(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Infoln(10, 10)
+	}, func(fields Fields) {
+		assert.Equal(t, fields["msg"], "10 10")
+	})
+}
+
+func TestInfoShouldNotAddSpacesBetweenStringAndNonstring(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Info("test", 10)
+	}, func(fields Fields) {
+		assert.Equal(t, fields["msg"], "test10")
+	})
+}
+
+func TestInfoShouldNotAddSpacesBetweenStrings(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Info("test", "test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["msg"], "testtest")
+	})
+}
+
+func TestWithFieldsShouldAllowAssignments(t *testing.T) {
+	var buffer bytes.Buffer
+	var fields Fields
+
+	logger := New()
+	logger.Out = &buffer
+	logger.Formatter = new(JSONFormatter)
+
+	localLog := logger.WithFields(Fields{
+		"key1": "value1",
+	})
+
+	localLog.WithField("key2", "value2").Info("test")
+	err := json.Unmarshal(buffer.Bytes(), &fields)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "value2", fields["key2"])
+	assert.Equal(t, "value1", fields["key1"])
+
+	buffer = bytes.Buffer{}
+	fields = Fields{}
+	localLog.Info("test")
+	err = json.Unmarshal(buffer.Bytes(), &fields)
+	assert.Nil(t, err)
+
+	_, ok := fields["key2"]
+	assert.Equal(t, false, ok)
+	assert.Equal(t, "value1", fields["key1"])
+}
+
+func TestUserSuppliedFieldDoesNotOverwriteDefaults(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.WithField("msg", "hello").Info("test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["msg"], "test")
+	})
+}
+
+func TestUserSuppliedMsgFieldHasPrefix(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.WithField("msg", "hello").Info("test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["msg"], "test")
+		assert.Equal(t, fields["fields.msg"], "hello")
+	})
+}
+
+func TestUserSuppliedTimeFieldHasPrefix(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.WithField("time", "hello").Info("test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["fields.time"], "hello")
+	})
+}
+
+func TestUserSuppliedLevelFieldHasPrefix(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.WithField("level", 1).Info("test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["level"], "info")
+		assert.Equal(t, fields["fields.level"], 1.0) // JSON has floats only
+	})
+}
+
+func TestDefaultFieldsAreNotPrefixed(t *testing.T) {
+	LogAndAssertText(t, func(log *Logger) {
+		ll := log.WithField("herp", "derp")
+		ll.Info("hello")
+		ll.Info("bye")
+	}, func(fields map[string]string) {
+		for _, fieldName := range []string{"fields.level", "fields.time", "fields.msg"} {
+			if _, ok := fields[fieldName]; ok {
+				t.Fatalf("should not have prefixed %q: %v", fieldName, fields)
+			}
+		}
+	})
+}
+
+func TestDoubleLoggingDoesntPrefixPreviousFields(t *testing.T) {
+
+	var buffer bytes.Buffer
+	var fields Fields
+
+	logger := New()
+	logger.Out = &buffer
+	logger.Formatter = new(JSONFormatter)
+
+	llog := logger.WithField("context", "eating raw fish")
+
+	llog.Info("looks delicious")
+
+	err := json.Unmarshal(buffer.Bytes(), &fields)
+	assert.NoError(t, err, "should have decoded first message")
+	assert.Equal(t, len(fields), 4, "should only have msg/time/level/context fields")
+	assert.Equal(t, fields["msg"], "looks delicious")
+	assert.Equal(t, fields["context"], "eating raw fish")
+
+	buffer.Reset()
+
+	llog.Warn("omg it is!")
+
+	err = json.Unmarshal(buffer.Bytes(), &fields)
+	assert.NoError(t, err, "should have decoded second message")
+	assert.Equal(t, len(fields), 4, "should only have msg/time/level/context fields")
+	assert.Equal(t, fields["msg"], "omg it is!")
+	assert.Equal(t, fields["context"], "eating raw fish")
+	assert.Nil(t, fields["fields.msg"], "should not have prefixed previous `msg` entry")
+
+}
+
+func TestConvertLevelToString(t *testing.T) {
+	assert.Equal(t, "debug", DebugLevel.String())
+	assert.Equal(t, "info", InfoLevel.String())
+	assert.Equal(t, "warning", WarnLevel.String())
+	assert.Equal(t, "error", ErrorLevel.String())
+	assert.Equal(t, "fatal", FatalLevel.String())
+	assert.Equal(t, "panic", PanicLevel.String())
+}
+
+func TestParseLevel(t *testing.T) {
+	l, err := ParseLevel("panic")
+	assert.Nil(t, err)
+	assert.Equal(t, PanicLevel, l)
+
+	l, err = ParseLevel("fatal")
+	assert.Nil(t, err)
+	assert.Equal(t, FatalLevel, l)
+
+	l, err = ParseLevel("error")
+	assert.Nil(t, err)
+	assert.Equal(t, ErrorLevel, l)
+
+	l, err = ParseLevel("warn")
+	assert.Nil(t, err)
+	assert.Equal(t, WarnLevel, l)
+
+	l, err = ParseLevel("warning")
+	assert.Nil(t, err)
+	assert.Equal(t, WarnLevel, l)
+
+	l, err = ParseLevel("info")
+	assert.Nil(t, err)
+	assert.Equal(t, InfoLevel, l)
+
+	l, err = ParseLevel("debug")
+	assert.Nil(t, err)
+	assert.Equal(t, DebugLevel, l)
+
+	l, err = ParseLevel("invalid")
+	assert.Equal(t, "not a valid logrus Level: \"invalid\"", err.Error())
+}
+
+func TestGetSetLevelRace(t *testing.T) {
+	wg := sync.WaitGroup{}
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				SetLevel(InfoLevel)
+			} else {
+				GetLevel()
+			}
+		}(i)
+
+	}
+	wg.Wait()
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/terminal_bsd.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/terminal_bsd.go
@@ -1,0 +1,9 @@
+// +build darwin freebsd openbsd netbsd dragonfly
+
+package logrus
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA
+
+type Termios syscall.Termios

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/terminal_linux.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/terminal_linux.go
@@ -1,0 +1,12 @@
+// Based on ssh/terminal:
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package logrus
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TCGETS
+
+type Termios syscall.Termios

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/terminal_notwindows.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/terminal_notwindows.go
@@ -1,0 +1,21 @@
+// Based on ssh/terminal:
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux darwin freebsd openbsd netbsd dragonfly
+
+package logrus
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// IsTerminal returns true if stderr's file descriptor is a terminal.
+func IsTerminal() bool {
+	fd := syscall.Stderr
+	var termios Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/terminal_solaris.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/terminal_solaris.go
@@ -1,0 +1,15 @@
+// +build solaris
+
+package logrus
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal() bool {
+	_, err := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TCGETA)
+	return err == nil
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/terminal_windows.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/terminal_windows.go
@@ -1,0 +1,27 @@
+// Based on ssh/terminal:
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package logrus
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+var (
+	procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
+)
+
+// IsTerminal returns true if stderr's file descriptor is a terminal.
+func IsTerminal() bool {
+	fd := syscall.Stderr
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/text_formatter.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/text_formatter.go
@@ -1,0 +1,161 @@
+package logrus
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	nocolor = 0
+	red     = 31
+	green   = 32
+	yellow  = 33
+	blue    = 34
+	gray    = 37
+)
+
+var (
+	baseTimestamp time.Time
+	isTerminal    bool
+)
+
+func init() {
+	baseTimestamp = time.Now()
+	isTerminal = IsTerminal()
+}
+
+func miniTS() int {
+	return int(time.Since(baseTimestamp) / time.Second)
+}
+
+type TextFormatter struct {
+	// Set to true to bypass checking for a TTY before outputting colors.
+	ForceColors bool
+
+	// Force disabling colors.
+	DisableColors bool
+
+	// Disable timestamp logging. useful when output is redirected to logging
+	// system that already adds timestamps.
+	DisableTimestamp bool
+
+	// Enable logging the full timestamp when a TTY is attached instead of just
+	// the time passed since beginning of execution.
+	FullTimestamp bool
+
+	// TimestampFormat to use for display when a full timestamp is printed
+	TimestampFormat string
+
+	// The fields are sorted by default for a consistent output. For applications
+	// that log extremely frequently and don't use the JSON formatter this may not
+	// be desired.
+	DisableSorting bool
+}
+
+func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
+	var keys []string = make([]string, 0, len(entry.Data))
+	for k := range entry.Data {
+		keys = append(keys, k)
+	}
+
+	if !f.DisableSorting {
+		sort.Strings(keys)
+	}
+
+	b := &bytes.Buffer{}
+
+	prefixFieldClashes(entry.Data)
+
+	isColorTerminal := isTerminal && (runtime.GOOS != "windows")
+	isColored := (f.ForceColors || isColorTerminal) && !f.DisableColors
+
+	timestampFormat := f.TimestampFormat
+	if timestampFormat == "" {
+		timestampFormat = DefaultTimestampFormat
+	}
+	if isColored {
+		f.printColored(b, entry, keys, timestampFormat)
+	} else {
+		if !f.DisableTimestamp {
+			f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat))
+		}
+		f.appendKeyValue(b, "level", entry.Level.String())
+		if entry.Message != "" {
+			f.appendKeyValue(b, "msg", entry.Message)
+		}
+		for _, key := range keys {
+			f.appendKeyValue(b, key, entry.Data[key])
+		}
+	}
+
+	b.WriteByte('\n')
+	return b.Bytes(), nil
+}
+
+func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []string, timestampFormat string) {
+	var levelColor int
+	switch entry.Level {
+	case DebugLevel:
+		levelColor = gray
+	case WarnLevel:
+		levelColor = yellow
+	case ErrorLevel, FatalLevel, PanicLevel:
+		levelColor = red
+	default:
+		levelColor = blue
+	}
+
+	levelText := strings.ToUpper(entry.Level.String())[0:4]
+
+	if !f.FullTimestamp {
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %-44s ", levelColor, levelText, miniTS(), entry.Message)
+	} else {
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ", levelColor, levelText, entry.Time.Format(timestampFormat), entry.Message)
+	}
+	for _, k := range keys {
+		v := entry.Data[k]
+		fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=%+v", levelColor, k, v)
+	}
+}
+
+func needsQuoting(text string) bool {
+	for _, ch := range text {
+		if !((ch >= 'a' && ch <= 'z') ||
+			(ch >= 'A' && ch <= 'Z') ||
+			(ch >= '0' && ch <= '9') ||
+			ch == '-' || ch == '.') {
+			return false
+		}
+	}
+	return true
+}
+
+func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interface{}) {
+
+	b.WriteString(key)
+	b.WriteByte('=')
+
+	switch value := value.(type) {
+	case string:
+		if needsQuoting(value) {
+			b.WriteString(value)
+		} else {
+			fmt.Fprintf(b, "%q", value)
+		}
+	case error:
+		errmsg := value.Error()
+		if needsQuoting(errmsg) {
+			b.WriteString(errmsg)
+		} else {
+			fmt.Fprintf(b, "%q", value)
+		}
+	default:
+		fmt.Fprint(b, value)
+	}
+
+	b.WriteByte(' ')
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/text_formatter_test.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/text_formatter_test.go
@@ -1,0 +1,61 @@
+package logrus
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestQuoting(t *testing.T) {
+	tf := &TextFormatter{DisableColors: true}
+
+	checkQuoting := func(q bool, value interface{}) {
+		b, _ := tf.Format(WithField("test", value))
+		idx := bytes.Index(b, ([]byte)("test="))
+		cont := bytes.Contains(b[idx+5:], []byte{'"'})
+		if cont != q {
+			if q {
+				t.Errorf("quoting expected for: %#v", value)
+			} else {
+				t.Errorf("quoting not expected for: %#v", value)
+			}
+		}
+	}
+
+	checkQuoting(false, "abcd")
+	checkQuoting(false, "v1.0")
+	checkQuoting(false, "1234567890")
+	checkQuoting(true, "/foobar")
+	checkQuoting(true, "x y")
+	checkQuoting(true, "x,y")
+	checkQuoting(false, errors.New("invalid"))
+	checkQuoting(true, errors.New("invalid argument"))
+}
+
+func TestTimestampFormat(t *testing.T) {
+	checkTimeStr := func(format string) {
+		customFormatter := &TextFormatter{DisableColors: true, TimestampFormat: format}
+		customStr, _ := customFormatter.Format(WithField("test", "test"))
+		timeStart := bytes.Index(customStr, ([]byte)("time="))
+		timeEnd := bytes.Index(customStr, ([]byte)("level="))
+		timeStr := customStr[timeStart+5 : timeEnd-1]
+		if timeStr[0] == '"' && timeStr[len(timeStr)-1] == '"' {
+			timeStr = timeStr[1 : len(timeStr)-1]
+		}
+		if format == "" {
+			format = time.RFC3339
+		}
+		_, e := time.Parse(format, (string)(timeStr))
+		if e != nil {
+			t.Errorf("time string \"%s\" did not match provided time format \"%s\": %s", timeStr, format, e)
+		}
+	}
+
+	checkTimeStr("2006-01-02T15:04:05.000000000Z07:00")
+	checkTimeStr("Mon Jan _2 15:04:05 2006")
+	checkTimeStr("")
+}
+
+// TODO add tests for sorting etc., this requires a parser for the text
+// formatter output.

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/writer.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/writer.go
@@ -1,0 +1,31 @@
+package logrus
+
+import (
+	"bufio"
+	"io"
+	"runtime"
+)
+
+func (logger *Logger) Writer() *io.PipeWriter {
+	reader, writer := io.Pipe()
+
+	go logger.writerScanner(reader)
+	runtime.SetFinalizer(writer, writerFinalizer)
+
+	return writer
+}
+
+func (logger *Logger) writerScanner(reader *io.PipeReader) {
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		logger.Print(scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		logger.Errorf("Error while reading from Writer: %s", err)
+	}
+	reader.Close()
+}
+
+func writerFinalizer(writer *io.PipeWriter) {
+	writer.Close()
+}

--- a/actions/load.go
+++ b/actions/load.go
@@ -14,7 +14,7 @@ import (
 )
 
 func LoadActionDefinition(actionName string) (*def.Action, []string, error) {
-	log.WithField("=>", actionName).Info("Reading action definition file")
+	log.WithField("file", actionName).Info("Reading action definition file")
 	act := strings.Split(actionName, "_")
 	action := def.BlankAction()
 
@@ -38,7 +38,7 @@ func LoadActionDefinition(actionName string) (*def.Action, []string, error) {
 
 func MockAction(act string) (*def.Action, []string) {
 	action := def.BlankAction()
-	log.WithField("=>", act).Debug("Mocking action")
+	log.WithField("file", act).Debug("Mocking action")
 	return action, []string{}
 }
 

--- a/actions/log.go
+++ b/actions/log.go
@@ -1,7 +1,0 @@
-package actions
-
-import (
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
-)
-
-var logger = AddLogger("actions")

--- a/actions/manage.go
+++ b/actions/manage.go
@@ -13,13 +13,17 @@ import (
 	"github.com/eris-ltd/eris-cli/perform"
 	"github.com/eris-ltd/eris-cli/util"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 )
 
 func NewAction(do *definitions.Do) error {
 	do.Name = strings.Join(do.Operations.Args, "_")
 	path := filepath.Join(ActionsPath, do.Name)
-	logger.Debugf("NewActionRaw to MockAction =>\t%v:%s\n", do.Name, path)
+	log.WithFields(log.Fields{
+		"action": do.Name,
+		"file":   path,
+	}).Debug("Creating new action (mocking)")
 	act, _ := MockAction(do.Name)
 	if err := WriteActionDefinitionFile(act, path); err != nil {
 		return err
@@ -52,8 +56,8 @@ func ImportAction(do *definitions.Do) error {
 			return err
 		}
 
-		if logger.Level > 0 {
-			err = ipfs.GetFromIPFS(s[1], fileName, "", logger.Writer)
+		if log.GetLevel() > 0 {
+			err = ipfs.GetFromIPFS(s[1], fileName, "", os.Stdout)
 		} else {
 			err = ipfs.GetFromIPFS(s[1], fileName, "", bytes.NewBuffer([]byte{}))
 		}
@@ -65,11 +69,11 @@ func ImportAction(do *definitions.Do) error {
 	}
 
 	if strings.Contains(s[0], "github") {
-		logger.Println("https://twitter.com/ryaneshea/status/595957712040628224")
+		log.Warn("https://twitter.com/ryaneshea/status/595957712040628224")
 		return nil
 	}
 
-	fmt.Println("I do not know how to get that file. Sorry.")
+	log.Warn("Failed to get that file. Sorry")
 	return nil
 }
 
@@ -94,13 +98,13 @@ func ExportAction(do *definitions.Do) error {
 		return err
 	}
 	do.Result = hash
-	logger.Println(hash)
+	log.Warn(hash)
 	return nil
 }
 
 func EditAction(do *definitions.Do) error {
 	actDefFile := util.GetFileByNameAndType("actions", do.Name)
-	logger.Infof("Editing Action =>\t\t%s\n", actDefFile)
+	log.WithField("=>", actDefFile).Info("Editing action")
 	do.Result = "success"
 	return Editor(actDefFile)
 }
@@ -114,17 +118,17 @@ func RenameAction(do *definitions.Do) error {
 	do.NewName = strings.Replace(do.NewName, " ", "_", -1)
 	act, _, err := LoadActionDefinition(do.Name)
 	if err != nil {
-		logger.Debugf("About to fail. Name:NewName =>\t%s:%s", do.Name, do.NewName)
+		log.WithField("=>", fmt.Sprintf("%s:%s", do.Name, do.NewName)).Debug("Failed renaming action")
 		return err
 	}
 
 	do.Name = strings.Replace(do.Name, " ", "_", -1)
-	logger.Debugf("About to find defFile =>\t%s\n", do.Name)
+	log.WithField("file", do.Name).Debug("Finding action definition file")
 	oldFile := util.GetFileByNameAndType("actions", do.Name)
 	if oldFile == "" {
 		return fmt.Errorf("Could not find that action definition file.")
 	}
-	logger.Debugf("Found defFile at =>\t\t%s\n", oldFile)
+	log.WithField("file", oldFile).Debug("Found action definition file")
 
 	if !strings.Contains(oldFile, ActionsPath) {
 		oldFile = filepath.Join(ActionsPath, oldFile) + ".toml"
@@ -141,19 +145,22 @@ func RenameAction(do *definitions.Do) error {
 	}
 
 	if newFile == oldFile {
-		logger.Infoln("Those are the same file. Not renaming")
+		log.Info("Not renaming the same file")
 		return nil
 	}
 
 	act.Name = strings.Replace(newNameBase, "_", " ", -1)
 
-	logger.Debugf("About to write new def file =>\t%s:%s\n", act.Name, newFile)
+	log.WithFields(log.Fields{
+		"old": act.Name,
+		"new": newFile,
+	}).Debug("Writing new action definition file")
 	err = WriteActionDefinitionFile(act, newFile)
 	if err != nil {
 		return err
 	}
 
-	logger.Debugf("Removing old file =>\t\t%s\n", oldFile)
+	log.WithField("file", oldFile).Debug("Removing old file")
 	os.Remove(oldFile)
 
 	return nil
@@ -171,7 +178,7 @@ func RmAction(do *definitions.Do) error {
 			oldFile = filepath.Join(ActionsPath, oldFile) + ".toml"
 		}
 
-		logger.Debugf("Removing file =>\t\t%s\n", oldFile)
+		log.WithField("file", oldFile).Debug("Removing file")
 		os.Remove(oldFile)
 	}
 	return nil
@@ -185,8 +192,8 @@ func exportFile(actionName string) (string, error) {
 	}
 
 	var hash string
-	if logger.Level > 0 {
-		hash, err = ipfs.SendToIPFS(fileName, "", logger.Writer)
+	if log.GetLevel() > 0 {
+		hash, err = ipfs.SendToIPFS(fileName, "", os.Stdout)
 	} else {
 		hash, err = ipfs.SendToIPFS(fileName, "", bytes.NewBuffer([]byte{}))
 	}

--- a/actions/manage.go
+++ b/actions/manage.go
@@ -104,7 +104,7 @@ func ExportAction(do *definitions.Do) error {
 
 func EditAction(do *definitions.Do) error {
 	actDefFile := util.GetFileByNameAndType("actions", do.Name)
-	log.WithField("=>", actDefFile).Info("Editing action")
+	log.WithField("file", actDefFile).Info("Editing action")
 	do.Result = "success"
 	return Editor(actDefFile)
 }
@@ -118,7 +118,10 @@ func RenameAction(do *definitions.Do) error {
 	do.NewName = strings.Replace(do.NewName, " ", "_", -1)
 	act, _, err := LoadActionDefinition(do.Name)
 	if err != nil {
-		log.WithField("=>", fmt.Sprintf("%s:%s", do.Name, do.NewName)).Debug("Failed renaming action")
+		log.WithFields(log.Fields{
+			"from": do.Name,
+			"to":   do.NewName,
+		}).Debug("Failed renaming action")
 		return err
 	}
 

--- a/actions/perform.go
+++ b/actions/perform.go
@@ -69,7 +69,7 @@ func StartServicesAndChains(do *definitions.Do) error {
 }
 
 func PerformCommand(action *definitions.Action, actionVars []string, quiet bool) error {
-	log.WithField("=>", action.Name).Info("Performing action")
+	log.WithField("action", action.Name).Info("Performing action")
 
 	dir, err := os.Getwd()
 	if err != nil {

--- a/actions/writer.go
+++ b/actions/writer.go
@@ -9,6 +9,7 @@ import (
 	def "github.com/eris-ltd/eris-cli/definitions"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/BurntSushi/toml"
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/gopkg.in/yaml.v2"
 )
 
@@ -22,7 +23,10 @@ func WriteActionDefinitionFile(actDef *def.Action, fileName string) error {
 		fileName = fileName + ".toml"
 	}
 
-	logger.Debugf("Writing action def file =>\t%s:%s\n", actDef.Name, fileName)
+	log.WithFields(log.Fields{
+		"action": actDef.Name,
+		"file":   fileName,
+	}).Debug("Writing action definition file")
 
 	writer, err := os.Create(fileName)
 	defer writer.Close()

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -34,9 +34,9 @@ func TestMain(m *testing.M) {
 	runtime.GOMAXPROCS(1)
 	log.SetFormatter(logger.ErisFormatter{})
 
-	// log.SetLevel(log.ErrorLevel)
+	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)
-	log.SetLevel(log.DebugLevel)
+	// log.SetLevel(log.DebugLevel)
 
 	tests.IfExit(tests.TestsInit("chain"))
 	log.Info("Test init completed. Starting main test sequence now")

--- a/chains/load.go
+++ b/chains/load.go
@@ -1,12 +1,16 @@
 package chains
 
 import (
+	"fmt"
+
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
+
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 func IsChainExisting(chain *definitions.Chain) bool {
-	logger.Debugf("Does Chain Exist? =>\t\t%s:%d\n", chain.Name, chain.Operations.ContainerNumber)
+	log.WithField("=>", fmt.Sprintf("%s:%d", chain.Name, chain.Operations.ContainerNumber)).Debug("Checking chain existing")
 	cName := util.FindChainContainer(chain.Name, chain.Operations.ContainerNumber, true)
 	if cName == nil {
 		return false
@@ -16,11 +20,11 @@ func IsChainExisting(chain *definitions.Chain) bool {
 }
 
 func IsChainRunning(chain *definitions.Chain) bool {
+	log.WithField("=>", fmt.Sprintf("%s:%d", chain.Name, chain.Operations.ContainerNumber)).Debug("Checking chain running")
 	cName := util.FindChainContainer(chain.Name, chain.Operations.ContainerNumber, false)
 	if cName == nil {
 		return false
 	}
 	chain.Operations.SrvContainerID = cName.ContainerID
 	return true
-
 }

--- a/chains/log.go
+++ b/chains/log.go
@@ -1,7 +1,0 @@
-package chains
-
-import (
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
-)
-
-var logger = AddLogger("chains")

--- a/chains/writer.go
+++ b/chains/writer.go
@@ -9,6 +9,8 @@ import (
 	def "github.com/eris-ltd/eris-cli/definitions"
 	srv "github.com/eris-ltd/eris-cli/services"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/BurntSushi/toml"
@@ -72,7 +74,7 @@ func MakeGenesisFile(do *def.Do) error {
 	doThr.Operations.ContainerNumber = 1
 	doThr.Operations.PublishAllPorts = true
 
-	logger.Infof("Starting chain from MakeGenesisFile =>\t%s\n", doThr.Name)
+	log.WithField("=>", doThr.Name).Info("Making genesis.json file. Starting chain")
 	if er := StartChain(doThr); er != nil {
 		return fmt.Errorf("error starting chain %v\n", er)
 	}
@@ -83,7 +85,8 @@ func MakeGenesisFile(do *def.Do) error {
 	// pipe this output to /chains/chainName/genesis.json
 	err := ExecChain(doThr)
 	if err != nil {
-		logger.Printf("exec chain err: %v\nCleaning up...\n", err)
+		log.Warnf("Executing chain error: %v", err)
+		log.Warn("Cleaning up")
 		doThr.Rm = true
 		doThr.RmD = true
 		if err := CleanUp(doThr); err != nil {

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -5,12 +5,13 @@ import (
 	"os"
 	"testing"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	def "github.com/eris-ltd/eris-cli/definitions"
+	"github.com/eris-ltd/eris-cli/logger"
 	srv "github.com/eris-ltd/eris-cli/services"
 	tests "github.com/eris-ltd/eris-cli/testutils"
 	"github.com/eris-ltd/eris-cli/util"
 
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient"
 )
 
@@ -18,7 +19,6 @@ var DEAD bool // XXX: don't double panic (TODO: Flushing twice blocks)
 
 func fatal(t *testing.T, err error) {
 	if !DEAD {
-		log.Flush()
 		tests.TestsTearDown()
 		DEAD = true
 		panic(err)
@@ -26,14 +26,11 @@ func fatal(t *testing.T, err error) {
 }
 
 func TestMain(m *testing.M) {
-	var logLevel log.LogLevel
+	log.SetFormatter(logger.ErisFormatter{})
 
-	logLevel = 0
-	// logLevel = 1
-	// logLevel = 3
-
-	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
-
+	log.SetLevel(log.ErrorLevel)
+	// log.SetLevel(log.InfoLevel)
+	// log.SetLevel(log.DebugLevel)
 	tests.IfExit(testsInit())
 
 	exitCode := m.Run()
@@ -144,10 +141,10 @@ func testStartService(t *testing.T, serviceName string, publishAll bool) {
 	do.Operations.Args = []string{serviceName}
 	do.Operations.ContainerNumber = 1 //util.AutoMagic(0, "service", true)
 	do.Operations.PublishAllPorts = publishAll
-	logger.Debugf("Starting service (via tests) =>\t%s:%d\n", serviceName, do.Operations.ContainerNumber)
+	log.WithField("=>", fmt.Sprintf("%s:%d", serviceName, do.Operations.ContainerNumber)).Debug("Starting service (from tests)")
 	e := srv.StartService(do)
 	if e != nil {
-		logger.Infof("Error starting service =>\t%v\n", e)
+		log.Infof("Error starting service: %v", e)
 		fatal(t, e)
 	}
 
@@ -161,27 +158,39 @@ func testExistAndRun(t *testing.T, servName string, containerNumber int, toExist
 	}
 }
 
-//[zr] TODO move to testings pacakge...wait with [pv] done with moving to testutils
-//could also refactor this to use labels && be more generalized...
+//[zr] TODO move to testings package
 func testNumbersExistAndRun(t *testing.T, servName string, containerExist, containerRun int) {
-	logger.Infof("\nTesting number of (%s) containers. Existing? (%d) and Running? (%d)\n", servName, containerExist, containerRun)
+	log.WithFields(log.Fields{
+		"=>":        servName,
+		"existing#": containerExist,
+		"running#":  containerRun,
+	}).Info("Checking number of containers for")
 
-	logger.Debugf("Checking Existing Containers =>\t%s\n", servName)
+	log.WithField("=>", servName).Debug("Checking existing containers for")
 	exist := util.HowManyContainersExisting(servName, "service")
-	logger.Debugf("Checking Running Containers =>\t%s\n", servName)
+
+	log.WithField("=>", servName).Debug("Checking running containers for")
 	run := util.HowManyContainersRunning(servName, "service")
 
 	if exist != containerExist {
-		logger.Printf("Wrong number of containers existing for service (%s). Expected (%d). Got (%d).\n", servName, containerExist, exist)
+		log.WithFields(log.Fields{
+			"name":     servName,
+			"expected": containerExist,
+			"got":      exist,
+		}).Error("Wrong number of existing containers")
 		fatal(t, nil)
 	}
 
 	if run != containerRun {
-		logger.Printf("Wrong number of containers running for service (%s). Expected (%d). Got (%d).\n", servName, containerRun, run)
+		log.WithFields(log.Fields{
+			"name":     servName,
+			"expected": containerExist,
+			"got":      run,
+		}).Error("Wrong number of running containers")
 		fatal(t, nil)
 	}
 
-	logger.Infoln("All good.\n")
+	log.Info("All good")
 }
 
 func testsInit() error {

--- a/clean/log.go
+++ b/clean/log.go
@@ -1,7 +1,0 @@
-package clean
-
-import (
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
-)
-
-var logger = AddLogger("clean")

--- a/commands/actions.go
+++ b/commands/actions.go
@@ -7,6 +7,8 @@ import (
 	"github.com/eris-ltd/eris-cli/util"
 
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
 )
 
@@ -178,7 +180,7 @@ func ListActions(cmd *cobra.Command, args []string) {
 		return
 	}
 	for _, s := range strings.Split(do.Result, "\n") {
-		logger.Println(strings.Replace(s, "_", " ", -1))
+		log.Println(strings.Replace(s, "_", " ", -1))
 	}
 }
 

--- a/commands/actions.go
+++ b/commands/actions.go
@@ -6,8 +6,8 @@ import (
 	act "github.com/eris-ltd/eris-cli/actions"
 	"github.com/eris-ltd/eris-cli/util"
 
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
 )
@@ -180,7 +180,7 @@ func ListActions(cmd *cobra.Command, args []string) {
 		return
 	}
 	for _, s := range strings.Split(do.Result, "\n") {
-		log.Println(strings.Replace(s, "_", " ", -1))
+		log.Warn(strings.Replace(s, "_", " ", -1))
 	}
 }
 

--- a/commands/contracts.go
+++ b/commands/contracts.go
@@ -6,6 +6,8 @@ import (
 	"github.com/eris-ltd/eris-cli/contracts"
 
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
 )
 
@@ -137,7 +139,7 @@ func ContractsExport(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "eq", cmd, args))
 	do.Name = args[0]
 	IfExit(contracts.PutPackage(do))
-	logger.Println(do.Result)
+	log.Println(do.Result)
 }
 
 func ContractsTest(cmd *cobra.Command, args []string) {

--- a/commands/contracts.go
+++ b/commands/contracts.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/eris-ltd/eris-cli/contracts"
 
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
 )
@@ -139,7 +139,7 @@ func ContractsExport(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "eq", cmd, args))
 	do.Name = args[0]
 	IfExit(contracts.PutPackage(do))
-	log.Println(do.Result)
+	log.Warn(do.Result)
 }
 
 func ContractsTest(cmd *cobra.Command, args []string) {

--- a/commands/eris.go
+++ b/commands/eris.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/eris-ltd/eris-cli/config"
 	"github.com/eris-ltd/eris-cli/definitions"
+	"github.com/eris-ltd/eris-cli/logger"
 	"github.com/eris-ltd/eris-cli/util"
 	"github.com/eris-ltd/eris-cli/version"
 
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/ipfs"
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
 )
 
@@ -32,13 +33,14 @@ Made with <3 by Eris Industries.
 Complete documentation is available at https://docs.erisindustries.com
 ` + "\nVersion:\n  " + VERSION,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		var logLevel log.LogLevel
+		log.SetFormatter(logger.ErisFormatter{})
+
+		log.SetLevel(log.WarnLevel)
 		if do.Verbose {
-			logLevel = 2
+			log.SetLevel(log.InfoLevel)
 		} else if do.Debug {
-			logLevel = 3
+			log.SetLevel(log.DebugLevel)
 		}
-		log.SetLoggers(logLevel, config.GlobalConfig.Writer, config.GlobalConfig.ErrorWriter)
 
 		ipfs.IpfsHost = config.GlobalConfig.Config.IpfsHost
 
@@ -53,9 +55,8 @@ Complete documentation is available at https://docs.erisindustries.com
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		err := config.SaveGlobalConfig(config.GlobalConfig.Config)
 		if err != nil {
-			logger.Errorln(err)
+			log.Errorln(err)
 		}
-		log.Flush()
 	},
 }
 

--- a/commands/files.go
+++ b/commands/files.go
@@ -3,8 +3,8 @@ package commands
 import (
 	"github.com/eris-ltd/eris-cli/files"
 
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
 )
 
@@ -127,7 +127,7 @@ func FilesPut(cmd *cobra.Command, args []string) {
 	do.Name = args[0]
 	err := files.PutFiles(do)
 	IfExit(err)
-	log.Println(do.Result)
+	log.Warn(do.Result)
 }
 
 func FilesPin(cmd *cobra.Command, args []string) {
@@ -142,7 +142,7 @@ func FilesPin(cmd *cobra.Command, args []string) {
 	}
 	err := files.PinFiles(do)
 	IfExit(err)
-	log.Println(do.Result)
+	log.Warn(do.Result)
 }
 
 func FilesCat(cmd *cobra.Command, args []string) {
@@ -153,7 +153,7 @@ func FilesCat(cmd *cobra.Command, args []string) {
 	do.Name = args[0]
 	err := files.CatFiles(do)
 	IfExit(err)
-	log.Println(do.Result)
+	log.Warn(do.Result)
 
 }
 
@@ -165,11 +165,11 @@ func FilesList(cmd *cobra.Command, args []string) {
 	do.Name = args[0]
 	err := files.ListFiles(do)
 	IfExit(err)
-	log.Println(do.Result)
+	log.Warn(do.Result)
 }
 
 func FilesManageCached(cmd *cobra.Command, args []string) {
 	err := files.ManagePinned(do)
 	IfExit(err)
-	log.Println(do.Result)
+	log.Warn(do.Result)
 }

--- a/commands/files.go
+++ b/commands/files.go
@@ -4,6 +4,7 @@ import (
 	"github.com/eris-ltd/eris-cli/files"
 
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
 )
 
@@ -126,7 +127,7 @@ func FilesPut(cmd *cobra.Command, args []string) {
 	do.Name = args[0]
 	err := files.PutFiles(do)
 	IfExit(err)
-	logger.Println(do.Result)
+	log.Println(do.Result)
 }
 
 func FilesPin(cmd *cobra.Command, args []string) {
@@ -141,7 +142,7 @@ func FilesPin(cmd *cobra.Command, args []string) {
 	}
 	err := files.PinFiles(do)
 	IfExit(err)
-	logger.Println(do.Result)
+	log.Println(do.Result)
 }
 
 func FilesCat(cmd *cobra.Command, args []string) {
@@ -152,7 +153,7 @@ func FilesCat(cmd *cobra.Command, args []string) {
 	do.Name = args[0]
 	err := files.CatFiles(do)
 	IfExit(err)
-	logger.Println(do.Result)
+	log.Println(do.Result)
 
 }
 
@@ -164,11 +165,11 @@ func FilesList(cmd *cobra.Command, args []string) {
 	do.Name = args[0]
 	err := files.ListFiles(do)
 	IfExit(err)
-	logger.Println(do.Result)
+	log.Println(do.Result)
 }
 
 func FilesManageCached(cmd *cobra.Command, args []string) {
 	err := files.ManagePinned(do)
 	IfExit(err)
-	logger.Println(do.Result)
+	log.Println(do.Result)
 }

--- a/commands/log.go
+++ b/commands/log.go
@@ -1,7 +1,0 @@
-package commands
-
-import (
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
-)
-
-var logger = AddLogger("commands")

--- a/commands/update.go
+++ b/commands/update.go
@@ -7,8 +7,9 @@ import (
 )
 
 var Update = &cobra.Command{
-	Use:   "update",
-	Short: "Update the eris tool.",
+	Use:     "update",
+	Aliases: []string{"upgrade"},
+	Short:   "Update the eris tool.",
 	Long: `Fetch the latest version (master branch by default)
 and re-install eris; requires git and go to be installed.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"fmt"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
 )
 
@@ -24,8 +24,8 @@ func addVerSionFlags() {
 
 func DisplayVersion(cmd *cobra.Command, args []string) {
 	if !quiet {
-		log.Println("Eris CLI Version: " + VERSION)
+		fmt.Println("Eris CLI Version: " + VERSION)
 	} else {
-		log.Println(VERSION)
+		fmt.Println(VERSION)
 	}
 }

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/cobra"
 )
 
@@ -23,8 +24,8 @@ func addVerSionFlags() {
 
 func DisplayVersion(cmd *cobra.Command, args []string) {
 	if !quiet {
-		logger.Println("Eris CLI Version: " + VERSION)
+		log.Println("Eris CLI Version: " + VERSION)
 	} else {
-		logger.Println(VERSION)
+		log.Println(VERSION)
 	}
 }

--- a/contracts/contracts_test.go
+++ b/contracts/contracts_test.go
@@ -4,25 +4,24 @@ import (
 	"os"
 	"testing"
 
+	"github.com/eris-ltd/eris-cli/logger"
 	tests "github.com/eris-ltd/eris-cli/testutils"
 
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	var logLevel log.LogLevel
+	log.SetFormatter(logger.ErisFormatter{})
 
-	logLevel = 0
-	// logLevel = 1
-	// logLevel = 2
-
-	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
+	log.SetLevel(log.ErrorLevel)
+	// log.SetLevel(log.InfoLevel)
+	// log.SetLevel(log.DebugLevel)
 
 	tests.IfExit(testsInit())
 
 	exitCode := m.Run()
 
-	logger.Infoln("Commensing with Tests Tear Down.")
+	log.Info("Tearing tests down")
 	if os.Getenv("TEST_IN_CIRCLE") != "true" {
 		tests.IfExit(tests.TestsTearDown())
 	}

--- a/contracts/log.go
+++ b/contracts/log.go
@@ -1,7 +1,0 @@
-package contracts
-
-import (
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
-)
-
-var logger = AddLogger("contracts")

--- a/contracts/operate.go
+++ b/contracts/operate.go
@@ -14,20 +14,24 @@ import (
 	"github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/util"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 )
 
 var pwd string
 
 func RunPackage(do *definitions.Do) error {
-	logger.Debugf("Welcome! Say the Marmots. Running App package.\n")
+	log.Debug("Welcome! Say the marmots. Running app package")
 	var err error
 	pwd, err = os.Getwd()
 	if err != nil {
 		return fmt.Errorf("Could not get the present working directory. Are you on Mars?\nError: %v\n", err)
 	}
 
-	logger.Debugf("\twith Host Path =>\t%s:%s\n", do.Path, pwd)
+	log.WithFields(log.Fields{
+		"host path": do.Path,
+		"pwd":       pwd,
+	}).Debug()
 	app, err := loaders.LoadContractPackage(do.Path, do.ChainName, do.Name, do.Type)
 	if err != nil {
 		do.Result = "could not load package"
@@ -81,17 +85,17 @@ func BootServicesAndChain(do *definitions.Do, app *definitions.Contracts) error 
 	case "":
 		if app.ChainName == "" {
 			// TODO [csk]: first check if there is a chain checked out. if not, then use throwAway
-			logger.Infof("No chain was given, booting a throwaway chain.\n")
+			log.Info("No chain was given, booting a throwaway chain")
 			err = bootThrowAwayChain(app.Name, do)
 		} else {
-			logger.Infof("Booting chain =>\t\t%s\n", app.ChainName)
+			log.WithField("=>", app.ChainName).Info("Booting chain")
 			err = bootChain(app.ChainName, do)
 		}
 	case "t", "tmp", "temp":
-		logger.Infof("No chain was given, booting a throwaway chain.\n")
+		log.Info("No chain was given, booting a throwaway chain")
 		err = bootThrowAwayChain(app.Name, do)
 	default:
-		logger.Infof("Booting chain =>\t\t%s\n", do.ChainName)
+		log.WithField("=>", do.ChainName).Info("Booting chain")
 		err = bootChain(do.ChainName, do)
 	}
 
@@ -179,21 +183,30 @@ func DefineAppActionService(do *definitions.Do, app *definitions.Contracts) erro
 	} else {
 		loca = path.Join(common.DataContainersPath, doData.Name, "apps", app.Name)
 	}
-	logger.Debugf("Creating App Data Cont =>\t%s:%s\n", do.Path, loca)
+	log.WithFields(log.Fields{
+		"path":     do.Path,
+		"location": loca,
+	}).Debug("Creating app data container")
 	common.Copy(do.Path, loca)
 	if err := data.ImportData(doData); err != nil {
 		return err
 	}
 	do.Operations.DataContainerName = util.DataContainersName(doData.Name, doData.Operations.ContainerNumber)
 
-	logger.Debugf("App Action Built.\n")
+	log.Debug("App action built")
 	return nil
 }
 
 func PerformAppActionService(do *definitions.Do, app *definitions.Contracts) error {
-	logger.Println("Performing Action. This can sometimes take a wee while.")
-	logger.Infof("\t=>\t\t\t%s:%s\n", do.Service.Name, do.Service.Image)
-	logger.Debugf("\t=>\t\t\t%s:%s\n", do.Service.WorkDir, do.Service.EntryPoint)
+	log.Warn("Performing action. This can sometimes take a wee while")
+	log.WithFields(log.Fields{
+		"service": do.Service.Name,
+		"image":   do.Service.Image,
+	}).Info()
+	log.WithFields(log.Fields{
+		"workdir":    do.Service.WorkDir,
+		"entrypoint": do.Service.EntryPoint,
+	}).Debug()
 
 	do.Operations.ContainerType = definitions.TypeService
 	if err := perform.DockerExecService(do.Service, do.Operations); err != nil {
@@ -201,15 +214,15 @@ func PerformAppActionService(do *definitions.Do, app *definitions.Contracts) err
 		return err
 	}
 
-	logger.Infof("Finished performing App Action.\n")
+	log.Info("Finished performing app action")
 	return nil
 }
 
 func CleanUp(do *definitions.Do, app *definitions.Contracts) error {
-	logger.Infof("Commensing CleanUp.\n")
+	log.Info("Cleaning up")
 
 	if do.Chain.ChainType == "throwaway" {
-		logger.Debugf("Destroying Throwaway Chain =>\t%s\n", do.Chain.Name)
+		log.WithField("=>", do.Chain.Name).Debug("Destroying throwaway chain")
 		doRm := definitions.NowDo()
 		doRm.Operations = do.Operations
 		doRm.Name = do.Chain.Name
@@ -217,11 +230,17 @@ func CleanUp(do *definitions.Do, app *definitions.Contracts) error {
 		doRm.RmD = true
 		chains.KillChain(doRm)
 
-		logger.Debugf("Removing latent files/dirs =>\t%s:%s\n", path.Join(common.DataContainersPath, do.Chain.Name), path.Join(common.ChainsPath, do.Chain.Name+".toml"))
-		os.RemoveAll(path.Join(common.DataContainersPath, do.Chain.Name))
-		os.Remove(path.Join(common.ChainsPath, do.Chain.Name+".toml"))
+		latentDir := path.Join(common.DataContainersPath, do.Chain.Name)
+		latentFile := path.Join(common.ChainsPath, do.Chain.Name+".toml")
+		log.WithFields(log.Fields{
+			"dir":  latentDir,
+			"file": latentFile,
+		}).Debug("Removing latent dir and file")
+
+		os.RemoveAll(latentDir)
+		os.Remove(latentFile)
 	} else {
-		logger.Debugf("No Throwaway Chain to destroy.\n")
+		log.Debug("No throwaway chain to destroy")
 	}
 
 	doData := definitions.NowDo()
@@ -241,27 +260,33 @@ func CleanUp(do *definitions.Do, app *definitions.Contracts) error {
 		loca = path.Join(common.DataContainersPath, doData.Name, "apps", app.Name)
 	}
 
-	logger.Debugf("Exporting Results =>\t\t%s:%s\n", doData.Source, loca)
+	log.WithFields(log.Fields{
+		"path":     doData.Source,
+		"location": loca,
+	}).Debug("Exporting results")
 	data.ExportData(doData)
 
 	if app.AppType.Name == "epm" {
 		files, _ := filepath.Glob(filepath.Join(loca, "*"))
 		for _, f := range files {
 			dest := filepath.Join(do.Path, filepath.Base(f))
-			logger.Debugf("Moving file =>\t\t\t%s:%s\n", f, dest)
+			log.WithFields(log.Fields{
+				"from": f,
+				"to":   dest,
+			}).Debug("Moving file")
 			common.Copy(f, dest)
 		}
 	}
 
 	if !do.RmD {
-		logger.Debugf("Removing data dir on host =>\t%s\n", path.Join(common.DataContainersPath, do.Service.Name))
+		log.WithField("dir", path.Join(common.DataContainersPath, do.Service.Name)).Debug("Removing data dir on host")
 		os.RemoveAll(path.Join(common.DataContainersPath, do.Service.Name))
 	}
 
 	if !do.Rm {
 		doRemove := definitions.NowDo()
 		doRemove.Operations.SrvContainerName = do.Operations.DataContainerName
-		logger.Debugf("Removing data contnr =>\t\t%s\n", doRemove.Operations.SrvContainerName)
+		log.WithField("=>", doRemove.Operations.SrvContainerName).Debug("Removing data container")
 		if err := perform.DockerRemove(nil, doRemove.Operations, false, true); err != nil {
 			return err
 		}
@@ -306,7 +331,7 @@ func bootThrowAwayChain(name string, do *definitions.Do) error {
 	}
 
 	do.Chain.Name = do.Name // setting this for tear down purposes
-	logger.Debugf("ThrowAwayChain booted =>\t%s\n", do.Name)
+	log.WithField("=>", do.Name).Debug("Throwaway chain booted")
 
 	do.Name = tmp
 	return nil
@@ -334,20 +359,20 @@ func prepareEpmAction(do *definitions.Do, app *definitions.Contracts) {
 	}
 
 	if do.CSV != "" {
-		logger.Debugf("Setting output format to =>\t%s\n", do.CSV)
+		log.WithField("format", do.CSV).Debug("Setting output format to")
 		do.Service.EntryPoint = do.Service.EntryPoint + " --output " + do.CSV
 	} else {
 		do.Service.EntryPoint = do.Service.EntryPoint + " --output json"
 	}
 
 	if do.EPMConfigFile != "" {
-		logger.Debugf("Setting config file to =>\t%s\n", do.EPMConfigFile)
+		log.WithField("config", do.EPMConfigFile).Debug("Setting config file to")
 		do.Service.EntryPoint = do.Service.EntryPoint + " --file " + path.Join(do.Service.WorkDir, do.EPMConfigFile)
 	}
 
 	if len(do.ConfigOpts) != 0 {
 		var toAdd string
-		logger.Debugf("Setting sets file to =>\t%v\n", do.ConfigOpts)
+		log.WithField("sets file", do.ConfigOpts).Debug("Setting sets file to")
 		for _, s := range do.ConfigOpts {
 			toAdd = toAdd + "," + s
 		}

--- a/data/load.go
+++ b/data/load.go
@@ -5,6 +5,8 @@ import (
 
 	def "github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
+
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 func PretendToBeAService(serviceYourPretendingToBe string, cNum ...int) *def.ServiceDefinition {
@@ -12,7 +14,7 @@ func PretendToBeAService(serviceYourPretendingToBe string, cNum ...int) *def.Ser
 	srv.Name = serviceYourPretendingToBe
 
 	if len(cNum) == 0 || cNum[0] == 0 {
-		logger.Debugf("Loading Service Definition =>\t%s:1 (autoassigned)\n", serviceYourPretendingToBe)
+		log.WithField("=>", fmt.Sprintf("%s:1", serviceYourPretendingToBe)).Debug("Loading service definition (autoassigned)")
 		// TODO: findNextContainerIndex => util/container_operations.go
 		if len(cNum) == 0 {
 			cNum = append(cNum, 1)
@@ -20,7 +22,7 @@ func PretendToBeAService(serviceYourPretendingToBe string, cNum ...int) *def.Ser
 			cNum[0] = 1
 		}
 	} else {
-		logger.Debugf("Loading Service Definition =>\t%s:%d\n", serviceYourPretendingToBe, cNum[0])
+		log.WithField("=>", fmt.Sprintf("%s:%d", serviceYourPretendingToBe, cNum[0])).Debug("Loading service definition")
 	}
 
 	srv.Operations.ContainerNumber = cNum[0]
@@ -30,13 +32,15 @@ func PretendToBeAService(serviceYourPretendingToBe string, cNum ...int) *def.Ser
 }
 
 func giveMeAllTheNames(name string, srv *def.ServiceDefinition) {
-	logger.Debugf("Giving myself all the names =>\t%s\n", name)
+	log.WithField("=>", name).Debug("Giving myself all the names")
 	srv.Name = name
 	srv.Service.Name = name
 	srv.Operations.SrvContainerName = util.DataContainersName(srv.Name, srv.Operations.ContainerNumber)
 	srv.Operations.DataContainerName = util.DataContainersName(srv.Name, srv.Operations.ContainerNumber)
-	logger.Debugf("My service container name is =>\t%s\n", srv.Operations.SrvContainerName)
-	logger.Debugf("My data container name is =>\t%s\n", srv.Operations.DataContainerName)
+	log.WithFields(log.Fields{
+		"data container":    srv.Operations.DataContainerName,
+		"service container": srv.Operations.SrvContainerName,
+	}).Debug("Using names")
 }
 
 func checkServiceGiven(args []string) error {

--- a/data/log.go
+++ b/data/log.go
@@ -1,7 +1,0 @@
-package data
-
-import (
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
-)
-
-var logger = AddLogger("data")

--- a/data/manage.go
+++ b/data/manage.go
@@ -11,11 +11,14 @@ import (
 	"github.com/eris-ltd/eris-cli/util"
 
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 func RenameData(do *definitions.Do) error {
-	logger.Infof("Renaming Data =>\t\t%s:%s\n", do.Name, do.NewName)
-	logger.Debugf("\twith ContainerNumber =>\t%d\n", do.Operations.ContainerNumber)
+	log.WithFields(log.Fields{
+		"from": fmt.Sprintf("%s:%d", do.Name, do.Operations.ContainerNumber),
+		"to":   fmt.Sprintf("%s:%d", do.NewName, do.Operations.ContainerNumber),
+	}).Info("Renaming data container")
 
 	if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
 		ops := loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
@@ -34,7 +37,7 @@ func RenameData(do *definitions.Do) error {
 
 func InspectData(do *definitions.Do) error {
 	if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
-		logger.Infoln("Inspecting data container" + do.Name)
+		log.WithField("=>", do.Name).Info("Inspecting data container")
 
 		srv := definitions.BlankServiceDefinition()
 		srv.Operations.SrvContainerName = util.ContainersName(definitions.TypeData, do.Name, do.Operations.ContainerNumber)
@@ -58,24 +61,24 @@ func RmData(do *definitions.Do) (err error) {
 	for _, name := range do.Operations.Args {
 		do.Name = name
 		if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
-			logger.Infoln("Removing data container " + do.Name)
+			log.WithField("=>", do.Name).Info("Removing data container")
 
 			srv := definitions.BlankServiceDefinition()
 			srv.Operations.SrvContainerName = util.ContainersName("data", do.Name, do.Operations.ContainerNumber)
 
 			if err = perform.DockerRemove(srv.Service, srv.Operations, false, do.Volumes); err != nil {
-				logger.Errorf("Error removing %s: %v", do.Name, err)
+				log.Errorf("Error removing %s: %v", do.Name, err)
 				return err
 			}
 
 		} else {
 			err = fmt.Errorf("I cannot find that data container for %s. Please check the data container name you sent me.", do.Name)
-			logger.Errorln(err)
+			log.Error(err)
 			return err
 		}
 
 		if do.RmHF {
-			logger.Println("Removing host folder " + do.Name)
+			log.WithField("=>", do.Name).Warn("Removing host directory")
 			if err = os.RemoveAll(path.Join(DataContainersPath, do.Name)); err != nil {
 				return err
 			}

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -3,11 +3,11 @@ package files
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/logger"
@@ -21,7 +21,6 @@ import (
 var erisDir string = path.Join(os.TempDir(), "eris")
 var file string
 var content string = "test content\n"
-var hash string
 
 var DEAD bool // XXX: don't double panic (TODO: Flushing twice blocks)
 func fatal(t *testing.T, err error) {
@@ -36,9 +35,9 @@ func fatal(t *testing.T, err error) {
 func TestMain(m *testing.M) {
 	log.SetFormatter(logger.ErisFormatter{})
 
-	// log.SetLevel(log.ErrorLevel)
+	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)
-	log.SetLevel(log.DebugLevel)
+	// log.SetLevel(log.DebugLevel)
 
 	if os.Getenv("TEST_IN_CIRCLE") == "true" {
 		erisDir = os.Getenv("HOME")
@@ -62,51 +61,68 @@ func TestPutFiles(t *testing.T) {
 	do.Name = file
 	log.WithField("=>", do.Name).Info("Putting file (from tests)")
 
-	// because IPFS is testy, we retry the put up to
-	// 10 times.
-	passed := false
-	for i := 0; i < 9; i++ {
-		if err := testPutFiles(do); err != nil {
-			time.Sleep(3 * time.Second)
-			continue
-		} else {
-			passed = true
-			break
-		}
-	}
-	if !passed {
-		// final time will throw
-		if err := testPutFiles(do); err != nil {
-			fatal(t, err)
-		}
+	hash := "QmcJdniiSKMp5az3fJvkbJTANd7bFtDoUkov3a8pkByWkv"
+
+	// Fake IPFS server.
+	os.Setenv("ERIS_IPFS_HOST", "http://localhost")
+	ipfs := tests.NewServer("localhost:8080")
+	ipfs.SetResponse(tests.ServerResponse{
+		Code: http.StatusOK,
+		Header: map[string][]string{
+			"Ipfs-Hash": []string{hash},
+		},
+	})
+	defer ipfs.Close()
+
+	if err := PutFiles(do); err != nil {
+		fatal(t, err)
 	}
 
-	hash = do.Result
+	if expected := "/ipfs/"; ipfs.Path() != expected {
+		fatal(t, fmt.Errorf("Called the wrong endpoint; expected %v, got %v\n", expected, ipfs.Path()))
+	}
+
+	if expected := "POST"; ipfs.Method() != expected {
+		fatal(t, fmt.Errorf("Used the wrong HTTP method; expected %v, got %v\n", expected, ipfs.Method()))
+	}
+
+	if ipfs.Body() != content {
+		fatal(t, fmt.Errorf("Put the bad file; expected %q, got %q\n", content, ipfs.Body()))
+	}
+
+	if hash != do.Result {
+		fatal(t, fmt.Errorf("Hash mismatch; expected %q, got %q\n", hash, do.Result))
+	}
+
 	log.WithField("result", do.Result).Debug("Finished putting a file")
 }
 
 func TestGetFiles(t *testing.T) {
 	fileName := strings.Replace(file, "temp", "pmet", 1)
+	hash := "QmcJdniiSKMp5az3fJvkbJTANd7bFtDoUkov3a8pkByWkv"
 	do := definitions.NowDo()
 	do.Name = hash
 	do.Path = fileName
-	// because IPFS is testy, we retry the put up to
-	// 10 times.
-	passed := false
-	for i := 0; i < 9; i++ {
-		if err := testGetFiles(do); err != nil {
-			time.Sleep(3 * time.Second)
-			continue
-		} else {
-			passed = true
-			break
-		}
+
+	// Fake IPFS server.
+	os.Setenv("ERIS_IPFS_HOST", "http://localhost")
+	ipfs := tests.NewServer("localhost:8080")
+	ipfs.SetResponse(tests.ServerResponse{
+		Code: http.StatusOK,
+		Body: content,
+	})
+	defer ipfs.Close()
+
+	if err := GetFiles(do); err != nil {
+		fatal(t, err)
 	}
-	if !passed {
-		// final time will throw
-		if err := testGetFiles(do); err != nil {
-			fatal(t, err)
-		}
+
+	if expected := "/ipfs/" + hash; ipfs.Path() != expected {
+		fatal(t, fmt.Errorf("Called the wrong endpoint; expected %v, got %v\n", expected, ipfs.Path()))
+	}
+
+	if expected := "GET"; ipfs.Method() != expected {
+		fatal(t, fmt.Errorf("Used the wrong HTTP method; expected %v, got %v\n", expected, ipfs.Method()))
 	}
 
 	f, err := os.Open(fileName)
@@ -120,7 +136,7 @@ func TestGetFiles(t *testing.T) {
 	}
 
 	if string(contentPuted) != content {
-		fatal(t, fmt.Errorf("ERROR: Content Put into IPFS and Pulled out to not match.\nExpected:\t%s\nReceived:\t%s\n", content, string(contentPuted)))
+		fatal(t, fmt.Errorf("Returned unexpected content; expected: %q, got %q", content, string(contentPuted)))
 	}
 }
 
@@ -133,11 +149,11 @@ func testsInit() error {
 	tests.IfExit(err)
 	f.Write([]byte(content))
 
-	do1 := definitions.NowDo()
-	do1.Operations.Args = []string{"ipfs"}
-	err = services.StartService(do1)
+	// Satisfy EnsureRunning.
+	do := definitions.NowDo()
+	do.Operations.Args = []string{"ipfs"}
+	err = services.StartService(do)
 	tests.IfExit(err)
-	time.Sleep(5 * time.Second) // boot time
 
 	return nil
 }
@@ -154,18 +170,4 @@ func testKillIPFS(t *testing.T) {
 	if e := services.KillService(do); e != nil {
 		t.Fatal(e)
 	}
-}
-
-func testPutFiles(do *definitions.Do) error {
-	if err := PutFiles(do); err != nil {
-		return err
-	}
-	return nil
-}
-
-func testGetFiles(do *definitions.Do) error {
-	if err := GetFiles(do); err != nil {
-		return err
-	}
-	return nil
 }

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -41,8 +41,8 @@ func TestMain(m *testing.M) {
 		erisDir = os.Getenv("HOME")
 	}
 
-        // Prevent CLI from starting IPFS.
-        os.Setenv("ERIS_SKIP_ENSURE", "true")
+	// Prevent CLI from starting IPFS.
+	os.Setenv("ERIS_SKIP_ENSURE", "true")
 
 	file = path.Join(erisDir, "temp")
 

--- a/files/log.go
+++ b/files/log.go
@@ -1,7 +1,0 @@
-package files
-
-import (
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
-)
-
-var logger = AddLogger("files")

--- a/initialize/log.go
+++ b/initialize/log.go
@@ -1,7 +1,0 @@
-package initialize
-
-import (
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
-)
-
-var logger = AddLogger("initialize")

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/eris-ltd/eris-cli/config"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 )
 
@@ -17,7 +18,7 @@ func cloneRepo(prompt bool, name, location string) error {
 	if _, err := os.Stat(filepath.Join(location, ".git")); !os.IsNotExist(err) {
 		// if the .git directory exists within ~/.eris/services (or w/e)
 		//   then pull rather than clone.
-		logger.Printf("The location is a git repository. Attempting to pull instead.\n")
+		log.Warn("The location is a git repository. Attempting to pull instead")
 		if err := pullRepo(location, prompt); err != nil {
 			return err
 		}
@@ -33,7 +34,7 @@ func cloneRepo(prompt bool, name, location string) error {
 			//   need to change down the road. generally, this should not be a big problem.
 			common.ClearDir(location)
 
-			logger.Printf("Cloning git repository.\n")
+			log.Warn("Cloning git repository")
 			c := exec.Command("git", "clone", src, location)
 
 			// XXX [csk]: we squelch this output to provide a nicer newb interface... may need to change later
@@ -44,7 +45,7 @@ func cloneRepo(prompt bool, name, location string) error {
 			}
 
 		} else {
-			logger.Debugf("Authorization not granted. Skipping.\n")
+			log.Debug("Authorization not granted. Skipping")
 		}
 	}
 	return nil
@@ -58,7 +59,7 @@ func pullRepo(location string, alreadyAsked bool) error {
 			return fmt.Errorf("Error:\tCould not move into the directory (%s)\n", location)
 		}
 
-		logger.Printf("Pulling origin master.\n")
+		log.Warn("Pulling origin master")
 		c := exec.Command("git", "pull", "origin", "master")
 
 		// XXX [csk]: we squelch this output to provide a nicer newb interface... may need to change later
@@ -66,7 +67,6 @@ func pullRepo(location string, alreadyAsked bool) error {
 
 		c.Stderr = config.GlobalConfig.ErrorWriter
 		if err := c.Run(); err != nil {
-			logger.Printf("err: %v\n", err)
 			return err
 		}
 
@@ -81,7 +81,8 @@ func pullRepo(location string, alreadyAsked bool) error {
 func askToPull(location string) bool {
 	var input string
 
-	logger.Printf("Looks like the %s directory exists.\nWould you like the marmots to pull in any recent changes? (y/n): ", location)
+	log.WithField("dir", location).Warn("Looks like the directory exists")
+	fmt.Print("Would you like the marmots to pull in any recent changes? (y/n): ")
 	fmt.Scanln(&input)
 
 	if input == "Y" || input == "y" || input == "YES" || input == "Yes" || input == "yes" {

--- a/keys/log.go
+++ b/keys/log.go
@@ -1,7 +1,0 @@
-package keys
-
-import (
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
-)
-
-var logger = AddLogger("keys")

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/viper"
 )
 
@@ -31,9 +32,9 @@ func LoadChainDefinition(chainName string, newCont bool, cNum ...int) (*definiti
 
 	if cNum[0] == 0 {
 		cNum[0] = util.AutoMagic(0, definitions.TypeChain, newCont)
-		logger.Debugf("Loading Chain Definition =>\t%s:%d (autoassigned)\n", chainName, cNum[0])
+		log.WithField("=>", fmt.Sprintf("%s:%d", chainName, cNum[0])).Debug("Loading chain definition (autoassigned)")
 	} else {
-		logger.Debugf("Loading Chain Definition =>\t%s:%d\n", chainName, cNum[0])
+		log.WithField("=>", fmt.Sprintf("%s:%d", chainName, cNum[0])).Debug("Loading chain definition")
 	}
 
 	chain := definitions.BlankChain()
@@ -65,9 +66,12 @@ func LoadChainDefinition(chainName string, newCont bool, cNum ...int) (*definiti
 	}
 
 	checkChainNames(chain)
-	logger.Debugf("Chain Loader. ContNumber =>\t%d\n", chain.Operations.ContainerNumber)
-	logger.Debugf("\twith Environment =>\t%v\n", chain.Service.Environment)
-	logger.Debugf("\tBooting =>\t\t%v:%v\n", chain.Service.EntryPoint, chain.Service.Command)
+	log.WithFields(log.Fields{
+		"container number": chain.Operations.ContainerNumber,
+		"environment":      chain.Service.Environment,
+		"entrypoint":       chain.Service.EntryPoint,
+		"cmd":              chain.Service.Command,
+	}).Debug("Chain definition loaded")
 	return chain, nil
 }
 
@@ -124,10 +128,10 @@ func MockChainDefinition(chainName, chainID string, newCont bool, cNum ...int) *
 
 	if len(cNum) == 0 {
 		chn.Operations.ContainerNumber = util.AutoMagic(cNum[0], definitions.TypeChain, newCont)
-		logger.Debugf("Mocking Chain Definition =>\t%s:%d (autoassigned)\n", chainName, cNum[0])
+		log.WithField("=>", fmt.Sprintf("%s:%d", chainName, cNum[0])).Debug("Mocking chain definition (autoassigned)")
 	} else {
 		chn.Operations.ContainerNumber = cNum[0]
-		logger.Debugf("Mocking Chain Definition =>\t%s:%d\n", chainName, cNum[0])
+		log.WithField("=>", fmt.Sprintf("%s:%d", chainName, cNum[0])).Debug("Mocking chain definition")
 	}
 
 	chn.Operations.ContainerType = definitions.TypeChain
@@ -139,6 +143,7 @@ func MockChainDefinition(chainName, chainID string, newCont bool, cNum ...int) *
 
 // marshal from viper to definitions struct
 func MarshalChainDefinition(chainConf *viper.Viper, chain *definitions.Chain) error {
+	log.Debug("Marshalling chain")
 	chnTemp := definitions.BlankChain()
 	err := chainConf.Marshal(chnTemp)
 	if err != nil {
@@ -154,8 +159,8 @@ func MarshalChainDefinition(chainConf *viper.Viper, chain *definitions.Chain) er
 	// opinionated. we know.
 	for _, s := range []string{"", "service."} {
 		if chainConf.GetBool(s + "data_container") {
-			logger.Debugln("Loader.Chain.Marshal. Data Containers Turned On.")
 			chain.Service.AutoData = true
+			log.WithField("autodata", chain.Service.AutoData).Debug()
 		}
 	}
 
@@ -171,7 +176,7 @@ func setChainDefaults(chain *definitions.Chain) error {
 		return err
 	}
 
-	logger.Debugf("Chain Defaults Set. Image =>\t%s\n", chain.Service.Image)
+	log.WithField("image", chain.Service.Image).Debug("Chain defaults set")
 	return nil
 }
 

--- a/loaders/contracts.go
+++ b/loaders/contracts.go
@@ -10,6 +10,8 @@ import (
 	"github.com/eris-ltd/eris-cli/definitions"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/viper"
+
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 func LoadContractPackage(path, chainName, command, typ string) (*definitions.Contracts, error) {
@@ -17,7 +19,7 @@ func LoadContractPackage(path, chainName, command, typ string) (*definitions.Con
 	contConf, err := loadContractPackage(path)
 
 	if err != nil {
-		logger.Infoln("The marmots could not read that package.json. Will use defaults.")
+		log.Info("The marmots could not read that package.json. Will use defaults")
 		app, _ = DefaultContractPackage()
 
 		_, err := LoadEPMInstructions(path)
@@ -34,10 +36,12 @@ func LoadContractPackage(path, chainName, command, typ string) (*definitions.Con
 		}
 	}
 
-	logger.Debugf("Package testType =>\t\t%s\n", app.TestType)
-	logger.Debugf("\tdeployType =>\t\t%s\n", app.DeployType)
-	logger.Debugf("\ttestTask =>\t\t%s\n", app.TestTask)
-	logger.Debugf("\tdeployTask =>\t\t%s\n", app.DeployTask)
+	log.WithFields(log.Fields{
+		"test task":   app.TestTask,
+		"test type":   app.TestType,
+		"deploy type": app.DeployType,
+		"deploy task": app.DeployTask,
+	}).Debug("Loading package")
 
 	if err := setAppType(app, chainName, command, typ); err != nil {
 		return nil, err
@@ -94,9 +98,11 @@ func marshalContractPackage(contConf *viper.Viper) (*definitions.Contracts, erro
 func setAppType(app *definitions.Contracts, name, command, typ string) error {
 	var t string
 
-	logger.Debugf("Setting App Type. Task =>\t%s\n", command)
-	logger.Debugf("\tChainType =>\t\t%s\n", typ)
-	logger.Debugf("\tChainName =>\t\t%s\n", name)
+	log.WithFields(log.Fields{
+		"task": command,
+		"type": typ,
+		"app":  name,
+	}).Debug("Setting app type")
 
 	if typ != "" {
 		t = typ
@@ -120,7 +126,7 @@ func setAppType(app *definitions.Contracts, name, command, typ string) error {
 		app.AppType = definitions.EPMApp()
 	}
 
-	logger.Debugf("\tApp Type =>\t\t%s\n", app.AppType.Name)
+	log.WithField("app type", app.AppType.Name).Debug()
 
 	return nil
 }

--- a/loaders/data.go
+++ b/loaders/data.go
@@ -1,8 +1,12 @@
 package loaders
 
 import (
+	"fmt"
+
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
+
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 // LoadDataDefinition returns an Operation structure for a blank data container
@@ -12,7 +16,7 @@ func LoadDataDefinition(dataName string, cNum int) *definitions.Operation {
 		cNum = 1
 	}
 
-	logger.Debugf("Loading Data Definition =>\t%s:%d\n", dataName, cNum)
+	log.WithField("=>", fmt.Sprintf("%s:%d", dataName, cNum)).Debug("Loading data definition")
 
 	ops := definitions.BlankOperation()
 	ops.ContainerNumber = cNum

--- a/loaders/log.go
+++ b/loaders/log.go
@@ -1,7 +1,0 @@
-package loaders
-
-import (
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
-)
-
-var logger = AddLogger("loader")

--- a/loaders/services.go
+++ b/loaders/services.go
@@ -12,6 +12,7 @@ import (
 	"github.com/eris-ltd/eris-cli/version"
 
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/spf13/viper"
 )
@@ -23,9 +24,9 @@ func LoadServiceDefinition(servName string, newCont bool, cNum ...int) (*definit
 
 	if cNum[0] == 0 {
 		cNum[0] = util.AutoMagic(0, definitions.TypeService, newCont)
-		logger.Debugf("Loading Service Definition =>\t%s:%d (autoassigned)\n", servName, cNum[0])
+		log.WithField("=>", fmt.Sprintf("%s:%d", servName, cNum[0])).Debug("Loading service definition (autoassigned)")
 	} else {
-		logger.Debugf("Loading Service Definition =>\t%s:%d\n", servName, cNum[0])
+		log.WithField("=>", fmt.Sprintf("%s:%d", servName, cNum[0])).Debug("Loading service definition")
 	}
 
 	srv := definitions.BlankServiceDefinition()
@@ -64,10 +65,10 @@ func MockServiceDefinition(servName string, newCont bool, cNum ...int) *definiti
 
 	if len(cNum) == 0 {
 		srv.Operations.ContainerNumber = util.AutoMagic(cNum[0], definitions.TypeService, newCont)
-		logger.Debugf("Mocking Service Definition =>\t%s:%d (autoassigned)\n", servName, cNum[0])
+		log.WithField("=>", fmt.Sprintf("%s:%d", servName, cNum[0])).Debug("Mocking service definition (autoassigned)")
 	} else {
 		srv.Operations.ContainerNumber = cNum[0]
-		logger.Debugf("Mocking Service Definition =>\t%s:%d\n", servName, cNum[0])
+		log.WithField("=>", fmt.Sprintf("%s:%d", servName, cNum[0])).Debug("Mocking service definition")
 	}
 
 	srv.Operations.ContainerType = definitions.TypeService
@@ -100,19 +101,19 @@ func ServiceFinalizeLoad(srv *definitions.ServiceDefinition) {
 	} else if srv.Name == "" && srv.Service.Name == "" && srv.Service.Image != "" { // If no name use image
 		srv.Name = strings.Replace(srv.Service.Image, "/", "_", -1)
 		srv.Service.Name = srv.Name
-		logger.Debugf("Defaulting to image name =>\t%s\n", srv.Name)
+		log.WithField("image", srv.Name).Debug("Defaulting to image")
 	} else if srv.Service.Name != "" && srv.Name == "" { // harmonize names
 		srv.Name = srv.Service.Name
-		logger.Debugf("Defaulting to service name =>\t%s\n", srv.Service.Name)
+		log.WithField("service", srv.Service.Name).Debug("Defaulting to service")
 	} else if srv.Service.Name == "" && srv.Name != "" {
 		srv.Service.Name = srv.Name
-		logger.Debugf("Defaulting to service name =>\t%s\n", srv.Name)
+		log.WithField("service", srv.Name).Debug("Defaulting to service")
 	}
 
 	container := util.FindServiceContainer(srv.Name, srv.Operations.ContainerNumber, true)
 
 	if container != nil {
-		logger.Debugf("Setting SrvCont Names =>\t%s:%s\n", container.FullName, container.ContainerID)
+		log.WithField("=>", container.FullName).Debug("Setting service container name")
 		srv.Operations.SrvContainerName = container.FullName
 		srv.Operations.SrvContainerID = container.ContainerID
 	} else {
@@ -122,7 +123,7 @@ func ServiceFinalizeLoad(srv *definitions.ServiceDefinition) {
 	if srv.Service.AutoData {
 		dataContainer := util.FindDataContainer(srv.Name, srv.Operations.ContainerNumber)
 		if dataContainer != nil {
-			logger.Debugf("Setting DataCont Names =>\t%s:%s\n", dataContainer.FullName, dataContainer.ContainerID)
+			log.WithField("=>", dataContainer.FullName).Debug("Setting data container name")
 			srv.Operations.DataContainerName = dataContainer.FullName
 			srv.Operations.DataContainerID = dataContainer.ContainerID
 		} else {
@@ -141,7 +142,14 @@ func ConnectToAService(srv *definitions.Service, ops *definitions.Operation, nam
 
 // links and mounts for service dependencies
 func connectToAService(srv *definitions.Service, ops *definitions.Operation, typ, name, internalName string, link, mount bool) {
-	logger.Debugf("Connecting service %s to %s %s (%s) with link (%v) and volumes-from (%v)\n", srv.Name, typ, name, internalName, link, mount)
+	log.WithFields(log.Fields{
+		"=>":            srv.Name,
+		"type":          typ,
+		"name":          name,
+		"internal name": internalName,
+		"link":          link,
+		"volumes from":  mount,
+	}).Debug("Connecting to service")
 	containerName := util.ContainersName(typ, name, ops.ContainerNumber)
 
 	if link {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,106 @@
+package logger
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+)
+
+type ErisFormatter struct{}
+
+const (
+	arrowTag = "=>"
+
+	// Where to place `tag=comment` on screen.
+	offset = 44
+
+	// Space between a log message and a tag name
+	spacing = 4
+)
+
+var (
+	// See terminfo(5) for the list of commands.
+	escReset = tput("sgr0")
+	escBold  = tput("bold")
+	// http://worldwidemann.com/content/images/2015/03/finalterm-colors.png
+	escTag = tput("setaf", 241)
+)
+
+// Tput asks the terminfo database for a particular escape sequence.
+func tput(command string, params ...interface{}) []byte {
+	args := []string{command}
+
+	for _, param := range params {
+		switch param.(type) {
+		case string:
+			args = append(args, param.(string))
+		case int:
+			args = append(args, fmt.Sprintf("%d", param))
+		}
+	}
+
+	out, err := exec.Command("tput", args...).Output()
+	if err != nil {
+		return []byte{}
+	}
+
+	return out
+}
+
+// highlight emphasizes a tag and a comment. It returns the highlighted
+// text along with an offset where to place it on screen.
+func highlight(tag, comment string) (adjustedOffset int, text string) {
+	tagDecorated := fmt.Sprintf("%s%s%s", escTag, tag, escReset)
+	commentDecorated := fmt.Sprintf("%s%s%s", escBold, comment, escReset)
+
+	if tag == arrowTag {
+		return offset + 2, fmt.Sprintf("%s", commentDecorated)
+	} else {
+		return offset - len(tag) + 1, fmt.Sprintf("%s=%s", tagDecorated, commentDecorated)
+	}
+}
+
+// Format implements the logrus.Formatter interface. It returns a formatted
+// log line as a slice of bytes.
+func (f ErisFormatter) Format(entry *log.Entry) (out []byte, err error) {
+	// Sort tag names in alphabetical order.
+	var keys []string
+	for key, _ := range entry.Data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	// Display a message and the first tag.
+	if len(entry.Data) > 0 {
+		tag, comment := keys[0], fmt.Sprintf("%v", entry.Data[keys[0]])
+
+		// Highlight the tag.
+		adjustedOffset, text := highlight(tag, comment)
+
+		if len(entry.Message) < adjustedOffset-spacing {
+			// Message with the tag inline.
+			out = append(out, fmt.Sprintf("%-*s%s\n", adjustedOffset, entry.Message, text)...)
+		} else {
+			// Message with the tag on a separate line.
+			out = append(out, fmt.Sprintf("%s\n%-*s%s\n", entry.Message, adjustedOffset, "", text)...)
+		}
+
+		// Remove the used tag name.
+		keys = keys[1:]
+	} else {
+		// Message without tags.
+		out = append(out, fmt.Sprintln(entry.Message)...)
+	}
+
+	// Display every other tag on a separate line.
+	for _, key := range keys {
+		// Highlight the tag.
+		adjustedOffset, text := highlight(key, fmt.Sprintf("%v", entry.Data[key]))
+
+		out = append(out, fmt.Sprintf("%-*s%s\n", adjustedOffset, "", text)...)
+	}
+
+	return out, nil
+}

--- a/perform/docker_run.go
+++ b/perform/docker_run.go
@@ -16,6 +16,8 @@ import (
 	def "github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+
 	dirs "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient"
 )
@@ -33,10 +35,10 @@ var (
 //  ops.Labels             - container creation time labels (use LoadDataDefinition)
 //
 func DockerCreateData(ops *def.Operation) error {
-	logger.Infof("Creating Data Container for =>\t%s\n", ops.DataContainerName)
+	log.WithField("=>", ops.DataContainerName).Info("Creating data container")
 
 	if _, exists := ContainerExists(ops); exists {
-		logger.Infoln("Data container exists. Not creating.")
+		log.Info("Data container exists. Not creating")
 		return ErrContainerExists
 	}
 
@@ -50,7 +52,8 @@ func DockerCreateData(ops *def.Operation) error {
 		return err
 	}
 
-	logger.Infof("Data Container ID =>\t\t%s\n", optsData.Name)
+	log.WithField("=>", optsData.Name).Info("Data container created")
+
 	return nil
 }
 
@@ -66,10 +69,13 @@ func DockerCreateData(ops *def.Operation) error {
 //  ops.Args              - if specified, run these args in a container
 //
 func DockerRunData(ops *def.Operation, service *def.Service) (result []byte, err error) {
-	logger.Infof("DockerRunData =>\t\t%s:%v\n", ops.DataContainerName, ops.Args)
+	log.WithFields(log.Fields{
+		"=>":   ops.DataContainerName,
+		"args": ops.Args,
+	}).Info("Running data container")
 
 	opts := configureVolumesFromContainer(ops, service)
-	logger.Debugf("\tImage =>\t\t%s\n", opts.Config.Image)
+	log.WithField("image", opts.Config.Image).Info("Data container configured")
 
 	_, err = createContainer(opts)
 	if err != nil {
@@ -78,27 +84,27 @@ func DockerRunData(ops *def.Operation, service *def.Service) (result []byte, err
 
 	// Clean up the container.
 	defer func() {
-		logger.Infof("Removing container =>\t\t%s\n", opts.Name)
+		log.WithField("=>", opts.Name).Info("Removing data container")
 		if err2 := removeContainer(opts.Name, true); err2 != nil {
 			if os.Getenv("CIRCLE_BRANCH") == "" {
 				err = fmt.Errorf("Tragic! Error removing data container after executing (%v): %v", err, err2)
 			}
 		}
-		logger.Infof("Container removed =>\t\t%s\n", opts.Name)
+		log.WithField("=>", opts.Name).Info("Container removed")
 	}()
 
 	// Start the container.
-	logger.Infof("Run Container =>\t\t%s\n", opts.Name)
+	log.WithField("=>", opts.Name).Info("Starting data container")
 	if err = startContainer(opts); err != nil {
 		return nil, err
 	}
 
-	logger.Infof("Waiting to exit =>\t\t%s\n", opts.Name)
+	log.WithField("=>", opts.Name).Info("Waiting for data container to exit")
 	if err := waitContainer(opts.Name); err != nil {
 		return nil, err
 	}
 
-	logger.Debugf("Getting logs for container =>\t%s\n", opts.Name)
+	log.WithField("=>", opts.Name).Info("Getting logs from container")
 	if err = logsContainer(opts.Name, true, "all"); err != nil {
 		return nil, err
 	}
@@ -119,10 +125,13 @@ func DockerRunData(ops *def.Operation, service *def.Service) (result []byte, err
 //
 // See parameter description for DockerRunData.
 func DockerExecData(ops *def.Operation, service *def.Service) (err error) {
-	logger.Infof("DockerExecData =>\t%s:%v\n", ops.DataContainerName, ops.Args)
+	log.WithFields(log.Fields{
+		"=>":   ops.DataContainerName,
+		"args": ops.Args,
+	}).Info("Executing data container")
 
 	opts := configureVolumesFromContainer(ops, service)
-	logger.Debugf("\tImage =>\t\t%s\n", opts.Config.Image)
+	log.WithField("image", opts.Config.Image).Info("Data container configured")
 
 	_, err = createContainer(opts)
 	if err != nil {
@@ -131,17 +140,17 @@ func DockerExecData(ops *def.Operation, service *def.Service) (err error) {
 
 	// Clean up the container.
 	defer func() {
-		logger.Infof("Removing container =>\t\t%s\n", opts.Name)
+		log.WithField("=>", opts.Name).Info("Removing data container")
 		if err2 := removeContainer(opts.Name, true); err2 != nil {
 			if os.Getenv("CIRCLE_BRANCH") == "" {
 				err = fmt.Errorf("Tragic! Error removing data container after executing (%v): %v", err, err2)
 			}
 		}
-		logger.Infof("Container removed =>\t\t%s\n", opts.Name)
+		log.WithField("=>", opts.Name).Info("Data container removed")
 	}()
 
 	// Start the container.
-	logger.Infof("Run Container =>\t\t%s\n", opts.Name)
+	log.WithField("=>", opts.Name).Info("Executing interactive data container")
 	if err = startInteractiveContainer(opts); err != nil {
 		return err
 	}
@@ -172,11 +181,11 @@ func DockerExecData(ops *def.Operation, service *def.Service) (err error) {
 //                          or never if unspecified)
 //
 func DockerRunService(srv *def.Service, ops *def.Operation) error {
-	logger.Infof("Starting Service =>\t\t%s\n", srv.Name)
+	log.WithField("=>", ops.SrvContainerName).Info("Running container")
 
 	_, running := ContainerRunning(ops)
 	if running {
-		logger.Infof("Service already Started. Skipping.\n\tService Name=>\t\t%s\n", srv.Name)
+		log.WithField("=>", ops.SrvContainerName).Info("Container already started. Skipping")
 		return nil
 	}
 
@@ -190,7 +199,7 @@ func DockerRunService(srv *def.Service, ops *def.Operation) error {
 	}
 
 	// Setup data container.
-	logger.Infof("Manage data containers? =>\t%t\n", srv.AutoData)
+	log.WithField("autodata", srv.AutoData).Info("Manage data containers?")
 	if srv.AutoData {
 		optsData, err := configureDataContainer(srv, ops, &optsServ)
 		if err != nil {
@@ -198,9 +207,9 @@ func DockerRunService(srv *def.Service, ops *def.Operation) error {
 		}
 
 		if _, exists := util.ParseContainers(ops.DataContainerName, true); exists {
-			logger.Infoln("Data Container already exists, am not creating.")
+			log.Info("Data container already exists. Not creating")
 		} else {
-			logger.Infoln("Data Container does not exist, creating.")
+			log.Info("Data container does not exist. Creating")
 			_, err := createContainer(optsData)
 			if err != nil {
 				return err
@@ -210,9 +219,9 @@ func DockerRunService(srv *def.Service, ops *def.Operation) error {
 
 	// Check existence || create the container.
 	if _, exists := ContainerExists(ops); exists {
-		logger.Infoln("Service container already exists, am not creating.")
+		log.Debug("Container already exists. Not creating")
 	} else {
-		logger.Infof("Service container does not exist, creating from image (%s).\n", srv.Image)
+		log.WithField("image", srv.Image).Debug("Container does not exist. Creating")
 
 		_, err := createContainer(optsServ)
 		if err != nil {
@@ -221,27 +230,27 @@ func DockerRunService(srv *def.Service, ops *def.Operation) error {
 	}
 
 	// Start the container.
-	logger.Infof("Starting service container =>\t%s\n", optsServ.Name)
-	if srv.AutoData {
-		logger.Infof("\twith data container =>\t%s\n", ops.DataContainerName)
-	}
-	logger.Debugf("\twith EntryPoint =>\t%v\n", optsServ.Config.Entrypoint)
-	logger.Debugf("\twith CMD =>\t\t%v\n", optsServ.Config.Cmd)
-	logger.Debugf("\twith Image =>\t\t%v\n", optsServ.Config.Image)
-	logger.Debugf("\twith AllPortsPubl'd =>\t%v\n", optsServ.HostConfig.PublishAllPorts)
-	logger.Debugf("\twith Environment =>\t%v\n", optsServ.Config.Env)
+	log.WithFields(log.Fields{
+		"=>":              optsServ.Name,
+		"data container":  ops.DataContainerName,
+		"entrypoint":      optsServ.Config.Entrypoint,
+		"cmd":             optsServ.Config.Cmd,
+		"published ports": optsServ.HostConfig.PublishAllPorts,
+		"environment":     optsServ.Config.Env,
+		"image":           optsServ.Config.Image,
+	}).Info("Starting container")
 	if err := startContainer(optsServ); err != nil {
 		return err
 	}
 
 	if ops.Remove {
-		logger.Infof("Removing container =>\t%s\n", optsServ.Name)
+		log.WithField("=>", optsServ.Name).Info("Removing container")
 		if err := removeContainer(optsServ.Name, false); err != nil {
 			return err
 		}
 	}
 
-	logger.Infof("Successfully started service =>\t%s\n", optsServ.Name)
+	log.WithField("=>", optsServ.Name).Info("Container started")
 
 	return nil
 }
@@ -254,7 +263,7 @@ func DockerRunService(srv *def.Service, ops *def.Operation) error {
 //
 // See parameter description for DockerRunService.
 func DockerExecService(srv *def.Service, ops *def.Operation) error {
-	logger.Infof("Starting Service =>\t\t%s\n", srv.Name)
+	log.WithField("=>", ops.SrvContainerName).Info("Executing container")
 
 	optsServ := configureInteractiveContainer(srv, ops)
 
@@ -266,7 +275,8 @@ func DockerExecService(srv *def.Service, ops *def.Operation) error {
 	}
 
 	// Setup data container.
-	logger.Infof("Manage data containers? =>\t%t\n", srv.AutoData)
+	log.WithField("autodata", srv.AutoData).Info("Manage data containers?")
+
 	if srv.AutoData {
 		optsData, err := configureDataContainer(srv, ops, &optsServ)
 		if err != nil {
@@ -274,9 +284,10 @@ func DockerExecService(srv *def.Service, ops *def.Operation) error {
 		}
 
 		if _, exists := util.ParseContainers(ops.DataContainerName, true); exists {
-			logger.Infoln("Data container already exists, am not creating.")
+			log.Info("Data container already exists, am not creating")
 		} else {
-			logger.Infoln("Data container does not exist, creating.")
+			log.Info("Data container does not exist. Creating")
+
 			_, err := createContainer(optsData)
 			if err != nil {
 				return err
@@ -284,30 +295,31 @@ func DockerExecService(srv *def.Service, ops *def.Operation) error {
 		}
 	}
 
-	logger.Infof("Service container does not exist, creating from image (%s).\n", srv.Image)
+	log.WithField("image", srv.Image).Debug("Container does not exist. Creating")
 	_, err = createContainer(optsServ)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
-		logger.Infof("Removing container =>\t\t%s\n", optsServ.Name)
+		log.WithField("=>", optsServ.Name).Info("Removing container")
 		if err := removeContainer(optsServ.Name, false); err != nil {
-			fmt.Errorf("Tragic! Error removing data container after executing (%v): %v", optsServ.Name, err)
+			log.WithField("=>", optsServ.Name).Error("Tragic! Error removing data container after executing")
+			log.Error(err)
 		}
-		logger.Infof("Container removed =>\t\t%s\n", optsServ.Name)
+		log.WithField("=>", optsServ.Name).Info("Container removed")
 	}()
 
 	// Start the container.
-	logger.Infof("Starting service container =>\t%s\n", optsServ.Name)
-	if srv.AutoData {
-		logger.Infof("\twith data container =>\t%s\n", ops.DataContainerName)
-	}
-	logger.Debugf("\twith EntryPoint =>\t%v\n", optsServ.Config.Entrypoint)
-	logger.Debugf("\twith CMD =>\t\t%v\n", optsServ.Config.Cmd)
-	logger.Debugf("\twith Image =>\t\t%v\n", optsServ.Config.Image)
-	logger.Debugf("\twith AllPortsPubl'd =>\t%v\n", optsServ.HostConfig.PublishAllPorts)
-	logger.Debugf("\twith Environment =>\t%v\n", optsServ.Config.Env)
+	log.WithFields(log.Fields{
+		"=>":              optsServ.Name,
+		"data container":  ops.DataContainerName,
+		"entrypoint":      optsServ.Config.Entrypoint,
+		"cmd":             optsServ.Config.Cmd,
+		"ports published": optsServ.HostConfig.PublishAllPorts,
+		"environment":     optsServ.Config.Env,
+		"image":           optsServ.Config.Image,
+	}).Info("Executing interactive container")
 	if err := startInteractiveContainer(optsServ); err != nil {
 		return err
 	}
@@ -329,9 +341,9 @@ func DockerExecService(srv *def.Service, ops *def.Operation) error {
 func DockerRebuild(srv *def.Service, ops *def.Operation, pullImage bool, timeout uint) error {
 	var wasRunning bool = false
 
-	logger.Infof("Starting Docker Rebuild =>\t%s\n", srv.Name)
+	log.WithField("=>", srv.Name).Info("Rebuilding container")
 
-	if service, exists := ContainerExists(ops); exists {
+	if _, exists := ContainerExists(ops); exists {
 		if _, running := ContainerRunning(ops); running {
 			wasRunning = true
 			err := DockerStop(srv, ops, timeout)
@@ -340,19 +352,19 @@ func DockerRebuild(srv *def.Service, ops *def.Operation, pullImage bool, timeout
 			}
 		}
 
-		logger.Infof("Removing old container =>\t%s\n", service.ID)
-		err := removeContainer(service.ID, true)
+		log.WithField("=>", ops.SrvContainerName).Info("Removing old container")
+		err := removeContainer(ops.SrvContainerName, true)
 		if err != nil {
 			return err
 		}
 
 	} else {
-		logger.Infoln("Service did not previously exist. Nothing to rebuild.")
+		log.Info("Container did not previously exist. Nothing to rebuild")
 		return nil
 	}
 
 	if pullImage {
-		logger.Infof("Pulling new image =>\t\t%s\n", srv.Image)
+		log.WithField("image", srv.Image).Info("Pulling image")
 		err := DockerPull(srv, ops)
 		if err != nil {
 			return err
@@ -366,21 +378,21 @@ func DockerRebuild(srv *def.Service, ops *def.Operation, pullImage bool, timeout
 		return err
 	}
 
-	logger.Infof("Creating new cont for srv =>\t%s\n", srv.Name)
+	log.WithField("=>", ops.SrvContainerName).Info("Recreating container")
 	_, err = createContainer(opts)
 	if err != nil {
 		return err
 	}
 
 	if wasRunning {
-		logger.Infof("Restarting srv with new ID =>\t%s\n", opts.Name)
+		log.WithField("=>", opts.Name).Info("Restarting container")
 		err := startContainer(opts)
 		if err != nil {
 			return err
 		}
 	}
 
-	logger.Infof("Finished rebuilding service =>\t%s\n", srv.Name)
+	log.WithField("=>", ops.SrvContainerName).Info("Container rebuilt")
 
 	return nil
 }
@@ -395,12 +407,14 @@ func DockerRebuild(srv *def.Service, ops *def.Operation, pullImage bool, timeout
 //
 // Also see container parameters for DockerRunService.
 func DockerPull(srv *def.Service, ops *def.Operation) error {
-	logger.Infof("Pulling an image (%s) for the service (%s)\n", srv.Image, srv.Name)
+	log.WithFields(log.Fields{
+		"=>":    srv.Name,
+		"image": srv.Image,
+	}).Info("Pulling container image for")
 
 	var wasRunning bool = false
 
-	if service, exists := ContainerExists(ops); exists {
-		logger.Infoln("Found Service ID: " + service.ID)
+	if _, exists := ContainerExists(ops); exists {
 		if _, running := ContainerRunning(ops); running {
 			wasRunning = true
 			err := DockerStop(srv, ops, 10)
@@ -408,14 +422,14 @@ func DockerPull(srv *def.Service, ops *def.Operation) error {
 				return err
 			}
 		}
-		err := removeContainer(service.ID, false)
+		err := removeContainer(ops.SrvContainerName, false)
 		if err != nil {
 			return err
 		}
 	}
 
-	if logger.Level > 0 {
-		err := pullImage(srv.Image, logger.Writer)
+	if log.GetLevel() > 0 {
+		err := pullImage(srv.Image, os.Stdout)
 		if err != nil {
 			return err
 		}
@@ -440,13 +454,17 @@ func DockerPull(srv *def.Service, ops *def.Operation) error {
 // output. If follow is true, it behaves like `tail -f`. It returns Docker
 // errors on exit if not successful.
 func DockerLogs(srv *def.Service, ops *def.Operation, follow bool, tail string) error {
-	if service, exists := ContainerExists(ops); exists {
-		logger.Infof("Getting Logs for Service ID =>\t%s:%v:%v\n", service.ID, follow, tail)
-		if err := logsContainer(service.ID, follow, tail); err != nil {
+	if _, exists := ContainerExists(ops); exists {
+		log.WithFields(log.Fields{
+			"=>":     ops.SrvContainerName,
+			"follow": follow,
+			"tail":   tail,
+		}).Info("Getting logs")
+		if err := logsContainer(ops.SrvContainerName, follow, tail); err != nil {
 			return err
 		}
 	} else {
-		logger.Infoln("Service does not exist. Cannot display logs.")
+		log.Info("Container does not exist. Cannot display logs")
 	}
 
 	return nil
@@ -457,14 +475,14 @@ func DockerLogs(srv *def.Service, ops *def.Operation, follow bool, tail string) 
 // either "line" to display a short info line or "all" to display everything. I
 // DockerInspect returns Docker errors on exit in not successful.
 func DockerInspect(srv *def.Service, ops *def.Operation, field string) error {
-	if service, exists := ContainerExists(ops); exists {
-		logger.Infof("Inspecting Service ID =>\t%s\n", service.ID)
-		err := inspectContainer(service.ID, field)
+	if _, exists := ContainerExists(ops); exists {
+		log.WithField("=>", ops.SrvContainerName).Info("Inspecting")
+		err := inspectContainer(ops.SrvContainerName, field)
 		if err != nil {
 			return err
 		}
 	} else {
-		logger.Infoln("Service container does not exist. Cannot inspect.")
+		log.Info("Container does not exist. Cannot inspect")
 	}
 	return nil
 }
@@ -478,23 +496,27 @@ func DockerStop(srv *def.Service, ops *def.Operation, timeout uint) error {
 	// don't limit this to verbose because it takes a few seconds
 	// [zr] unless force sets timeout to 0 (for, eg. stdout)
 	if timeout != 0 {
-		logger.Printf("Docker is Stopping =>\t\t%s\tThis may take a few seconds.\n", srv.Name)
+		log.WithField("=>", srv.Name).Warn("Stopping (may take a few seconds)")
 	}
-	logger.Debugf("\twith ContainerNumber =>\t%d\n", ops.ContainerNumber)
-	logger.Debugf("\twith SrvContnerName =>\t%s\n", ops.SrvContainerName)
 
-	container, running := ContainerExists(ops)
+	log.WithFields(log.Fields{
+		"=>":      ops.SrvContainerName,
+		"timeout": timeout,
+	}).Info("Stopping container")
+
+	_, running := ContainerExists(ops)
 	if running {
-		logger.Infof("Service is running =>\t\t%s:%d\n", srv.Name, ops.ContainerNumber)
-		err := stopContainer(container.ID, timeout)
+		log.WithField("=>", ops.SrvContainerName).Debug("Container found running")
+
+		err := stopContainer(ops.SrvContainerName, timeout)
 		if err != nil {
 			return err
 		}
 	} else {
-		logger.Infof("Service is not running =>\t%s:%d\n", srv.Name, ops.ContainerNumber)
+		log.WithField("=>", ops.SrvContainerName).Debug("Container found not running")
 	}
 
-	logger.Infof("Finished stopping service =>\t%s\n", srv.Name)
+	log.WithField("=>", ops.SrvContainerName).Info("Container stopped")
 
 	return nil
 }
@@ -513,17 +535,18 @@ func DockerStop(srv *def.Service, ops *def.Operation, timeout uint) error {
 func DockerRename(ops *def.Operation, newName string) error {
 	longNewName := util.ContainersName(ops.ContainerType, newName, ops.ContainerNumber)
 
-	logger.Infof("Renaming container =>\t\t%s to %s\n", ops.SrvContainerName, longNewName)
+	log.WithFields(log.Fields{
+		"from": ops.SrvContainerName,
+		"to":   longNewName,
+	}).Info("Renaming container")
 
-	logger.Debugln("\tChecking container exist")
-
+	log.WithField("=>", ops.SrvContainerName).Debug("Checking container exists")
 	container, err := util.DockerClient.InspectContainer(ops.SrvContainerName)
 	if err != nil {
 		return err
 	}
 
-	logger.Debugln("\tChecking new container exist (should fail)")
-
+	log.WithField("=>", longNewName).Debug("Checking new container exists")
 	_, err = util.DockerClient.InspectContainer(longNewName)
 	if err == nil {
 		return ErrContainerExists
@@ -532,14 +555,13 @@ func DockerRename(ops *def.Operation, newName string) error {
 	// Mark if the container's running to restart it later.
 	_, wasRunning := ContainerRunning(ops)
 	if wasRunning {
-		logger.Debugln("\tStopping container")
+		log.Debug("Stopping old container")
 		if err := util.DockerClient.StopContainer(container.ID, 5); err != nil {
-			logger.Debugln("\tNot stopped")
+			log.Debug("Container not stopped")
 		}
 	}
 
-	logger.Debugln("\tRemoving container")
-
+	log.Debug("Removing container")
 	removeOpts := docker.RemoveContainerOptions{
 		ID:            container.ID,
 		RemoveVolumes: true,
@@ -549,8 +571,7 @@ func DockerRename(ops *def.Operation, newName string) error {
 		return err
 	}
 
-	logger.Debugln("\tCreating the new container")
-
+	log.Debug("Creating new container")
 	createOpts := docker.CreateContainerOptions{
 		Name:       longNewName,
 		Config:     container.Config,
@@ -577,7 +598,7 @@ func DockerRename(ops *def.Operation, newName string) error {
 
 	newContainer, err := util.DockerClient.CreateContainer(createOpts)
 	if err != nil {
-		logger.Debugln("Not created")
+		log.Debug("Container not created")
 		return err
 	}
 
@@ -585,11 +606,11 @@ func DockerRename(ops *def.Operation, newName string) error {
 	if wasRunning {
 		err := util.DockerClient.StartContainer(newContainer.ID, createOpts.HostConfig)
 		if err != nil {
-			logger.Debugln("Not restarted")
+			log.Debug("Container not restarted")
 		}
 	}
 
-	logger.Infoln("Container renamed")
+	log.WithField("=>", longNewName).Info("Container renamed to")
 
 	return nil
 }
@@ -599,21 +620,21 @@ func DockerRename(ops *def.Operation, newName string) error {
 // If volumes is true, the associated volumes are removed for both containers.
 // DockerRemove returns Docker errors on exit if not successful.
 func DockerRemove(srv *def.Service, ops *def.Operation, withData, volumes bool) error {
-	if service, exists := ContainerExists(ops); exists {
-		logger.Infof("Removing Service ID =>\t\t%s\n", service.ID)
-		if err := removeContainer(service.ID, volumes); err != nil {
+	if _, exists := ContainerExists(ops); exists {
+		log.WithField("=>", ops.SrvContainerName).Info("Removing container")
+		if err := removeContainer(ops.SrvContainerName, volumes); err != nil {
 			return err
 		}
 		if withData {
-			if srv, ext := DataContainerExists(ops); ext {
-				logger.Infof("\t with DataContanr ID =>\t%s\n", srv.ID)
-				if err := removeContainer(srv.ID, volumes); err != nil {
+			if _, ext := DataContainerExists(ops); ext {
+				log.WithField("=>", ops.DataContainerName).Info("Removing dependent data container")
+				if err := removeContainer(ops.DataContainerName, volumes); err != nil {
 					return err
 				}
 			}
 		}
 	} else {
-		logger.Infoln("Service container does not exist. Cannot remove.")
+		log.Info("Container does not exist. Cannot remove")
 	}
 
 	return nil
@@ -690,17 +711,20 @@ func createContainer(opts docker.CreateContainerOptions) (*docker.Container, err
 		if err == docker.ErrNoSuchImage {
 			if os.Getenv("ERIS_PULL_APPROVE") != "true" {
 				var input string
-				logger.Printf("The docker image (%s) is not found locally.\nWould you like the marmots to pull it from the repository? (y/n) ", opts.Config.Image)
+				log.WithField("image", opts.Config.Image).Warn("The docker image not found locally")
+				fmt.Print("Would you like the marmots to pull it from the repository? (y/n): ")
 				fmt.Scanln(&input)
 
 				if input == "Y" || input == "y" || input == "YES" || input == "Yes" || input == "yes" {
-					logger.Debugf("\nUser assented to pull.\n")
+					log.Debug("User assented to pull")
 				} else {
-					logger.Debugf("\nUser refused to pull.\n")
+					log.Debug("User refused to pull")
 					return nil, fmt.Errorf("Cannot start a container based on an image you will not let me pull.\n")
 				}
 			} else {
-				logger.Printf("The docker image (%s) is not found locally.\nThe marmots are approved to pull from the repository on your behalf.\nThis could take a minute.\n", opts.Config.Image)
+				log.WithField("image", opts.Config.Image).Warn("The Docker image is not found locally")
+				log.Warn("The marmots are approved to pull it from the repository on your behalf")
+				log.Warn("This could take a few minutes")
 			}
 			if err := pullImage(opts.Config.Image, nil); err != nil {
 				return nil, err
@@ -721,22 +745,14 @@ func startContainer(opts docker.CreateContainerOptions) error {
 }
 
 func startInteractiveContainer(opts docker.CreateContainerOptions) error {
-	// Set terminal into raw mode, and restore upon container exit.
-	savedState, err := term.SetRawTerminal(os.Stdin.Fd())
-	if err != nil {
-		logger.Infoln("Cannot set the terminal into raw mode")
-	} else {
-		defer term.RestoreTerminal(os.Stdin.Fd(), savedState)
-	}
-
 	// Trap signals so we can drop out of the container.
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, os.Kill)
 	go func() {
 		<-c
-		logger.Infof("\nCaught signal. Stopping container %s\n", opts.Name)
-		if err = stopContainer(opts.Name, 5); err != nil {
-			logger.Errorf("Error stopping container: %v\n", err)
+		log.WithField("=>", opts.Name).Info("Caught signal. Stopping container")
+		if err := stopContainer(opts.Name, 5); err != nil {
+			log.Errorf("Error stopping container: %v", err)
 		}
 	}()
 
@@ -755,7 +771,16 @@ func startInteractiveContainer(opts docker.CreateContainerOptions) error {
 		attached <- struct{}{}
 	}
 
-	logger.Infof("Waiting to exit for removal =>\t%s\n", opts.Name)
+	log.WithField("=>", opts.Name).Info("Waiting for container to exit")
+
+	// Set terminal into raw mode, and restore upon container exit.
+	savedState, err := term.SetRawTerminal(os.Stdin.Fd())
+	if err != nil {
+		log.Info("Cannot set the terminal into raw mode")
+	} else {
+		defer term.RestoreTerminal(os.Stdin.Fd(), savedState)
+	}
+
 	if err := waitContainer(opts.Name); err != nil {
 		return err
 	}
@@ -844,8 +869,6 @@ func inspectContainer(id, field string) error {
 }
 
 func stopContainer(id string, timeout uint) error {
-	logger.Debugf("\twith ContainerID =>\t%s\n", id)
-	logger.Debugf("\twith Timeout =>\t\t%d\n", timeout)
 	err := util.DockerClient.StopContainer(id, timeout)
 	if err != nil {
 		return err
@@ -1048,7 +1071,11 @@ func configureVolumesFromContainer(ops *def.Operation, service *def.Service) doc
 		opts.Config.Entrypoint = strings.Fields(service.EntryPoint)
 	}
 
-	logger.Debugf("configurVolumesFromContainer =>\t%v:%v\n", opts.Config.Cmd, opts.Config.Entrypoint)
+	log.WithFields(log.Fields{
+		"cmd":        opts.Config.Cmd,
+		"entrypoint": opts.Config.Entrypoint,
+	}).Debug("Data container configured")
+
 	return opts
 }
 

--- a/perform/docker_run.go
+++ b/perform/docker_run.go
@@ -1054,8 +1054,8 @@ func configureVolumesFromContainer(ops *def.Operation, service *def.Service) doc
 		},
 	}
 
+	opts.Config.OpenStdin = true
 	if ops.Interactive {
-		opts.Config.OpenStdin = true
 		opts.Config.Cmd = []string{"/bin/bash"}
 	} else {
 		opts.Config.Cmd = ops.Args

--- a/perform/log.go
+++ b/perform/log.go
@@ -1,7 +1,0 @@
-package perform
-
-import (
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
-)
-
-var logger = AddLogger("perform")

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -19,9 +19,9 @@ import (
 func TestMain(m *testing.M) {
 	log.SetFormatter(logger.ErisFormatter{})
 
-	// log.SetLevel(log.ErrorLevel)
+	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)
-	log.SetLevel(log.DebugLevel)
+	// log.SetLevel(log.DebugLevel)
 
 	tests.IfExit(tests.TestsInit("perform"))
 

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -9,20 +9,19 @@ import (
 	"github.com/eris-ltd/eris-cli/config"
 	def "github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/loaders"
+	"github.com/eris-ltd/eris-cli/logger"
 	tests "github.com/eris-ltd/eris-cli/testutils"
 	"github.com/eris-ltd/eris-cli/util"
 
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	var logLevel log.LogLevel
+	log.SetFormatter(logger.ErisFormatter{})
 
-	logLevel = 0
-	// logLevel = 1
-	// logLevel = 3
-
-	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
+	// log.SetLevel(log.ErrorLevel)
+	// log.SetLevel(log.InfoLevel)
+	log.SetLevel(log.DebugLevel)
 
 	tests.IfExit(tests.TestsInit("perform"))
 
@@ -327,7 +326,7 @@ func TestExecServiceSimple(t *testing.T) {
 
 func TestExecServiceLogOutput(t *testing.T) {
 	const (
-		name   = "ipfs"
+		name   = "keys"
 		number = 99
 	)
 
@@ -357,7 +356,7 @@ func TestExecServiceLogOutput(t *testing.T) {
 
 func TestExecServiceLogOutputLongRunning(t *testing.T) {
 	const (
-		name   = "ipfs"
+		name   = "keys"
 		number = 99
 	)
 
@@ -387,7 +386,7 @@ func TestExecServiceLogOutputLongRunning(t *testing.T) {
 
 func TestExecServiceLogOutputInteractive(t *testing.T) {
 	const (
-		name   = "ipfs"
+		name   = "keys"
 		number = 99
 	)
 
@@ -1475,7 +1474,7 @@ func TestLogsSimple(t *testing.T) {
 	const (
 		name   = "ipfs"
 		number = 99
-		tail   = "10"
+		tail   = "100"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1504,7 +1503,7 @@ func TestLogsSimple(t *testing.T) {
 		t.Fatalf("expected logs pulled, got %v", err)
 	}
 
-	if !strings.Contains(buf.String(), "Initializing daemon") {
+	if !strings.Contains(buf.String(), "Starting IPFS") {
 		t.Fatalf("expected certain log entries, got %q", buf.String())
 	}
 }
@@ -1547,7 +1546,7 @@ func TestLogsTail(t *testing.T) {
 	const (
 		name   = "ipfs"
 		number = 99
-		tail   = "2"
+		tail   = "100"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1576,7 +1575,7 @@ func TestLogsTail(t *testing.T) {
 		t.Fatalf("expected logs pulled, got %v", err)
 	}
 
-	if !strings.Contains(buf.String(), "Gateway") {
+	if !strings.Contains(buf.String(), "Starting IPFS") {
 		t.Fatalf("expected certain log entries, got %q", buf.String())
 	}
 }

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -326,7 +326,7 @@ func TestExecServiceSimple(t *testing.T) {
 
 func TestExecServiceLogOutput(t *testing.T) {
 	const (
-		name   = "keys"
+		name   = "ipfs"
 		number = 99
 	)
 
@@ -386,7 +386,7 @@ func TestExecServiceLogOutputLongRunning(t *testing.T) {
 
 func TestExecServiceLogOutputInteractive(t *testing.T) {
 	const (
-		name   = "keys"
+		name   = "ipfs"
 		number = 99
 	)
 

--- a/services/load.go
+++ b/services/load.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+        "os"
 
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/loaders"
@@ -18,6 +19,10 @@ var (
 
 //checks that a service is running. if not, tells user to start it
 func EnsureRunning(do *definitions.Do) error {
+        if os.Getenv("ERIS_SKIP_ENSURE") != "" {
+               return nil
+        } 
+
 	srv, err := loaders.LoadServiceDefinition(do.Name, false, do.Operations.ContainerNumber)
 	if err != nil {
 		return err

--- a/services/load.go
+++ b/services/load.go
@@ -8,6 +8,8 @@ import (
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/loaders"
 	"github.com/eris-ltd/eris-cli/util"
+
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 var (
@@ -25,18 +27,18 @@ func EnsureRunning(do *definitions.Do) error {
 		e := fmt.Sprintf("The requested service is not running, start it with `eris services start %s`", do.Name)
 		return errors.New(e)
 	} else {
-		logger.Infof("%s is running.\n", strings.ToUpper(do.Name))
+		log.WithField("=>", strings.ToUpper(do.Name)).Info("Service is running")
 	}
 	return nil
 }
 
 func IsServiceExisting(service *definitions.Service, ops *definitions.Operation) bool {
-	logger.Debugf("Is Service Existing? =>\t\t%s:%d\n", service.Name, ops.ContainerNumber)
+	log.WithField("=>", fmt.Sprintf("%s:%d", service.Name, ops.ContainerNumber)).Debug("Checking service existing")
 	return parseContainers(service, ops, true)
 }
 
 func IsServiceRunning(service *definitions.Service, ops *definitions.Operation) bool {
-	logger.Debugf("Is Service Running? =>\t\t%s:%d\n", service.Name, ops.ContainerNumber)
+	log.WithField("=>", fmt.Sprintf("%s:%d", service.Name, ops.ContainerNumber)).Debug("Checking service running")
 	return parseContainers(service, ops, false)
 }
 
@@ -54,14 +56,14 @@ func parseContainers(service *definitions.Service, ops *definitions.Operation, a
 	if cName == nil {
 		return false
 	}
-	ops.SrvContainerName = cName.DockersName
+	ops.SrvContainerName = cName.FullName
 	ops.SrvContainerID = cName.ContainerID
 
 	// populate data container specifics
 	if service.AutoData && ops.DataContainerID == "" {
 		dName := util.FindDataContainer(service.Name, ops.ContainerNumber)
 		if dName != nil {
-			ops.DataContainerName = dName.DockersName
+			ops.DataContainerName = dName.FullName
 			ops.DataContainerID = dName.ContainerID
 		}
 	}

--- a/services/log.go
+++ b/services/log.go
@@ -1,7 +1,0 @@
-package services
-
-import (
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
-)
-
-var logger = AddLogger("services")

--- a/services/manage.go
+++ b/services/manage.go
@@ -42,7 +42,7 @@ func ImportService(do *definitions.Do) error {
 	_, err = loaders.LoadServiceDefinition(do.Name, false, 0)
 	//XXX add protections?
 	if err != nil {
-		return fmt.Errorf("Your service defintion file looks improperly formatted and will not marshal.")
+		return fmt.Errorf("Your service definition file looks improperly formatted and will not marshal.")
 	}
 
 	do.Result = "success"
@@ -281,17 +281,15 @@ func InspectServiceByService(srv *definitions.Service, ops *definitions.Operatio
 }
 
 func exportFile(servName string) (string, error) {
-	fileName := fmt.Sprintf("%s%s", FindServiceDefinitionFile(servName), ".toml")
-
-	fn := path.Join(ServicesPath, fileName)
+	fileName := FindServiceDefinitionFile(servName)
 
 	var hash string
 	var err error
 
 	if log.GetLevel() > 0 {
-		hash, err = ipfs.SendToIPFS(fn, "", os.Stdout)
+		hash, err = ipfs.SendToIPFS(fileName, "", os.Stdout)
 	} else {
-		hash, err = ipfs.SendToIPFS(fn, "", bytes.NewBuffer([]byte{}))
+		hash, err = ipfs.SendToIPFS(fileName, "", bytes.NewBuffer([]byte{}))
 	}
 
 	if err != nil {

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	def "github.com/eris-ltd/eris-cli/definitions"
 	ini "github.com/eris-ltd/eris-cli/initialize"
@@ -31,6 +30,9 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.DebugLevel)
 
 	tests.IfExit(testsInit())
+
+        // Prevent CLI from starting IPFS.
+        os.Setenv("ERIS_SKIP_ENSURE", "true")
 
 	exitCode := m.Run()
 
@@ -231,9 +233,6 @@ func TestKillRmService(t *testing.T) {
 }
 
 func TestExportService(t *testing.T) {
-	testStartService(t, "ipfs", false)
-	time.Sleep(5 * time.Second)
-
 	do := def.NowDo()
 	do.Name = "ipfs"
 

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -10,10 +10,11 @@ import (
 	def "github.com/eris-ltd/eris-cli/definitions"
 	ini "github.com/eris-ltd/eris-cli/initialize"
 	"github.com/eris-ltd/eris-cli/loaders"
+	"github.com/eris-ltd/eris-cli/logger"
 	tests "github.com/eris-ltd/eris-cli/testutils"
 	"github.com/eris-ltd/eris-cli/util"
 
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 var srv *def.ServiceDefinition
@@ -22,19 +23,17 @@ var servName string = "ipfs"
 var hash string
 
 func TestMain(m *testing.M) {
-	var logLevel log.LogLevel
+	log.SetFormatter(logger.ErisFormatter{})
 
-	logLevel = 0
-	// logLevel = 1
-	// logLevel = 3
-
-	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
+	// log.SetLevel(log.ErrorLevel)
+	// log.SetLevel(log.InfoLevel)
+	log.SetLevel(log.DebugLevel)
 
 	tests.IfExit(testsInit())
 
 	exitCode := m.Run()
 
-	logger.Infoln("Commensing with Tests Tear Down.")
+	log.Info("Tearing tests down")
 	if os.Getenv("TEST_IN_CIRCLE") != "true" {
 		tests.IfExit(tests.TestsTearDown())
 	}
@@ -64,26 +63,33 @@ func TestLoadServiceDefinition(t *testing.T) {
 	var e error
 	srv, e = loaders.LoadServiceDefinition(servName, true, 1)
 	if e != nil {
-		logger.Errorln(e)
+		log.Error(e)
 		tests.IfExit(e)
 	}
 
 	if srv.Name != servName {
-		logger.Errorf("FAILURE: improper name on LOAD. expected: %s\tgot: %s\n", servName, srv.Name)
+		log.WithFields(log.Fields{
+			"expected": servName,
+			"got":      srv.Name,
+		}).Error("Improper name on load")
 	}
 
 	if srv.Service.Name != servName {
-		logger.Errorf("FAILURE: improper service name on LOAD. expected: %s\tgot: %s\n", servName, srv.Service.Name)
+		log.WithFields(log.Fields{
+			"expected": servName,
+			"got":      srv.Service.Name,
+		}).Error("Improper service name on load")
+
 		tests.IfExit(e)
 	}
 
 	if !srv.Service.AutoData {
-		logger.Errorf("FAILURE: data_container not properly read on LOAD.\n")
+		log.Error("data_container not properly read on load")
 		tests.IfExit(e)
 	}
 
 	if srv.Operations.DataContainerName == "" {
-		logger.Errorf("FAILURE: data_container_name not set.\n")
+		log.Error("data_container_name not set")
 		tests.IfExit(e)
 	}
 }
@@ -101,10 +107,14 @@ func TestInspectService(t *testing.T) {
 	do.Name = servName
 	do.Operations.Args = []string{"name"}
 	do.Operations.ContainerNumber = 1
-	logger.Debugf("Inspect service (via tests) =>\t%s:%v:%d\n", servName, do.Operations.Args, do.Operations.ContainerNumber)
+	log.WithFields(log.Fields{
+		"=>":   fmt.Sprintf("%s:%d", servName, do.Operations.ContainerNumber),
+		"args": do.Operations.Args,
+	}).Debug("Inspect service (from tests)")
+
 	e := InspectService(do)
 	if e != nil {
-		logger.Infof("Error inspecting service =>\t%v\n", e)
+		log.Infof("Error inspecting service: %v", e)
 		tests.IfExit(e)
 	}
 
@@ -112,10 +122,13 @@ func TestInspectService(t *testing.T) {
 	do.Name = servName
 	do.Operations.Args = []string{"config.user"}
 	do.Operations.ContainerNumber = 1
-	logger.Debugf("Inspect service (via tests) =>\t%s:%v\n", servName, do.Operations.Args)
+	log.WithFields(log.Fields{
+		"=>":   servName,
+		"args": do.Operations.Args,
+	}).Debug("Inspect service (from tests)")
 	e = InspectService(do)
 	if e != nil {
-		logger.Infof("Error inspecting service =>\t%v\n", e)
+		log.Infof("Error inspecting service: %v", e)
 		tests.IfExit(e)
 	}
 }
@@ -127,20 +140,18 @@ func TestLogsService(t *testing.T) {
 	do.Name = servName
 	do.Follow = false
 	do.Tail = "5"
-	logger.Debugf("Inspect logs (via tests) =>\t%s:%v\n", servName, do.Tail)
+	log.WithFields(log.Fields{
+		"=>":   servName,
+		"tail": do.Tail,
+	}).Debug("Inspect logs (from tests)")
 	e := LogsService(do)
 	if e != nil {
-		logger.Errorln(e)
+		log.Error(e)
 		tests.IfExit(e)
 	}
 }
 
 func TestExecService(t *testing.T) {
-	/*if os.Getenv("TEST_IN_CIRCLE") == "true" {
-		logger.Println("Testing in Circle. Where we don't have exec privileges (due to their driver). Skipping test.")
-		return
-	}*/
-
 	testStartService(t, servName, true)
 	defer testKillService(t, servName, true)
 
@@ -148,10 +159,13 @@ func TestExecService(t *testing.T) {
 	do.Name = servName
 	do.Operations.Interactive = false
 	do.Operations.Args = strings.Fields("ls -la /root/")
-	logger.Debugf("Exec-ing serv (via tests) =>\t%s:%v\n", servName, strings.Join(do.Operations.Args, " "))
+	log.WithFields(log.Fields{
+		"=>":   servName,
+		"args": do.Operations.Args,
+	}).Debug("Executing service (from tests)")
 	e := ExecService(do)
 	if e != nil {
-		logger.Errorln(e)
+		log.Error(e)
 		t.Fail()
 	}
 }
@@ -160,7 +174,7 @@ func TestUpdateService(t *testing.T) {
 	testStartService(t, servName, false)
 	defer testKillService(t, servName, true)
 	if os.Getenv("TEST_IN_CIRCLE") == "true" {
-		logger.Println("Testing in Circle. Where we don't have rm privileges (due to their driver). Skipping test.")
+		log.Warn("Testing in Circle where we don't have rm privileges. Skipping test")
 		return
 	}
 
@@ -168,10 +182,10 @@ func TestUpdateService(t *testing.T) {
 	do.Name = servName
 	do.Pull = false
 	do.Timeout = 1
-	logger.Debugf("Update serv (via tests) =>\t%s\n", servName)
+	log.WithField("=>", servName).Debug("Update service (from tests)")
 	e := UpdateService(do)
 	if e != nil {
-		logger.Errorln(e)
+		log.Error(e)
 		tests.IfExit(e)
 	}
 
@@ -186,9 +200,9 @@ func TestKillRmService(t *testing.T) {
 	do.Rm = false
 	do.RmD = false
 	do.Operations.Args = []string{servName}
-	logger.Debugf("Stopping serv (via tests) =>\t%s\n", servName)
+	log.WithField("=>", servName).Debug("Stopping service (from tests)")
 	if e := KillService(do); e != nil {
-		logger.Errorln(e)
+		log.Error(e)
 		tests.IfExit(e)
 	}
 
@@ -196,7 +210,7 @@ func TestKillRmService(t *testing.T) {
 	testNumbersExistAndRun(t, servName, 1, 0)
 
 	if os.Getenv("TEST_IN_CIRCLE") == "true" {
-		logger.Println("Testing in Circle. Where we don't have rm privileges (due to their driver). Skipping test.")
+		log.Warn("Testing in Circle where we don't have rm privileges. Skipping test")
 		return
 	}
 
@@ -205,9 +219,9 @@ func TestKillRmService(t *testing.T) {
 	do.Operations.Args = []string{servName}
 	do.File = false
 	do.RmD = true
-	logger.Debugf("Removing serv (via tests) =>\t%s\n", servName)
+	log.WithField("=>", servName).Debug("Removing service (from tests)")
 	if e := RmService(do); e != nil {
-		logger.Errorln(e)
+		log.Error(e)
 		tests.IfExit(e)
 	}
 
@@ -253,7 +267,10 @@ func TestImportService(t *testing.T) {
 	} else {
 		do.Hash = hash
 	}
-	logger.Debugf("Import-ing serv (via tests) =>\t%s:%v\n", do.Name, do.Hash)
+	log.WithFields(log.Fields{
+		"=>":   do.Name,
+		"hash": do.Hash,
+	}).Debug("Importing service (from tests)")
 
 	// because IPFS is testy, we retry the put up to
 	// 10 times.
@@ -283,21 +300,26 @@ func TestNewService(t *testing.T) {
 	servName := "keys"
 	do.Name = servName
 	do.Operations.Args = []string{"quay.io/eris/keys"}
-	logger.Debugf("New-ing serv (via tests) =>\t%s:%v\n", do.Name, do.Operations.Args)
+
+	log.WithFields(log.Fields{
+		"=>":   do.Name,
+		"args": do.Operations.Args,
+	}).Debug("Creating a new service (from tests)")
 	e := NewService(do)
 	if e != nil {
-		logger.Errorln(e)
+		log.Error(e)
 		tests.IfExit(e)
 	}
 
 	do = def.NowDo()
 	do.Operations.Args = []string{servName}
-	// do.Operations.ContainerNumber = util.AutoMagic(0, "service")
-	//do.Operations.ContainerNumber = 1
-	logger.Debugf("Starting serv (via tests) =>\t%v:%d\n", do.Operations.Args, do.Operations.ContainerNumber)
+	log.WithFields(log.Fields{
+		"container number": do.Operations.ContainerNumber,
+		"args":             do.Operations.Args,
+	}).Debug("Starting service (from tests)")
 	e = StartService(do)
 	if e != nil {
-		logger.Errorln(e)
+		log.Error(e)
 		tests.IfExit(e)
 	}
 
@@ -315,9 +337,10 @@ func TestRenameService(t *testing.T) {
 	do := def.NowDo()
 	do.Name = "keys"
 	do.NewName = "syek"
-	// do.Operations.ContainerNumber = util.AutoMagic(0, "service")
-	//do.Operations.ContainerNumber = 1
-	logger.Debugf("Renaming serv (via tests) =>\t%s:%v\n", do.Name, do.NewName)
+	log.WithFields(log.Fields{
+		"from": do.Name,
+		"to":   do.NewName,
+	}).Debug("Renaming service (from tests)")
 	if e := RenameService(do); e != nil {
 		tests.IfExit(fmt.Errorf("Error (tests fail) =>\t\t%v\n", e))
 	}
@@ -330,11 +353,12 @@ func TestRenameService(t *testing.T) {
 	do = def.NowDo()
 	do.Name = "syek"
 	do.NewName = "keys"
-	// do.Operations.ContainerNumber = util.AutoMagic(0, "service")
-	//do.Operations.ContainerNumber = 1
-	logger.Debugf("Renaming serv (via tests) =>\t%s:%v\n", do.Name, do.NewName)
+	log.WithFields(log.Fields{
+		"from": do.Name,
+		"to":   do.NewName,
+	}).Debug("Renaming service (from tests)")
 	if e := RenameService(do); e != nil {
-		logger.Errorf("Error (tests fail) =>\t\t%v\n", e)
+		log.Errorf("Error (tests fail): %v", e)
 		tests.IfExit(e)
 	}
 
@@ -362,11 +386,12 @@ func TestCatService(t *testing.T) {
 func TestStartKillServiceWithDependencies(t *testing.T) {
 	do := def.NowDo()
 	do.Operations.Args = []string{"do_not_use"}
-	//do.Operations.ContainerNumber = 1
-	// do.Operations.ContainerNumber = util.AutoMagic(0, "service")
-	logger.Debugf("Starting service with deps =>\t%s:%s\n", servName, "keys")
+	log.WithFields(log.Fields{
+		"service":    servName,
+		"dependency": "keys",
+	}).Debug("Starting service with dependency (from tests)")
 	if e := StartService(do); e != nil {
-		logger.Infof("Error starting service =>\t%v\n", e)
+		log.Infof("Error starting service: %v", e)
 		tests.IfExit(e)
 	}
 
@@ -376,10 +401,7 @@ func TestStartKillServiceWithDependencies(t *testing.T) {
 		testExistAndRun(t, servName, 1, false, false)
 		testNumbersExistAndRun(t, servName, 0, 0)
 
-		// XXX: option for kill to kill dependencies too
 		testKillService(t, "keys", true)
-		//testExistAndRun(t, "keys", 1, false, false)
-		//testNumbersExistAndRun(t, "keys", 1, 0)
 	}()
 
 	testExistAndRun(t, servName, 1, true, true)
@@ -397,10 +419,10 @@ func testStartService(t *testing.T, serviceName string, publishAll bool) {
 	do.Operations.Args = []string{serviceName}
 	do.Operations.ContainerNumber = 1 //util.AutoMagic(0, "service", true)
 	do.Operations.PublishAllPorts = publishAll
-	logger.Debugf("Starting service (via tests) =>\t%s:%d\n", serviceName, do.Operations.ContainerNumber)
+	log.WithField("=>", fmt.Sprintf("%s:%d", serviceName, do.Operations.ContainerNumber)).Debug("Starting service (from tests)")
 	e := StartService(do)
 	if e != nil {
-		logger.Infof("Error starting service =>\t%v\n", e)
+		log.Infof("Error starting service: %v", e)
 		tests.IfExit(e)
 	}
 
@@ -409,7 +431,7 @@ func testStartService(t *testing.T, serviceName string, publishAll bool) {
 }
 
 func testKillService(t *testing.T, serviceName string, wipe bool) {
-	logger.Debugf("Stopping serv (via tests) =>\t%s\n", servName)
+	log.WithField("=>", servName).Debug("Stopping service (from tests)")
 
 	do := def.NowDo()
 	do.Name = serviceName
@@ -420,7 +442,7 @@ func testKillService(t *testing.T, serviceName string, wipe bool) {
 	}
 	e := KillService(do)
 	if e != nil {
-		logger.Errorln(e)
+		log.Error(e)
 		tests.IfExit(e)
 	}
 	testExistAndRun(t, serviceName, 1, !wipe, false)
@@ -434,11 +456,16 @@ func testExistAndRun(t *testing.T, servName string, containerNumber int, toExist
 }
 
 func testNumbersExistAndRun(t *testing.T, servName string, containerExist, containerRun int) {
-	logger.Infof("\nTesting number of (%s) containers. Existing? (%d) and Running? (%d)\n", servName, containerExist, containerRun)
+	log.WithFields(log.Fields{
+		"=>":        servName,
+		"existing#": containerExist,
+		"running#":  containerRun,
+	}).Info("Checking number of containers for")
 
-	logger.Debugf("Checking Existing Containers =>\t%s\n", servName)
+	log.WithField("=>", servName).Debug("Checking existing containers for")
 	exist := util.HowManyContainersExisting(servName, "service")
-	logger.Debugf("Checking Running Containers =>\t%s\n", servName)
+
+	log.WithField("=>", servName).Debug("Checking running containers for")
 	run := util.HowManyContainersRunning(servName, "service")
 
 	if exist != containerExist {
@@ -449,7 +476,7 @@ func testNumbersExistAndRun(t *testing.T, servName string, containerExist, conta
 		tests.IfExit(fmt.Errorf("Wrong number of containers running for service (%s). Expected (%d). Got (%d).\n", servName, containerRun, run))
 	}
 
-	logger.Infoln("All good.\n")
+	log.Info("All good")
 }
 
 func testsInit() error {

--- a/testutils/testing_server.go
+++ b/testutils/testing_server.go
@@ -1,0 +1,166 @@
+package testutils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+)
+
+// This is a fake server implementation to test Eris command line tools
+// hitting proper API endpoints.
+
+// Server holds an httptest.Server handler along with the last recorded
+// API endpoint call (path, method, body).
+type Server struct {
+	mu       *sync.RWMutex
+	server   *httptest.Server
+	response ServerResponse
+
+	path   string
+	method string
+	body   string
+}
+
+// ServerResponse holds predefined server response for any API call.
+// SetResponse() method can change that after the fake server
+// has been created.
+type ServerResponse struct {
+	Code   int
+	Body   string
+	Header http.Header
+}
+
+// ServeHTTP is an http.Handler interface implementation. This handler serves
+// all API calls and records the last path, method and request body.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := ioutil.ReadAll(r.Body)
+	defer r.Body.Close()
+
+	// Record request.
+	s.setMethod(r.Method)
+	s.setPath(r.URL.Path)
+	s.setBody(string(body))
+
+	// Send out prerecorded response.
+	for k, v := range s.response.Header {
+		w.Header()[k] = v
+	}
+	w.WriteHeader(s.response.Code)
+	fmt.Fprintf(w, s.response.Body)
+}
+
+// Method returns the last HTTP method used to call the server.
+func (s *Server) Method() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.method
+}
+
+// Path returns the last API path used to call the server.
+func (s *Server) Path() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.path
+}
+
+// Body returns the last request body sent to the server.
+func (s *Server) Body() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.body
+}
+
+// URL returns the base URL path for the server.
+func (s Server) URL() string {
+	return s.server.URL
+}
+
+// Close stops the server.
+func (s *Server) Close() {
+	s.server.Close()
+}
+
+// SetResponse changes the prerecorded response for the running server.
+func (s *Server) SetResponse(response ServerResponse) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.response = response
+}
+
+func (s *Server) setMethod(method string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.method = method
+}
+
+func (s *Server) setPath(path string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.path = path
+}
+
+func (s *Server) setBody(body string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.body = body
+}
+
+// NewServer creates a new fake server that serves requests at addr base URL.
+// addr parameter is optional; if it is omitted, random port is used to serve
+// on localhost. That random port can be retrieved with server.URL() call.
+// NewServer returns nil on error.
+//
+// Usage:
+//
+//   server := testutils.NewServer()
+//
+//   server := testutils.NewServer("localhost:8080")
+//   server.SetResponse(testutils.ServerResponse{
+//	Code: http.StatusNotFound,
+//      Body: "{}",
+//      Header: map[string][]string{
+//     	   "Content-Type": []string{"application/json"},
+//      },
+//   })
+//
+func NewServer(params ...interface{}) *Server {
+	s := &Server{
+		mu: &sync.RWMutex{},
+		response: ServerResponse{
+			Code:   http.StatusOK,
+			Header: make(map[string][]string),
+		},
+	}
+
+	// NewServer().
+	if len(params) == 0 {
+		s.server = httptest.NewServer(s)
+		return s
+	}
+
+	// NewServer(addr).
+	s.server = httptest.NewUnstartedServer(s)
+
+	if _, ok := params[0].(string); !ok {
+		panic("can accept only strings as addr")
+	}
+
+	listener, err := net.Listen("tcp", params[0].(string))
+	if err != nil {
+		return nil
+	}
+	s.server.Listener = listener
+	s.server.Start()
+
+	return s
+}

--- a/testutils/testing_server.go
+++ b/testutils/testing_server.go
@@ -152,12 +152,12 @@ func NewServer(params ...interface{}) *Server {
 	s.server = httptest.NewUnstartedServer(s)
 
 	if _, ok := params[0].(string); !ok {
-		panic("can accept only strings as addr")
+                panic("can accept only strings as addr")
 	}
 
 	listener, err := net.Listen("tcp", params[0].(string))
 	if err != nil {
-		return nil
+		panic(err)
 	}
 	s.server.Listener = listener
 	s.server.Start()

--- a/testutils/testing_server.go
+++ b/testutils/testing_server.go
@@ -24,9 +24,8 @@ type Server struct {
 	body   string
 }
 
-// ServerResponse holds predefined server response for any API call.
-// SetResponse() method can change that after the fake server
-// has been created.
+// ServerResponse holds a prerecorded server response for any API call.
+// The response can be set with the SetResponse() method.
 type ServerResponse struct {
 	Code   int
 	Body   string
@@ -50,6 +49,56 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(s.response.Code)
 	fmt.Fprintf(w, s.response.Body)
+}
+
+// NewServer creates a new fake server that serves requests at addr base URL.
+// addr parameter is optional; if it is omitted, random port is used to serve
+// on localhost. That random port can be retrieved with server.URL() call.
+// NewServer panics on error.
+//
+// Usage:
+//
+//   server := testutils.NewServer()
+//
+//   server := testutils.NewServer("localhost:8080")
+//   server.SetResponse(testutils.ServerResponse{
+//	Code: http.StatusNotFound,
+//      Body: "{}",
+//      Header: map[string][]string{
+//     	   "Content-Type": []string{"application/json"},
+//      },
+//   })
+//
+func NewServer(addr ...interface{}) *Server {
+	s := &Server{
+		mu: &sync.RWMutex{},
+		response: ServerResponse{
+			Code:   http.StatusOK,
+			Header: make(map[string][]string),
+		},
+	}
+
+	// NewServer().
+	if len(addr) == 0 {
+		s.server = httptest.NewServer(s)
+		return s
+	}
+
+	// NewServer(addr).
+	s.server = httptest.NewUnstartedServer(s)
+
+	if _, ok := addr[0].(string); !ok {
+		panic("can accept only strings as addr")
+	}
+
+	listener, err := net.Listen("tcp", addr[0].(string))
+	if err != nil {
+		panic(err)
+	}
+	s.server.Listener = listener
+	s.server.Start()
+
+	return s
 }
 
 // Method returns the last HTTP method used to call the server.
@@ -113,54 +162,4 @@ func (s *Server) setBody(body string) {
 	defer s.mu.Unlock()
 
 	s.body = body
-}
-
-// NewServer creates a new fake server that serves requests at addr base URL.
-// addr parameter is optional; if it is omitted, random port is used to serve
-// on localhost. That random port can be retrieved with server.URL() call.
-// NewServer returns nil on error.
-//
-// Usage:
-//
-//   server := testutils.NewServer()
-//
-//   server := testutils.NewServer("localhost:8080")
-//   server.SetResponse(testutils.ServerResponse{
-//	Code: http.StatusNotFound,
-//      Body: "{}",
-//      Header: map[string][]string{
-//     	   "Content-Type": []string{"application/json"},
-//      },
-//   })
-//
-func NewServer(params ...interface{}) *Server {
-	s := &Server{
-		mu: &sync.RWMutex{},
-		response: ServerResponse{
-			Code:   http.StatusOK,
-			Header: make(map[string][]string),
-		},
-	}
-
-	// NewServer().
-	if len(params) == 0 {
-		s.server = httptest.NewServer(s)
-		return s
-	}
-
-	// NewServer(addr).
-	s.server = httptest.NewUnstartedServer(s)
-
-	if _, ok := params[0].(string); !ok {
-                panic("can accept only strings as addr")
-	}
-
-	listener, err := net.Listen("tcp", params[0].(string))
-	if err != nil {
-		panic(err)
-	}
-	s.server.Listener = listener
-	s.server.Start()
-
-	return s
 }

--- a/testutils/testing_utils.go
+++ b/testutils/testing_utils.go
@@ -1,4 +1,4 @@
-package testings
+package testutils
 
 import (
 	"fmt"
@@ -48,10 +48,6 @@ func TestsInit(testType string) (err error) {
 	do.Yes = true
 	if err := ini.Initialize(do); err != nil {
 		IfExit(fmt.Errorf("TRAGIC. Could not initialize the eris dir.\n"))
-	}
-
-	if testType == "services" {
-		checkIPFSnotRunning() //TODO make more general & use for other things?
 	}
 
 	log.Info("Test init completed. Starting main test sequence now")

--- a/testutils/testing_utils.go
+++ b/testutils/testing_utils.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -182,6 +183,23 @@ func FakeServiceDefinition(tmpDir, name, definition string) error {
 // Remove the Docker image. A wrapper over Docker client's library.
 func RemoveImage(name string) error {
 	return util.DockerClient.RemoveImage(name)
+}
+
+// FileContents returns the contents of a file as a string
+// or panics on error.
+func FileContents(filename string) string {
+	f, err := os.Open(filename)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	content, err := ioutil.ReadAll(f)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(content)
 }
 
 // each pacakge will need its own custom stuff if need be

--- a/util/chains_info.go
+++ b/util/chains_info.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 )
 
@@ -52,11 +53,11 @@ func GetHead() (string, error) {
 // Expects the chain type and head (id) to be full (already resolved)
 func ChangeHead(name string) error {
 	if !IsKnownChain(name) && name != "" {
-		logger.Debugf("Chain name not known. Not saving.\n")
+		log.Debug("Chain name not known. Not saving")
 		return nil
 	}
 
-	logger.Debugf("Chain name known (or blank). Saving to head file.\n")
+	log.Debug("Chain name known (or blank). Saving to head file")
 	// read in the entire head file and clip
 	// if we have reached the max length
 	b, err := ioutil.ReadFile(common.HEAD)
@@ -80,6 +81,6 @@ func ChangeHead(name string) error {
 		return err
 	}
 
-	logger.Debugf("Head file saved.\n")
+	log.Debug("Head file saved")
 	return nil
 }

--- a/util/clean.go
+++ b/util/clean.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient"
+
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 func Clean(prompt, all, rmd, images bool) error {
@@ -94,7 +96,7 @@ func removeErisDir(prompt bool) error {
 			return err
 		}
 	} else {
-		logger.Println("permission to remove eris root directory not given, continuing with clean")
+		log.Warn("Permission to remove eris root directory not given, continuing with clean")
 	}
 	return nil
 }
@@ -127,7 +129,7 @@ func removeErisImages(prompt bool) error {
 		for _, rt := range repoTag {
 			r, err := regexp.Compile(`eris`)
 			if err != nil {
-				logger.Printf("regexp error: %v\n", err)
+				log.Errorf("Regexp error: %v", err)
 			}
 
 			if r.MatchString(rt) == true {
@@ -139,13 +141,16 @@ func removeErisImages(prompt bool) error {
 
 	if !prompt || canWeRemove(erisImages, "images") {
 		for i, imageID := range erisImageIDs {
-			logger.Debugf("removing image: %s with ID\t%s ", erisImages[i], imageID)
+			log.WithFields(log.Fields{
+				"=>": erisImages[i],
+				"id": imageID,
+			}).Debug("Removing image")
 			if err := DockerClient.RemoveImage(imageID); err != nil {
 				return err
 			}
 		}
 	} else {
-		logger.Println("permission to remove images not given, continuing with clean")
+		log.Warn("Permission to remove images not given, continuing with clean")
 	}
 	return nil
 }
@@ -154,14 +159,16 @@ func canWeRemove(removing []string, what string) bool {
 	//if nothing in removing, say so and return, or something
 	var input string
 	if what == "all" {
-		logger.Printf("The marmots are about to forcefully remove all running and existing eris containers with corresponding volumes. Please confirm (y/Y):\n")
+		fmt.Print("The marmots are about to forcefully remove all running and existing eris containers with corresponding volumes. Please confirm (y/Y): ")
 	} else {
-		logger.Printf("The marmots are about to remove %s:\n%sPlease confirm (y/Y):", what, strings.Join(removing, "\n"))
+		log.WithField("=>", what).Warn("The marmots are about to remove")
+		log.Warn(strings.Join(removing, "\n"))
+		fmt.Print("Please confirm (y/Y): ")
 	}
 
 	fmt.Scanln(&input)
 	if input == "Y" || input == "y" || input == "YES" || input == "Yes" || input == "yes" {
-		logger.Printf("authorization given, removing %s\n", what)
+		log.WithField("=>", what).Warn("Authorization given, removing")
 		return true
 	} else {
 		return false

--- a/util/container_info.go
+++ b/util/container_info.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient"
 )
 
@@ -53,12 +54,12 @@ func ContainerDisassemble(containerName string) *ContainerName {
 	pop := strings.Split(containerName, "_")
 
 	if len(pop) < 4 {
-		logger.Debugln("The marmots cannot disassemble container name", containerName)
+		log.WithField("=>", containerName).Debug("The marmots cannot disassemble container name")
 		return &ContainerName{}
 	}
 
 	if !(pop[0] == "eris" || pop[0] == "/eris") {
-		logger.Debugln("The marmots cannot disassemble container name", containerName)
+		log.WithField("=>", containerName).Debug("The marmots cannot disassemble container name")
 		return &ContainerName{}
 	}
 
@@ -66,7 +67,8 @@ func ContainerDisassemble(containerName string) *ContainerName {
 	srt := strings.Join(pop[2:len(pop)-1], "_")
 	num, err := strconv.Atoi(pop[len(pop)-1])
 	if err != nil {
-		logger.Debugln("The marmots cannot disassemble container name", containerName)
+		log.WithField("=>", containerName).Debug("The marmots cannot disassemble container name")
+
 		return &ContainerName{}
 	}
 
@@ -121,9 +123,8 @@ func ErisContainersByType(typ string, running bool) []*ContainerName {
 	contns, err := DockerClient.ListContainers(docker.ListContainersOptions{All: running})
 
 	if len(contns) == 0 || err != nil {
-		logger.Infoln("There are no containers.")
 		if err != nil {
-			logger.Debugf("Marmot error duing DockerClient.ListContainers: %v\n", err)
+			log.Debugf("Marmot error during Docker container listing: %v", err)
 		}
 		return containers
 	}
@@ -135,7 +136,6 @@ func ErisContainersByType(typ string, running bool) []*ContainerName {
 			}
 			if r.MatchString(c) {
 				c = strings.Replace(c, "/", "", 1) // Docker's leading slash
-				// logger.Debugf("Found Eris Container =>\t\t%s\n", c)
 				cont := ContainerDisassemble(c)
 				cont.ContainerID = con.ID
 				containers = append(containers, cont)
@@ -174,13 +174,11 @@ func ServiceContainers(running bool) []*ContainerName {
 }
 
 func ServiceContainerNames(running bool) []string {
-	// logger.Debugf("Populating current containrs =>\tall? %t\n", running)
 	a := ServiceContainers(running)
 	b := []string{}
 	for _, c := range a {
 		b = append(b, c.ShortName)
 	}
-	// logger.Debugf("Containers I found =>\t\t%v\n", b)
 	return b
 }
 
@@ -241,12 +239,12 @@ func FindServiceContainer(srvName string, number int, running bool) *ContainerNa
 	for _, srv := range ServiceContainers(running) {
 		if srv.ShortName == srvName {
 			if srv.Number == number {
-				logger.Debugf("Found Service container =>\t%s:%s and %d:%d\n", srv.ShortName, srvName, srv.Number, number)
+				log.WithField("match", fmt.Sprintf("%s:%d", srv.ShortName, srv.Number)).Debug("Found service container")
 				return srv
 			}
 		}
 	}
-	logger.Infof("Could not find service cont =>\t%s:%d\n", srvName, number)
+	log.WithField("=>", fmt.Sprintf("%s:%d", srvName, number)).Info("Could not find service container")
 	return nil
 }
 
@@ -262,12 +260,12 @@ func FindChainContainer(name string, number int, running bool) *ContainerName {
 	for _, srv := range ChainContainers(running) {
 		if srv.ShortName == name {
 			if srv.Number == number {
-				logger.Debugf("Found Chain container =>\t%s:%s and %d:%d\n", srv.ShortName, name, srv.Number, number)
+				log.WithField("match", fmt.Sprintf("%s:%d", srv.ShortName, srv.Number)).Debug("Found chain container")
 				return srv
 			}
 		}
 	}
-	logger.Infof("Could not find chain cont =>\t%s:%d\n", name, number)
+	log.WithField("=>", fmt.Sprintf("%s:%d", name, number)).Info("Could not find chain container")
 	return nil
 }
 
@@ -282,12 +280,12 @@ func FindDataContainer(name string, number int) *ContainerName {
 	for _, srv := range DataContainers() {
 		if srv.ShortName == name {
 			if srv.Number == number {
-				logger.Debugf("Found Data container =>\t\t%s:%s and %d:%d\n", srv.ShortName, name, srv.Number, number)
+				log.WithField("match", fmt.Sprintf("%s:%d", srv.ShortName, srv.Number)).Debug("Found data container")
 				return srv
 			}
 		}
 	}
-	logger.Infof("Could not find data cont =>\t%s:%d\n", name, number)
+	log.WithField("=>", fmt.Sprintf("%s:%d", name, number)).Info("Could not find data container")
 	return nil
 }
 

--- a/util/container_operations.go
+++ b/util/container_operations.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	dirs "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 )
 
@@ -87,7 +88,7 @@ func Merge(base, over interface{}) error {
 // container to work on unless newCont == true in which case it would return the highest
 // container number plus one.
 func AutoMagic(cNum int, typ string, newCont bool) int {
-	logger.Debugf("Automagic (base) =>\t\t%s:%d\n", typ, cNum)
+	log.WithField("automagic", cNum).Debug()
 	contns := ErisContainersByType(typ, true)
 
 	contnums := make([]int, len(contns))
@@ -112,7 +113,8 @@ func AutoMagic(cNum int, typ string, newCont bool) int {
 		result = 1
 	}
 
-	logger.Debugf("Automagic (result) =>\t\t%s:%d\n", typ, result)
+	log.WithField("automagic", result).Debug()
+
 	return result
 }
 

--- a/util/container_stats.go
+++ b/util/container_stats.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/eris-ltd/eris-cli/config"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/oleiade/reflections"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/olekukonko/tablewriter"
@@ -36,7 +37,7 @@ func PrintInspectionReport(cont *docker.Container, field string) error {
 		if err != nil {
 			return err
 		}
-		logger.Printf("%s\n", strings.Join(parts, " "))
+		log.Warn(strings.Join(parts, " "))
 	case "all":
 		for _, obj := range []interface{}{cont, cont.Config, cont.HostConfig, cont.NetworkSettings} {
 			t, err := reflections.Fields(obj)
@@ -55,7 +56,7 @@ func PrintInspectionReport(cont *docker.Container, field string) error {
 }
 
 func PrintTableReport(typ string, existing, all bool) (string, error) {
-	logger.Debugf("PrintTableReport Initialized =>\t%s", typ)
+	log.WithField("type", typ).Debug("Table report initialized")
 
 	var conts []*ContainerName
 	if !all {
@@ -148,9 +149,9 @@ func PrintPortMappings(id string, ports []string) error {
 
 			// If only one port request, display just the binding.
 			if minimalDisplay {
-				logger.Printf("%s\n", hostAndPortBinding)
+				log.Warn(hostAndPortBinding)
 			} else {
-				logger.Printf("%s -> %s\n", port, hostAndPortBinding)
+				log.Warnf("%s -> %s", port, hostAndPortBinding)
 			}
 		}
 	}
@@ -181,7 +182,7 @@ func printLine(container *docker.Container, existing bool) ([]string, error) {
 
 // this function is for parsing single variables
 func printField(container interface{}, field string) error {
-	logger.Debugf("Inspecting field =>\t\t%s\n", field)
+	log.WithField("=>", field).Debug("Inspecting field")
 	var line string
 
 	// We allow fields to be passed using dot syntax, but
@@ -193,7 +194,7 @@ func printField(container interface{}, field string) error {
 	FieldCamel := strings.Join(lineSplit, ".")
 
 	f, _ := reflections.GetFieldKind(container, FieldCamel)
-	logger.Debugln("field type", f.String())
+	log.Debug("Field type", f)
 	switch f.String() {
 	case "ptr":
 		//we don't recurse into to gain a bit more control... this function will be rarely used and doesn't have to be perfectly parseable.
@@ -268,7 +269,7 @@ func camelize(field string) string {
 }
 
 func writeTemplate(container interface{}, toParse string) error {
-	logger.Debugf("Template parsing =>\t\t%s", toParse)
+	log.WithField("=>", strings.Replace(toParse, "\n", " ", -1)).Info("Template parsing")
 	tmpl, err := template.New("field").Parse(toParse)
 	if err != nil {
 		return err
@@ -291,7 +292,7 @@ func ParseContainers(name string, all bool) (docker.APIContainers, bool) {
 	if all == false {
 		category = "running"
 	}
-	logger.Debugf("Parsing Containers =>\t\t%s:%s\n", name, category)
+	log.WithField("=>", fmt.Sprintf("%s:%s", name, category)).Debug("Parsing containers")
 	containers := listContainers(all)
 
 	r := regexp.MustCompile(name)
@@ -300,13 +301,13 @@ func ParseContainers(name string, all bool) (docker.APIContainers, bool) {
 		for _, container := range containers {
 			for _, n := range container.Names {
 				if r.MatchString(n) {
-					logger.Debugf("Container Found =>\t\t%s\n", name)
+					log.WithField("=>", name).Debug("Container found")
 					return container, true
 				}
 			}
 		}
 	}
-	logger.Debugf("Container Not Found =>\t\t%s\n", name)
+	log.WithField("=>", name).Debug("Container not found")
 	return docker.APIContainers{}, false
 }
 

--- a/util/docker_client.go
+++ b/util/docker_client.go
@@ -31,7 +31,7 @@ func DockerConnect(verbose bool, machName string) { // TODO: return an error...?
 			//if os.Getenv("DOCKER_HOST") == "" && os.Getenv("DOCKER_CERT_PATH") == "" {
 			endpoint := "unix:///var/run/docker.sock"
 
-			log.WithField("=>", endpoint).Debug("Checking the Linux Docker socket")
+			log.WithField("=>", endpoint).Debug("Checking Linux Docker socket")
 			u, _ := url.Parse(endpoint)
 			_, err := net.Dial(u.Scheme, u.Path)
 			if err != nil {
@@ -77,11 +77,11 @@ func DockerConnect(verbose bool, machName string) { // TODO: return an error...?
 		dockerHost, dockerCertPath, err = getMachineDeets(machName) // machName is "eris" by default
 
 		if err != nil {
-			log.Debug("Could not connect to the Eris Docker Machine")
+			log.Debug("Could not connect to Eris Docker Machine")
 			log.Errorf("Trying %q Docker Machine: %v", "default", err)
 			dockerHost, dockerCertPath, err = getMachineDeets("default") // during toolbox setup this is the machine that is created
 			if err != nil {
-				log.Debugf("Could not connect to the %q Docker Machine", "default")
+				log.Debugf("Could not connect to %q Docker Machine", "default")
 				log.Debugf("Error: %v", err)
 				log.Debug("Trying to set up new machine")
 				if e2 := CheckDockerClient(); e2 != nil {
@@ -210,7 +210,7 @@ func getMachineDeets(machName string) (string, string, error) {
 		return "", "", noConnectError
 	}
 
-	log.Info("Querying whether the host and user have access to the right files for TLS connection to Docker")
+	log.Info("Querying host and user have access to the right files for TLS connection to Docker")
 	if err := checkKeysAndCerts(dPath); err != nil {
 		return "", "", err
 	}

--- a/util/listing_functions.go
+++ b/util/listing_functions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/definitions"
 )
 
@@ -79,7 +80,7 @@ func ListRunningOrExisting(quiet, testing, existing bool, typ string) (result st
 	if existing {
 		re = "Existing"
 	}
-	logger.Debugf("Asking Docker Client for the %s Containers. Quiet? %v\n", re, quiet)
+	log.WithField("status", strings.ToLower(re)).Debug("Asking Docker to list containers")
 
 	if quiet || testing {
 		if typ == "services" {
@@ -94,11 +95,11 @@ func ListRunningOrExisting(quiet, testing, existing bool, typ string) (result st
 
 	} else {
 		if typ == "services" {
-			logger.Debugf("List%sRaw:PrintTable =>\t%s:%v\n", re, "service", existing)
+			log.WithField("=>", fmt.Sprintf("service:%v", strings.ToLower(re))).Debug("Printing table")
 			result, _ = PrintTableReport("service", existing, false) //false is for All, dealt with somewhere else
 		}
 		if typ == "chains" {
-			logger.Debugf("List%sRaw:PrintTable =>\t%s:%v\n", re, "chain", existing)
+			log.WithField("=>", fmt.Sprintf("chain:%v", strings.ToLower(re))).Debugf("Printing table")
 			result, _ = PrintTableReport("chain", existing, false)
 		}
 		if typ == "data" {

--- a/util/log.go
+++ b/util/log.go
@@ -1,7 +1,0 @@
-package util
-
-import (
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
-)
-
-var logger = AddLogger("util")

--- a/util/migrate_dirs_test.go
+++ b/util/migrate_dirs_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 
 	"github.com/eris-ltd/eris-cli/config"
+	"github.com/eris-ltd/eris-cli/logger"
 
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 var erisDir string = path.Join(os.TempDir(), "eris")
@@ -25,26 +26,21 @@ var apps string = path.Join(erisDir, "apps")
 var newDirs = []string{chains, apps}
 
 func TestMain(m *testing.M) {
-	var logLevel log.LogLevel
+	log.SetFormatter(logger.ErisFormatter{})
 
-	logLevel = 0
-	// logLevel = 1
-	// logLevel = 3
-
-	log.SetLoggers(logLevel, os.Stdout, os.Stderr)
+	log.SetLevel(log.ErrorLevel)
+	// log.SetLevel(log.InfoLevel)
+	// log.SetLevel(log.DebugLevel)
 
 	if err := testsInit(); err != nil {
-		logger.Errorln(err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 
 	exitCode := m.Run()
 
 	if os.Getenv("TEST_IN_CIRCLE") != "true" {
 		if err := testsTearDown(); err != nil {
-			logger.Errorln(err)
-			log.Flush()
-			os.Exit(1)
+			log.Fatal(err)
 		}
 	}
 
@@ -177,8 +173,7 @@ func testsTearDown() error {
 
 func ifExit(err error) {
 	if err != nil {
-		logger.Errorln(err)
-		log.Flush()
+		log.Error(err)
 		testsTearDown()
 		os.Exit(1)
 	}

--- a/util/update_tool.go
+++ b/util/update_tool.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 )
 
@@ -17,7 +19,8 @@ func UpdateEris(branch string) {
 	//checks for deprecated dir names and renames them
 	err := MigrateDeprecatedDirs(common.DirsToMigrate, false) // false = no prompt
 	if err != nil {
-		logger.Printf("directory migration error: %v\ncontinuing with update without migration\n", err)
+		log.Warnf("Directory migration error: %v", err)
+		log.Warn("Continuing with update without migration")
 	}
 
 	//change pwd to eris/cli
@@ -33,24 +36,20 @@ func UpdateEris(branch string) {
 	InstallEris()
 	ver := version() //because version.Version will be in RAM.
 
-	logger.Printf("The marmots have updated eris successfully.\n%s\n", ver)
+	log.WithField("version", ver).Warn("The marmots have updated Eris successfully")
 }
 
 func CheckGitAndGo(git, gO bool) {
 	if git {
 		stdOut1, err := exec.Command("git", "version").CombinedOutput()
 		if err != nil {
-			logger.Printf("ensure you have git installed:\n%v\n", string(stdOut1))
-			logger.Println("or if running `eris init` use the --skip-pull flag")
-			os.Exit(1)
-
+			log.WithField("version", string(stdOut1)).Fatal("Ensure you have git installed or if running `eris init` use the `--skip-pull` flag")
 		}
 	}
 	if gO {
 		stdOut2, err := exec.Command("go", "version").CombinedOutput()
 		if err != nil {
-			logger.Printf("ensure you have go installed:\n%s\n", string(stdOut2))
-			os.Exit(1)
+			log.WithField("version", string(stdOut2)).Fatal("Ensure you have Go installed")
 		}
 	}
 }
@@ -58,19 +57,17 @@ func CheckGitAndGo(git, gO bool) {
 func ChangeDirectory() {
 	goPath := os.Getenv("GOPATH")
 	if goPath == "" {
-		fmt.Printf("You do not have $GOPATH set. Please make sure this is set and rerun the command.\n")
-		os.Exit(1)
+		log.Fatal("You do not have $GOPATH set. Please make sure this is set and rerun the command")
 	}
 
 	dir := path.Join(goPath, "src/github.com/eris-ltd/eris-cli/")
 	err := os.Chdir(dir)
 
 	if err != nil {
-		fmt.Printf("error changing directory\n%v\n", err)
-		os.Exit(1)
+		log.Fatalf("Error changing directory: %v")
 	}
 
-	logger.Debugf("directory changed to:\n%s\n", dir)
+	log.WithField("dir", dir).Debug("Directory changed to")
 }
 
 func CheckoutBranch(branch string) {
@@ -78,11 +75,10 @@ func CheckoutBranch(branch string) {
 
 	stdOut, err := exec.Command("git", checkoutArgs...).CombinedOutput()
 	if err != nil {
-		fmt.Printf("error checking out %s:\n%s\n", branch, string(stdOut))
-		os.Exit(1)
+		log.WithField("branch", branch).Fatalf("Error checking out branch: %v", string(stdOut))
 	}
 
-	logger.Debugf("%s checked-out\n", branch)
+	log.WithField("branch", branch).Debug("Branch checked-out")
 }
 
 func PullBranch(branch string) {
@@ -90,11 +86,10 @@ func PullBranch(branch string) {
 
 	stdOut, err := exec.Command("git", pullArgs...).CombinedOutput()
 	if err != nil {
-		fmt.Printf("error pulling from github:\n%s\n", string(stdOut))
-		os.Exit(1)
+		log.Fatalf("Error pulling from GitHub: %v", string(stdOut))
 	}
 
-	logger.Debugf("%s pulled successfully\n", branch)
+	log.WithField("branch", branch).Debug("Branch pulled successfully")
 }
 
 func InstallEris() {
@@ -102,11 +97,10 @@ func InstallEris() {
 
 	stdOut, err := exec.Command("go", goArgs...).CombinedOutput()
 	if err != nil {
-		fmt.Printf("error with go install ./cmd/eris:\n%s\n", string(stdOut))
-		os.Exit(1)
+		log.Fatalf("Error with go install ./cmd/eris: %v", string(stdOut))
 	}
 
-	logger.Debugf("Go install worked correctly.\n")
+	log.Debug("Go install worked correctly")
 }
 
 func version() string {


### PR DESCRIPTION
The Logrus library replaces the current logging library to allow to get rid of formatting in log messages (tabs, newlines, `=>`) and to make the code look cleaner.

## Library usage

Simple logging at various levels:

```
log.Fatalf("Error changing directory: %v")
log.Error(err)
log.Warn("Failed to get that file. Sorry")
log.Info("Chain container does not exist")
log.Debug("Not requiring input. Proceeding")
``` 

Logging with a stand out item (unnamed). That item is most often a container, a chain, or a service name.

```
log.WithField("=>", doChns.Name).Debug("Starting chain")
``` 

Logging with a named stand out parameter. 

```
log.WithField("args", do.Operations.Args).Info("Performing action (from tests)")
log.WithField("image", srv.Image).Debug("Container does not exist. Creating")
log.WithField("drop", dropped).Debug()
```

Logging with multiple standout parameters.

```
log.WithFields(log.Fields{
	"from": do.Name,
	"to":   do.NewName,
}).Info("Renaming action")
  
log.WithFields(log.Fields{
  	"=>":        servName,
	"existing#": containerExist,
	"running#":  containerRun,
}).Info("Checking number of containers for")
```
  
Standout item names are sorted alphabetically with the unnamed parameter `=>` always the first. The order can be changed by splitting one log message into multiple log messages:
  
```
log.WithField("running#", containerRun).Info()
log.WithField("existing#", containerExist).Info()
log.WithField("=>", servName).Info("Checking number of containers for")
```
  
### Eris' default log levels

Default Eris log level for command line tools has been set to `warn`.

```
log.SetLevel(log.WarnLevel)
if do.Verbose {
	log.SetLevel(log.InfoLevel)
} else if do.Debug {
	log.SetLevel(log.DebugLevel)
}
```

### Test prologue

```
log.SetFormatter(logger.ErisFormatter{})

log.SetLevel(log.ErrorLevel)
// log.SetLevel(log.InfoLevel)
// log.SetLevel(log.DebugLevel)
```

### Writer

Logrus library doesn't give access to its writer, so the writer has been set to `stdout`:

```
if log.GetLevel() > 0 {
  err = ipfs.GetFromIPFS(s[1], fileName, "", os.Stdout)
} else {
  err = ipfs.GetFromIPFS(s[1], fileName, "", bytes.NewBuffer([]byte{}))
}
```

### A few things for consideration

* Logrus' `Print` level equals `Info` level in the new library and is printed out only when the `verbose` or `debug` mode is on, so older `log.Print()` log messages have been converted to `log.Warn()` (or to `log.Error()` where it made more sense) with a few exceptions.

* Logrus always ends a log message with an `\n`, so there's no need to invoke `log.Infoln()` or `log.Infof("\n")` or similar. For this reason, the messages that require user's input (**Do you wish to continue? (y/n):**) have been converted to use `fmt.Print()`.

* Logrus logs only to `stderr`.

* Logrus's comma operator doesn't add a space between operands (a small bug on the library's part). This snippet:

  ```
  log.Print("a", "b")
  ```
  
  produces `ab\n`. (While it should have produced `a b\n`)

## Log messages

These rules have been applied to log messages while rewriting them in some places:

* Sentences start with a capital letter, but don't end with a dot. Multiple sentences on the same line are separated with a dot: **Chain not currently running. Skipping** 
* Articles in log messages are usually dropped (magazine headline style); separate words are not capitalized: **Getting connection details from environment**
* Names of functions are removed, but the messages are made still easily distinguishable (greppable): **Running data container** (instead of **DockerRunData**) or **Table report initialized** (instead of **PrintTableReport Initialized**).
* Verbs for log messages; nouns for tags (the `WithField` thing). The noun log messages are converted to verbs or tags:

  ```
  log.WithField("drop", dropped).Debug()
  ```
  
  instead of

  ```
  logger.Debugf("Args to add to the steps =>\t%s\n", dropped)
  ```
  
* Removed all initial indents: **"Blah-blah-blah"** instead of **"\tBlah-blah-blah"**.
* All references to container `id`s have been removed or replaced with container full names.
* Log messages in tests have been given the suffix **from tests** (vs **via tests**) for more uniformity.

## Color scheme

![256color](http://i.imgur.com/8u3XSVa.png)

The yellow on the screenshot is not a color, but the bold terminal attribute which allows for more flexibility with various user's color schemes and terminal settings. 

Errors and warnings are not using special colors (tried a few—abandoned; they make the output look distracting and cheaper).

Reversed fore- and background and a different Terminal color setting for bold:

![reversed](http://i.imgur.com/FKmI8jR.png)

This is Linux console on Digital Ocean (its stand out color is white):

![linux](http://i.imgur.com/WBPCSoh.png)

Dark grey is the only color with this color scheme. It is neutral enough and can match many user defined color schemes. Some modern terminals adjust the colors to prevent them from becoming invisible (Mac OS Terminal app):

Darker background:

![darkgrey1](http://i.imgur.com/J54YQVR.png)

Lighter background:

![darkgrey2](http://i.imgur.com/wzJoLef.png)

On terminals with 8 colors:

```
$ TERM=linux eris services start ipfs -d
```
![8colors](http://i.imgur.com/9fuAdpq.png)

On terminals with no color support or Windows:

```
$ TERM=dumb eris services start ipfs -d
```
![0colors](http://i.imgur.com/SyK6lU7.png)
 
## Other changes

* The tests for `ImportService`, `ExportService`, `PutFiles`, `GetFiles` have been rewritten to use a fake service implementation which records which API endpoints have been called and responds with a fixed response. The tests check that the functions call the server and that they do what they're supposed to do with received results (return a hash, create a file, etc.) This way it is much more faster and reliable and still tests both Eris CLI and `common/go/ipfs` library. Most importantly, it will allow to get rid of IPFS startup errors once and for all. The only downside is that if the IPFS API interface changes, the Eris CLI tests wouldn't know that.
* The `TestServiceLinkChainedService()` test has been amended for more robustness.
* The `perform` package functions have been changed to use container full names instead of IDs.
