### PR TITLE
make `eris chains new` work when data container already exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN curl -sSL -o $INSTALL_BASE/wrapdocker https://raw.githubusercontent.com/jpet
 RUN chmod +x $INSTALL_BASE/wrapdocker
 
 # DOCKER-MACHINE (for testing)
-ENV DOCKER_MACHINE_VERSION 0.4.0
+ENV DOCKER_MACHINE_VERSION 0.5.4
 RUN curl -sSL -o $INSTALL_BASE/docker-machine \
   https://github.com/docker/machine/releases/download/v$DOCKER_MACHINE_VERSION/docker-machine_linux-amd64 && \
   chmod +x $INSTALL_BASE/docker-machine

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -16,9 +16,9 @@ import (
 	"github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/util"
 
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/ipfs"
-	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 func RegisterChain(do *definitions.Do) error {
@@ -30,7 +30,7 @@ func RegisterChain(do *definitions.Do) error {
 	do.ChainID = do.Name
 
 	// NOTE: registration expects you to have the data container
-	if !data.IsKnown(do.Name) {
+	if !util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
 		return fmt.Errorf("Registration requires you to have a data container for the chain. Could not find data for %s", do.Name)
 	}
 

--- a/chains/operate.go
+++ b/chains/operate.go
@@ -18,8 +18,8 @@ import (
 	"github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/util"
 
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid"
 )
@@ -252,13 +252,13 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 	}
 
 	// ensure/create data container
-	if !data.IsKnown(do.Name) {
+	if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
+		log.WithField("=>", do.Name).Debug("Chain data container already exists")
+	} else {
 		ops := loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
 		if err := perform.DockerCreateData(ops); err != nil {
 			return fmt.Errorf("Error creating data container =>\t%v", err)
 		}
-	} else {
-		log.WithField("=>", do.Name).Debug("Chain data container already exists")
 	}
 
 	log.WithField("=>", do.Name).Debug("Chain data container built")

--- a/data/load.go
+++ b/data/load.go
@@ -49,22 +49,3 @@ func checkServiceGiven(args []string) error {
 	}
 	return nil
 }
-
-func parseKnown(name string, num int) bool {
-	name = util.NameAndNumber(name, num)
-	return _parseKnown(name)
-}
-
-func _parseKnown(name string) bool {
-	do := def.NowDo()
-	do.Existing = true
-	util.ListAll(do, "data")
-	if len(do.Operations.Args) != 0 {
-		for _, srv := range do.Operations.Args {
-			if srv == name {
-				return true
-			}
-		}
-	}
-	return false
-}

--- a/data/manage.go
+++ b/data/manage.go
@@ -10,8 +10,8 @@ import (
 	"github.com/eris-ltd/eris-cli/perform"
 	"github.com/eris-ltd/eris-cli/util"
 
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 )
 
 func RenameData(do *definitions.Do) error {
@@ -87,8 +87,4 @@ func RmData(do *definitions.Do) (err error) {
 
 	do.Result = "success"
 	return err
-}
-
-func IsKnown(name string) bool {
-	return _parseKnown(name)
 }


### PR DESCRIPTION
This PR fixes the issue #393 by checking container existence prior to creating it.

The `data.IsKnown()` call is replaced with `util.IsDataContainer()`.

The `data.IsKnown()` function and its helpers are removed.