### PR TITLE
list keys on host and container

### DIFF
--- a/actions/perform.go
+++ b/actions/perform.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
-    	"runtime"
+
 	"github.com/eris-ltd/eris-cli/chains"
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/services"
@@ -94,9 +95,9 @@ func PerformCommand(action *definitions.Action, actionVars []string, quiet bool)
 
 	for n, step := range action.Steps {
 		cmd := exec.Command("sh", "-c", step)
-	        if runtime.GOOS == "windows" {
-	            cmd = exec.Command("cmd", "/c", step)
-	        }
+		if runtime.GOOS == "windows" {
+			cmd = exec.Command("cmd", "/c", step)
+		}
 		cmd.Env = actionVars
 		cmd.Dir = dir
 

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -65,9 +65,11 @@ type Do struct {
 	Destination string `mapstructure:"," json:"," yaml:"," toml:","`
 
 	//listing functions
-	Known    bool `mapstructure:"," json:"," yaml:"," toml:","`
-	Running  bool `mapstructure:"," json:"," yaml:"," toml:","`
-	Existing bool `mapstructure:"," json:"," yaml:"," toml:","`
+	Known     bool `mapstructure:"," json:"," yaml:"," toml:","`
+	Running   bool `mapstructure:"," json:"," yaml:"," toml:","`
+	Existing  bool `mapstructure:"," json:"," yaml:"," toml:","`
+	Host      bool `mapstructure:"," json:"," yaml:"," toml:","` //keys ls
+	Container bool `mapstructure:"," json:"," yaml:"," toml:","` //keys ls
 
 	// <key>=<value> pairs
 	Env []string `mapstructure:"," json:"," yaml:"," toml:","`

--- a/keys/readers.go
+++ b/keys/readers.go
@@ -1,0 +1,60 @@
+package keys
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/eris-ltd/eris-cli/config"
+	"github.com/eris-ltd/eris-cli/definitions"
+	srv "github.com/eris-ltd/eris-cli/services"
+	"github.com/eris-ltd/eris-cli/util"
+
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
+)
+
+func ListKeys(do *definitions.Do) error {
+	if do.Host {
+		keysPath := filepath.Join(KeysPath, "data")
+		addrs, err := ioutil.ReadDir(keysPath)
+		if err != nil {
+			return err
+		}
+		hostAddrs := make([]string, len(addrs))
+		for i, addr := range addrs {
+			hostAddrs[i] = addr.Name()
+		}
+		log.WithField("=>", hostAddrs[0]).Warn("The keys on your host kind marmot:")
+		hostAddrs = append(hostAddrs[:0], hostAddrs[1:]...)
+		for _, addr := range hostAddrs {
+			log.WithField("=>", addr).Warn()
+		}
+	}
+
+	if do.Container {
+		keysOut := new(bytes.Buffer)
+		config.GlobalConfig.Writer = keysOut
+		do.Name = "keys"
+		do.Operations.ContainerNumber = 1
+		if err := srv.EnsureRunning(do); err != nil {
+			return err
+		}
+
+		do.Operations.Interactive = false
+		do.Operations.Args = []string{"ls", "/home/eris/.eris/keys/data"}
+
+		if err := srv.ExecService(do); err != nil {
+			return err
+		}
+		keysOutString := strings.Split(util.TrimString(string(keysOut.Bytes())), "\n")
+		log.WithField("=>", keysOutString[0]).Warn("The keys in your container kind marmot:")
+		keysOutString = append(keysOutString[:0], keysOutString[1:]...)
+		for _, addr := range keysOutString {
+			log.WithField("=>", addr).Warn()
+		}
+
+	}
+	return nil
+}

--- a/keys/readers.go
+++ b/keys/readers.go
@@ -26,6 +26,7 @@ func ListKeys(do *definitions.Do) error {
 		for i, addr := range addrs {
 			hostAddrs[i] = addr.Name()
 		}
+		do.Result = strings.Join(hostAddrs, ",")
 		log.WithField("=>", hostAddrs[0]).Warn("The keys on your host kind marmot:")
 		hostAddrs = append(hostAddrs[:0], hostAddrs[1:]...)
 		for _, addr := range hostAddrs {
@@ -49,6 +50,7 @@ func ListKeys(do *definitions.Do) error {
 			return err
 		}
 		keysOutString := strings.Split(util.TrimString(string(keysOut.Bytes())), "\n")
+		do.Result = strings.Join(keysOutString, ",")
 		log.WithField("=>", keysOutString[0]).Warn("The keys in your container kind marmot:")
 		keysOutString = append(keysOutString[:0], keysOutString[1:]...)
 		for _, addr := range keysOutString {


### PR DESCRIPTION
helps #356, closes #401
Usage:
`$ eris keys ls` => keys on host & container
`$ eris keys ls --container` => keys in container
`$ eris keys ls --host` => keys on host
- looks in in `~/.eris/keys/data`
- includes tests w/ minor refactor of keys tests