### PR TITLE
This change fix the bug detected on issue https://github.com/eris-ltd…

### DIFF
--- a/actions/perform.go
+++ b/actions/perform.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
+    	"runtime"
 	"github.com/eris-ltd/eris-cli/chains"
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/services"
@@ -94,6 +94,9 @@ func PerformCommand(action *definitions.Action, actionVars []string, quiet bool)
 
 	for n, step := range action.Steps {
 		cmd := exec.Command("sh", "-c", step)
+	        if runtime.GOOS == "windows" {
+	            cmd = exec.Command("cmd", "/c", step)
+	        }
 		cmd.Env = actionVars
 		cmd.Dir = dir
 


### PR DESCRIPTION
This change fix the bug detected on issue https://github.com/eris-ltd/eris-cli/issues/416.
We Introduce a flag for the Windows environment and run the cmd command instead of the sh command we use on *Nix environments.

Signed-off-by: Alexandre Vázquez <alexandre.vazquez@gmail.com>