### PR TITLE
Issue #291

### DIFF
--- a/commands/update.go
+++ b/commands/update.go
@@ -26,6 +26,6 @@ func addUpdateFlags() {
 }
 
 func UpdateTool(cmd *cobra.Command, args []string) {
-	util.UpdateEris(do.Branch)
+	util.UpdateEris(do.Branch, true, true)
 
 }

--- a/tests/machines/setup.go
+++ b/tests/machines/setup.go
@@ -36,13 +36,13 @@ func main() {
 	}
 
 	if err := vetAndPopulate(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintf(os.Stderr, "vetAndPopulate error: %v\n", err)
 		os.Exit(1)
 	}
 
 	branch, err := getBranch()
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintf(os.Stderr, "getBranch error: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/util/update_tool.go
+++ b/util/update_tool.go
@@ -2,19 +2,109 @@ package util
 
 import (
 	"fmt"
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
-
-	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
-
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
+	"runtime"
+	"strings"
 )
 
-func UpdateEris(branch string) {
+func downloadLatestRelease() (string, error) {
+	latestURL := "https://github.com/eris-ltd/eris-cli/releases/latest"
+	resp, err := http.Get(latestURL)
+	if err != nil {
+		log.Printf("could not retrieve latest eris release at %s", latestURL)
+	}
+	latestURL = resp.Request.URL.String()
+	lastPos := strings.LastIndex(latestURL, "/")
+	version := latestURL[lastPos+1:]
+	platform := runtime.GOOS
+	arch := runtime.GOARCH
+	hostURL := "https://github.com/eris-ltd/eris-cli/releases/download/" + version + "/"
+	filename := "eris_" + version[1:] + "_" + platform + "_" + arch
+	fileURL := hostURL + filename
+	switch platform {
+	case "linux":
+		filename += ".tar.gz"
+	default:
+		filename += ".zip"
+	}
+
+	ChangeDirectory("bin")
+	var erisBin string
+	output, err := os.Create(filename)
+	// if we dont have permissions to create a file where eris cli exists, attempt to create file within HOME folder
+	if err != nil {
+		erisBin := filepath.Join(common.ScratchPath, "bin")
+		if _, err = os.Stat(erisBin); os.IsNotExist(err) {
+			err = os.MkdirAll(erisBin, 0755)
+			if err != nil {
+				log.Println("Error creating directory", erisBin, "Did not download binary. Exiting...")
+				return "", err
+			}
+		}
+		err = os.Chdir(erisBin)
+		if err != nil {
+			log.Println("Error changing directory to", erisBin, "Did not download binary. Exiting...")
+			return "", err
+		}
+		output, err = os.Create(filename)
+		if err != nil {
+			log.Println("Error creating file", erisBin, "Exiting...")
+			return "", err
+		}
+	}
+	defer output.Close()
+	fileResponse, err := http.Get(fileURL)
+	if err != nil {
+		log.Println("Error while downloading", filename, "-", err)
+		return "", err
+	}
+	defer fileResponse.Body.Close()
+	io.Copy(output, fileResponse.Body)
+	if err != nil {
+		log.Println("Error saving downloaded file", filename, "-", err)
+		return "", err
+	}
+	erisLoc, _ := exec.LookPath("eris")
+	if erisBin != "" {
+		log.Println("downloaded eris binary", version, "for", platform, "to", erisBin, "\n Please manually move to", erisLoc)
+	} else {
+		log.Println("downloaded eris binary", version, "for", platform, "to", erisLoc)
+	}
+	var unzip string = "tar -xvf"
+	if platform != "linux" {
+		unzip = "unzip"
+	}
+	cmd := exec.Command("bin/sh", "-c", unzip, filename)
+	err = cmd.Run()
+	if err != nil {
+		log.Println("unzipping", filename, "failed:", err)
+	}
+	return filename, nil
+}
+
+func UpdateEris(branch string, checkGit bool, checkGo bool) {
 
 	//check that git/go are installed
-	CheckGitAndGo(true, true)
+	hasGit, hasGo := CheckGitAndGo(checkGit, checkGo)
+	if hasGo == false {
+		log.Println("Go is not installed. Downloading eris-cli binary...")
+		_, err := downloadLatestRelease()
+		if err != nil {
+			log.Println("Latest binary failed to download with error:", err)
+			log.Println("Exiting...")
+			os.Exit(1)
+		}
+	} else if hasGit == false {
+		log.Println("Git is not installed. Please install git before continuing.")
+		log.Println("Exiting...")
+		os.Exit(1)
+	}
 
 	//checks for deprecated dir names and renames them
 	err := MigrateDeprecatedDirs(common.DirsToMigrate, false) // false = no prompt
@@ -24,7 +114,7 @@ func UpdateEris(branch string) {
 	}
 
 	//change pwd to eris/cli
-	ChangeDirectory()
+	ChangeDirectory("src")
 
 	if branch == "" {
 		branch = "master"
@@ -39,35 +129,52 @@ func UpdateEris(branch string) {
 	log.WithField("=>", ver).Warn("The marmots have updated Eris successfully")
 }
 
-func CheckGitAndGo(git, gO bool) {
+func CheckGitAndGo(git, gO bool) (bool, bool) {
+	hasGit := false
+	hasGo := false
 	if git {
 		stdOut1, err := exec.Command("git", "version").CombinedOutput()
 		if err != nil {
 			log.WithField("version", string(stdOut1)).Fatal("Ensure you have git installed or if running `eris init` use the `--skip-pull` flag")
+		} else {
+			hasGit = true
 		}
 	}
 	if gO {
 		stdOut2, err := exec.Command("go", "version").CombinedOutput()
 		if err != nil {
 			log.WithField("version", string(stdOut2)).Fatal("Ensure you have Go installed")
+		} else {
+			hasGo = true
 		}
 	}
+	return hasGit, hasGo
 }
 
-func ChangeDirectory() {
-	goPath := os.Getenv("GOPATH")
-	if goPath == "" {
-		log.Fatal("You do not have $GOPATH set. Please make sure this is set and rerun the command")
+func ChangeDirectory(to string) {
+	if to == "bin" {
+		erisLoc, _ := exec.LookPath("eris")
+		locLen := len(erisLoc) - 4
+		erisLoc = erisLoc[:locLen]
+		err := os.Chdir(erisLoc)
+		if err != nil {
+			log.Fatalf("Error changing directory: %v", err)
+		}
+		log.WithField("dir", erisLoc).Debug("Directory changed to")
+	} else if to == "src" {
+		goPath := os.Getenv("GOPATH")
+		if goPath == "" {
+			log.Fatal("You do not have $GOPATH set. Please make sure this is set and rerun the command.")
+		}
+
+		dir := filepath.Join(goPath, "src", "github.com", "eris-ltd", "eris-cli")
+		err := os.Chdir(dir)
+
+		if err != nil {
+			log.Fatalf("Error changing directory: %v")
+		}
+		log.WithField("dir", dir).Debug("Directory changed to")
 	}
-
-	dir := filepath.Join(goPath, "src", "github.com", "eris-ltd", "eris-cli")
-	err := os.Chdir(dir)
-
-	if err != nil {
-		log.Fatalf("Error changing directory: %v")
-	}
-
-	log.WithField("dir", dir).Debug("Directory changed to")
 }
 
 func CheckoutBranch(branch string) {

--- a/util/update_tool_test.go
+++ b/util/update_tool_test.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"os"
+	"testing"
+)
+
+type testCases struct {
+	hasGit bool
+	hasGo  bool
+}
+
+func TestCheckGitAndGo(t *testing.T) {
+	var tests = []testCases{
+		{true, true},
+		{true, false},
+		{false, true},
+		{false, false},
+	}
+	for _, g := range tests {
+		resultGit, resultGo := CheckGitAndGo(g.hasGit, g.hasGo)
+		if g.hasGit != resultGit && g.hasGo != resultGo {
+			t.Fatalf("Expected git = %b and go = %b.\nResult: git = %b, go = %b", g.hasGit, g.hasGo, resultGit, resultGo)
+		}
+	}
+}
+
+func TestDownloadLatestRelease(t *testing.T) {
+	filename, err := downloadLatestRelease()
+	if err != nil {
+		t.Fatal("Download failed with error:", err)
+	} else {
+		t.Log("Latest Release downloads successfully. Removing...")
+		err := os.Remove(filename)
+		if err != nil {
+			t.Error("could not remove eris-cli binary test-download.", err)
+		}
+	}
+
+}


### PR DESCRIPTION
https://github.com/eris-ltd/eris-cli/issues/291

Modified CheckGitAndGo() to return two boolean values for whether git and go are found on the system.

Modified UpdateEris() to take two extra parameters specifying whether to check git and go respectively.

Added downloadLatestBinary() which downloads the latest release of eris-cli to the users ~/bin folder, and tells them to include that folder in their PATH variable. (Perhaps it should check for it and, if missing, ask the user if they'd like to add it?)

Also added tests for CheckGitAndGo and downloadLatestBinary functions.