### PR TITLE
data directory & command (minor refactor)

### DIFF
--- a/commands/data.go
+++ b/commands/data.go
@@ -181,7 +181,6 @@ func RmData(cmd *cobra.Command, args []string) {
 	IfExit(data.RmData(do))
 }
 
-//TODO add checks for ErisContainerRoot
 //src on host, dest in container
 func ImportData(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(3, "eq", cmd, args))

--- a/commands/data.go
+++ b/commands/data.go
@@ -24,13 +24,15 @@ The [eris data import] and [eris data export] commands should be
 thought of from the point of view of the container.
 
 The [eris data import] command sends a directory *as is* from 
-SRC on the host to DEST inside of the data container.
+SRC on the host to an existing DEST inside of the data container.
 
 The [eris data export] command performs this process in the reverse. 
 It sucks out whatever is in the SRC directory in the data container 
 and sticks it back into a DEST directory on the host.
 
-Note: container paths enter at /home/eris/.eris
+Notes: 
+- container paths enter at /home/eris/.eris
+- import host path must be absolute, export host path is indifferent
 
 At Eris, we use this functionality to formulate little JSONs
 and configs on the host and then "stick them back into the
@@ -55,7 +57,8 @@ var dataImport = &cobra.Command{
 	Short: "Import from a host folder to a named data container's directory",
 	Long: `Import from a host folder to a named data container's directory.
 Requires src and dest for each host and container, respectively.
-Container path enters at /home/eris/.eris`,
+Container path enters at /home/eris/.eris
+Source (host) path must be absolute and destination dir must exist.`,
 	Run: ImportData,
 }
 
@@ -64,7 +67,8 @@ var dataExport = &cobra.Command{
 	Short: "Export a named data container's directory to a host directory",
 	Long: `Export a named data container's directory to a host directory.
 Requires src and dest for each container and host, respectively.
-Container path enters at /home/eris/.eris`,
+Container path enters at /home/eris/.eris
+Destination (host) path can be relative.`,
 	Run: ExportData,
 }
 

--- a/commands/data.go
+++ b/commands/data.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	//	"path/filepath"
 	"strings"
 
 	"github.com/eris-ltd/eris-cli/data"
@@ -15,7 +14,6 @@ import (
 //----------------------------------------------------
 
 // Primary Data Sub-Command
-//TODO re-write
 var Data = &cobra.Command{
 	Use:   "data",
 	Short: "Manage data containers for your application.",
@@ -25,13 +23,12 @@ data into containers for use by your application.
 The [eris data import] and [eris data export] commands should be 
 thought of from the point of view of the container.
 
-The [eris data import] command sends files *as is* from 
-~/.eris/data/NAME on the host to ~/.eris/ inside 
-of the data container.
+The [eris data import] command sends a directory *as is* from 
+SRC on the host to DEST inside of the data container.
 
 The [eris data export] command performs this process in the reverse. 
-It sucks out whatever is in the volumes of the data container 
-and sticks it back into ~/.eris/data/NAME on the host.
+It sucks out whatever is in the SRC directory in the data container 
+and sticks it back into a DEST directory on the host.
 
 At Eris, we use this functionality to formulate little JSONs
 and configs on the host and then "stick them back into the

--- a/commands/data.go
+++ b/commands/data.go
@@ -30,6 +30,8 @@ The [eris data export] command performs this process in the reverse.
 It sucks out whatever is in the SRC directory in the data container 
 and sticks it back into a DEST directory on the host.
 
+Note: container paths enter at /home/eris/.eris
+
 At Eris, we use this functionality to formulate little JSONs
 and configs on the host and then "stick them back into the
 containers"`,
@@ -52,7 +54,8 @@ var dataImport = &cobra.Command{
 	Use:   "import NAME SRC DEST",
 	Short: "Import from a host folder to a named data container's directory",
 	Long: `Import from a host folder to a named data container's directory.
-Requires src and dest for each host and container, respectively.`,
+Requires src and dest for each host and container, respectively.
+Container path enters at /home/eris/.eris`,
 	Run: ImportData,
 }
 
@@ -60,7 +63,8 @@ var dataExport = &cobra.Command{
 	Use:   "export NAME SRC DEST",
 	Short: "Export a named data container's directory to a host directory",
 	Long: `Export a named data container's directory to a host directory.
-Requires src and dest for each container and host, respectively.`,
+Requires src and dest for each container and host, respectively.
+Container path enters at /home/eris/.eris`,
 	Run: ExportData,
 }
 
@@ -173,6 +177,8 @@ func RmData(cmd *cobra.Command, args []string) {
 	IfExit(data.RmData(do))
 }
 
+//TODO add checks for ErisContainerRoot
+//src on host, dest in container
 func ImportData(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(3, "eq", cmd, args))
 	do.Name = args[0]
@@ -181,6 +187,7 @@ func ImportData(cmd *cobra.Command, args []string) {
 	IfExit(data.ImportData(do))
 }
 
+//src in container, dest on host
 func ExportData(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(3, "eq", cmd, args))
 	do.Name = args[0]

--- a/commands/eris.go
+++ b/commands/eris.go
@@ -48,10 +48,8 @@ Complete documentation is available at https://docs.erisindustries.com
 
 		dockerVersion, _ := util.DockerClientVersion()
 		marmot := "Come back after you have upgraded and the marmots will be happy to service your blockchain management needs"
-		if os.Getenv("TEST_IN_CIRCLE") != "true" {
-			if dockerVersion < dVerMin {
-				IfExit(fmt.Errorf("Eris requires docker version >= %v\nThe marmots have detected docker version: %v\n%s", dVerMin, dockerVersion, marmot))
-			}
+		if dockerVersion < dVerMin {
+			IfExit(fmt.Errorf("Eris requires docker version >= %v\nThe marmots have detected docker version: %v\n%s", dVerMin, dockerVersion, marmot))
 		}
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {

--- a/config/config.go
+++ b/config/config.go
@@ -142,6 +142,7 @@ func ChangeErisDir(erisDir string) {
 	dir.LllcScratchPath = filepath.Join(dir.ScratchPath, "lllc")
 	dir.SolcScratchPath = filepath.Join(dir.ScratchPath, "sol")
 	dir.SerpScratchPath = filepath.Join(dir.ScratchPath, "ser")
+	dir.DataContainersPath = filepath.Join(dir.ScratchPath, "data")
 }
 
 func marshallGlobalConfig(globalConfig *viper.Viper, config *ErisConfig) error {

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -17,6 +17,8 @@ import (
 var dataName string = "dataTest1"
 var newName string = "dataTest2"
 
+//TODO disentngle tests
+
 func TestMain(m *testing.M) {
 	log.SetFormatter(logger.ErisFormatter{})
 
@@ -65,6 +67,22 @@ func TestImportDataRawNoPriorExist(t *testing.T) {
 	testExist(t, dataName, true)
 }
 
+func TestExportData(t *testing.T) {
+	do := definitions.NowDo()
+	do.Name = dataName
+	do.Source = common.ErisContainerRoot
+	do.Destination = filepath.Join(common.DataContainersPath, do.Name)
+	do.Operations.ContainerNumber = 1
+	if err := ExportData(do); err != nil {
+		log.Error(err)
+		t.FailNow()
+	}
+
+	if _, err := os.Stat(path.Join(common.DataContainersPath, dataName, "test")); os.IsNotExist(err) {
+		log.Errorf("Tragic! Exported file does not exist: %s", err)
+		t.Fail()
+	}
+}
 func TestExecData(t *testing.T) {
 	do := definitions.NowDo()
 	do.Name = dataName
@@ -78,23 +96,6 @@ func TestExecData(t *testing.T) {
 	}).Info("Executing data (from tests)")
 	if err := ExecData(do); err != nil {
 		log.Error(err)
-		t.Fail()
-	}
-}
-
-func TestExportData(t *testing.T) {
-	do := definitions.NowDo()
-	do.Name = dataName
-	do.Source = common.ErisContainerRoot
-	do.Destination = filepath.Join(common.DataContainersPath, do.Name)
-	do.Operations.ContainerNumber = 1
-	if err := ExportData(do); err != nil {
-		log.Error(err)
-		t.FailNow()
-	}
-
-	if _, err := os.Stat(filepath.Join(common.DataContainersPath, dataName, "tset")); os.IsNotExist(err) {
-		log.Errorf("Tragic! Exported file does not exist: %s", err)
 		t.Fail()
 	}
 }

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -17,8 +17,6 @@ import (
 var dataName string = "dataTest1"
 var newName string = "dataTest2"
 
-//TODO disentngle tests
-
 func TestMain(m *testing.M) {
 	log.SetFormatter(logger.ErisFormatter{})
 
@@ -37,8 +35,9 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
+//TODO add some export/import test robustness
 func TestImportDataRawNoPriorExist(t *testing.T) {
-	testCreateDataByImport(t, dataName)
+	testCreateDataByImport(t, dataName) //was basically copied from this test
 	defer testKillDataCont(t, dataName)
 }
 
@@ -155,6 +154,7 @@ func TestInspectData(t *testing.T) {
 	}
 }
 
+//now is testKillDataCont()
 func TestRmData(t *testing.T) {
 	testCreateDataByImport(t, dataName)
 	testExist(t, dataName, true)
@@ -202,6 +202,7 @@ func testKillDataCont(t *testing.T, name string) {
 	}
 
 	testCreateDataByImport(t, name)
+	testExist(t, name, true)
 
 	do := definitions.NowDo()
 	do.Name = name

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(testsInit())
+	tests.IfExit(tests.TestsInit("data"))
 
 	exitCode := m.Run()
 
@@ -55,7 +55,7 @@ func TestExportData(t *testing.T) {
 		t.FailNow()
 	}
 
-	if _, err := os.Stat(path.Join(common.DataContainersPath, dataName, "test")); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(common.DataContainersPath, dataName, "test")); os.IsNotExist(err) {
 		log.Errorf("Tragic! Exported file does not exist: %s", err)
 		t.Fail()
 	}
@@ -166,14 +166,14 @@ func TestRmData(t *testing.T) {
 //creates a new data container w/ dir to be used by a test
 //maybe give create opts? => paths, files, file contents, etc
 func testCreateDataByImport(t *testing.T, name string) {
-	newDataDir := path.Join(common.DataContainersPath, name)
+	newDataDir := filepath.Join(common.DataContainersPath, name)
 	if err := os.MkdirAll(newDataDir, 0777); err != nil {
 		log.Error(err)
 		t.FailNow()
 		os.Exit(1)
 	}
 
-	f, err := os.Create(path.Join(newDataDir, "test"))
+	f, err := os.Create(filepath.Join(newDataDir, "test"))
 	if err != nil {
 		log.Error(err)
 		t.FailNow()

--- a/data/operate.go
+++ b/data/operate.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	//	"strings"
 
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/loaders"
@@ -195,30 +194,29 @@ func moveOutOfDirAndRmDir(src, dest string) error {
 	return nil
 }
 
-//check path for ErisContainerRoot
+// check path for ErisContainerRoot
+// XXX this is opiniated & we may want to change in future
+// for more flexibility with filesystem of data conts
 func checkErisContainerRoot(do *definitions.Do, typ string) error {
 
 	r, err := regexp.Compile(ErisContainerRoot)
 	if err != nil {
 		return err
 	}
+
 	switch typ {
 	case "import":
 		if r.MatchString(do.Destination) != true { //if not there join it
-			fmt.Printf("dest before %s\n", do.Destination)
 			do.Destination = path.Join(ErisContainerRoot, do.Destination)
-			fmt.Printf("dest after%s\n", do.Destination)
 			return nil
 		} else { // matches: do nothing
 			return nil
 		}
 	case "export":
-		if r.MatchString(do.Source) != true { //if not there join it
-			fmt.Printf("source before %s\n", do.Source)
+		if r.MatchString(do.Source) != true {
 			do.Source = path.Join(ErisContainerRoot, do.Source)
-			fmt.Printf("source after%s\n", do.Source)
 			return nil
-		} else { // matches: do nothing
+		} else {
 			return nil
 		}
 	}

--- a/data/operate.go
+++ b/data/operate.go
@@ -129,23 +129,21 @@ func ExportData(do *definitions.Do) error {
 		}
 
 		// now if docker dumps to exportPath/.eris we should remove
-		//   move everything from .eris to exportPath
+		// move everything from .eris to exportPath
 		if err := moveOutOfDirAndRmDir(filepath.Join(exportPath, ".eris"), exportPath); err != nil {
 			return err
 		}
 
-		// // finally remove everything in the data directory and move
-		// //   the temp contents there
+		// finally remove everything in the data directory and move
+		// the temp contents there
 		if _, err := os.Stat(do.Destination); os.IsNotExist(err) {
 			if e2 := os.MkdirAll(do.Destination, 0755); e2 != nil {
 				return fmt.Errorf("Error:\tThe marmots could neither find, nor had access to make the directory: (%s)\n", do.Destination)
 			}
 		}
-		// ClearDir(do.Destionation)
 		if err := moveOutOfDirAndRmDir(exportPath, do.Destination); err != nil {
 			return err
 		}
-
 	} else {
 		return fmt.Errorf("I cannot find that data container. Please check the data container name you sent me.")
 	}

--- a/data/operate.go
+++ b/data/operate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient"
 )
 
+//import from: do.Source(on host), to: do.Destination(in container)
 func ImportData(do *definitions.Do) error {
 	if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
 
@@ -57,6 +58,7 @@ func ImportData(do *definitions.Do) error {
 		doChown.Operations.DataContainerName = containerName
 		doChown.Operations.ContainerType = "data"
 		doChown.Operations.ContainerNumber = 1
+		//required b/c `docker cp` (UploadToContainer) goes in as root
 		doChown.Operations.Args = []string{"chown", "--recursive", "eris", do.Destination}
 		_, err = perform.DockerRunData(doChown.Operations, nil)
 		if err != nil {
@@ -89,6 +91,7 @@ func ExecData(do *definitions.Do) error {
 	return nil
 }
 
+//export from: do.Source(in container), to: do.Destination(on host)
 func ExportData(do *definitions.Do) error {
 	if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
 		log.WithField("=>", do.Name).Info("Exporting data container")


### PR DESCRIPTION
this PR:
- eliminates use of `~/.eris/data` (replaced by `~/.eris/scratch/data` under the hood)
- refactors `eris data import/export` to each require `src/dest`
- 3 argument are required: `eris data import/export NAME SRC DEST`
- helpers updated to reflect this change, with notes on path specification.
- data package tests are updated to be independent of each other.

closes #400 