### PR TITLE
deduplicate common files & images

### DIFF
--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/list"
 	tests "github.com/eris-ltd/eris-cli/testutils"
+	ver "github.com/eris-ltd/eris-cli/version"
 
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	logger "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
@@ -43,24 +44,27 @@ func TestListKnownActions(t *testing.T) {
 	tests.IfExit(list.ListActions(do))
 	k := strings.Split(do.Result, "\n") // tests output formatting.
 
-	if len(k) != 4 {
-		tests.IfExit(fmt.Errorf("Found %v action definition files, Expected 4. Something is wrong.\n", len(k)))
+	ver.ACTION_DEFINITIONS = append(ver.ACTION_DEFINITIONS, "do_not_use.toml")
+
+	if len(k) != len(ver.ACTION_DEFINITIONS) {
+		tests.IfExit(fmt.Errorf("Did not find correct number of action definitions files, Expected %v, found %v.\n", len(ver.ACTION_DEFINITIONS), len(k)))
+	}
+
+	actDefs := make(map[string]bool)
+
+	for _, act := range ver.ACTION_DEFINITIONS {
+		actDef := strings.Split(act, ".")
+		actDefs[actDef[0]] = true
 	}
 
 	i := 0
 	for _, actFile := range k {
-		switch actFile {
-		case "do_not_use":
-			i++
-		case "chain_info":
-			i++
-		case "dns_register":
-			i++
-		case "keys_list":
+		if actDefs[actFile] == true {
 			i++
 		}
 	}
-	if i != 4 {
+
+	if i != len(ver.ACTION_DEFINITIONS) {
 		tests.IfExit(fmt.Errorf("Could not find all the expected action definition files.\n"))
 	}
 }

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -471,10 +471,10 @@ func TestServiceLinkNoChain(t *testing.T) {
 	defer tests.RemoveAllContainers()
 
 	if err := tests.FakeServiceDefinition(erisDir, "fake", `
-chain = \"$chain:fake\"
+chain = "$chain:fake"
 
 [service]
-name = \"fake\"
+name = "fake"
 image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
 data_container = true
 `); err != nil {

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -20,7 +21,7 @@ import (
 	"github.com/eris-ltd/eris-cli/services"
 	tests "github.com/eris-ltd/eris-cli/testutils"
 	"github.com/eris-ltd/eris-cli/util"
-	"github.com/eris-ltd/eris-cli/version"
+	ver "github.com/eris-ltd/eris-cli/version"
 
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
@@ -76,7 +77,7 @@ func TestChainGraduate(t *testing.T) {
 		tests.IfExit(err)
 	}
 
-	image := "quay.io/eris/erisdb:" + version.VERSION
+	image := path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_DB)
 	if srvDef.Service.Image != image {
 		tests.IfExit(fmt.Errorf("FAILURE: improper service image on GRADUATE. expected: %s\tgot: %s\n", image, srvDef.Service.Image))
 	}
@@ -470,11 +471,11 @@ func TestServiceLinkNoChain(t *testing.T) {
 	defer tests.RemoveAllContainers()
 
 	if err := tests.FakeServiceDefinition(erisDir, "fake", `
-chain = "$chain:fake"
+chain = \"$chain:fake\"
 
 [service]
-name = "fake"
-image = "quay.io/eris/ipfs"
+name = \"fake\"
+image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
 data_container = true
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
@@ -496,7 +497,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "quay.io/eris/ipfs"
+image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
 	}
@@ -516,7 +517,7 @@ func TestServiceLinkBadChainWithoutChainInDefinition(t *testing.T) {
 	if err := tests.FakeServiceDefinition(erisDir, "fake", `
 [service]
 name = "fake"
-image = "quay.io/eris/ipfs"
+image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
 	}
@@ -555,7 +556,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "quay.io/eris/ipfs"
+image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
 	}
@@ -607,7 +608,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "quay.io/eris/ipfs"
+image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
 data_container = true
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
@@ -660,7 +661,7 @@ chain = "`+chainName+`:fake"
 
 [service]
 name = "fake"
-image = "quay.io/eris/ipfs"
+image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
 	}
@@ -712,7 +713,7 @@ chain = "blah-blah:blah"
 
 [service]
 name = "fake"
-image = "quay.io/eris/ipfs"
+image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
 	}
@@ -784,7 +785,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "quay.io/eris/ipfs"
+image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
 
 [dependencies]
 services = [ "sham" ]
@@ -797,7 +798,7 @@ chain = "$chain:sham"
 
 [service]
 name = "sham"
-image = "quay.io/eris/keys"
+image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)+`"
 data_container = true
 `); err != nil {
 		t.Fatalf("can't create a sham service definition: %v", err)

--- a/definitions/app_types.go
+++ b/definitions/app_types.go
@@ -27,7 +27,7 @@ func AllAppTypes() map[string]*AppType {
 func EPMApp() *AppType {
 	app := BlankAppType()
 	app.Name = "epm"
-	app.BaseImage = path.Join(version.QUAY, version.ERIS_IMG_PM)
+	app.BaseImage = path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_PM)
 	app.EntryPoint = "epm --chain chain:46657 --sign keys:4767"
 	app.DeployCmd = ""
 	app.TestCmd = ""

--- a/definitions/app_types.go
+++ b/definitions/app_types.go
@@ -1,7 +1,8 @@
 package definitions
 
 import (
-	"fmt"
+	"path"
+
 	"github.com/eris-ltd/eris-cli/version"
 )
 
@@ -26,7 +27,7 @@ func AllAppTypes() map[string]*AppType {
 func EPMApp() *AppType {
 	app := BlankAppType()
 	app.Name = "epm"
-	app.BaseImage = fmt.Sprintf("quay.io/eris/epm:%s", version.VERSION)
+	app.BaseImage = path.Join(version.QUAY, version.ERIS_IMG_PM)
 	app.EntryPoint = "epm --chain chain:46657 --sign keys:4767"
 	app.DeployCmd = ""
 	app.TestCmd = ""

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -109,9 +110,9 @@ func pullDefaultImages() error {
 			tag = nameSplit[2]
 		}
 		image = nameSplit[0]
-
+		img := path.Join(ver.ERIS_REG_DEF, image)
 		opts := docker.PullImageOptions{
-			Repository:   image,
+			Repository:   img,
 			Registry:     ver.ERIS_REG_DEF,
 			Tag:          tag,
 			OutputStream: os.Stdout,
@@ -123,6 +124,7 @@ func pullDefaultImages() error {
 
 		if err := util.DockerClient.PullImage(opts, auth); err != nil {
 			//try with hub (empty string)
+			opts.Repository = image
 			opts.Registry = ver.ERIS_REG_BAK
 			if err := util.DockerClient.PullImage(opts, auth); err != nil {
 				return err

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -112,7 +112,7 @@ func pullDefaultImages() error {
 
 		opts := docker.PullImageOptions{
 			Repository:   image,
-			Registry:     ver.QUAY,
+			Registry:     ver.ERIS_REG_DEF,
 			Tag:          tag,
 			OutputStream: os.Stdout,
 		}
@@ -122,8 +122,8 @@ func pullDefaultImages() error {
 		}
 
 		if err := util.DockerClient.PullImage(opts, auth); err != nil {
-			//try with hub
-			opts.Registry = ver.HUB // empty string
+			//try with hub (empty string)
+			opts.Registry = ver.ERIS_REG_BAK
 			if err := util.DockerClient.PullImage(opts, auth); err != nil {
 				return err
 			}

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -97,7 +97,7 @@ func ServiceDefFromChain(chain *definitions.Chain, cmd string) *definitions.Serv
 	// chainID := chain.ChainID
 	setChainDefaults(chain)
 	chain.Service.Name = chain.Name // this let's the data containers flow thru
-	chain.Service.Image = path.Join(version.QUAY, version.ERIS_IMG_DB)
+	chain.Service.Image = path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_DB)
 	chain.Service.AutoData = true // default. they can turn it off. it's like BarBri
 	chain.Service.Command = cmd
 

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -2,6 +2,7 @@ package loaders
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 
 	"github.com/eris-ltd/eris-cli/config"
@@ -94,10 +95,9 @@ func ChainsAsAService(chainName string, newCont bool, cNum ...int) (*definitions
 
 func ServiceDefFromChain(chain *definitions.Chain, cmd string) *definitions.ServiceDefinition {
 	// chainID := chain.ChainID
-	vers := version.VERSION
 	setChainDefaults(chain)
 	chain.Service.Name = chain.Name // this let's the data containers flow thru
-	chain.Service.Image = "quay.io/eris/erisdb:" + vers
+	chain.Service.Image = path.Join(version.QUAY, version.ERIS_IMG_DB)
 	chain.Service.AutoData = true // default. they can turn it off. it's like BarBri
 	chain.Service.Command = cmd
 

--- a/perform/docker_run.go
+++ b/perform/docker_run.go
@@ -19,7 +19,6 @@ import (
 
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/docker/docker/pkg/term"
-
 	dirs "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient"
 )

--- a/perform/docker_run.go
+++ b/perform/docker_run.go
@@ -1036,7 +1036,7 @@ func configureVolumesFromContainer(ops *def.Operation, service *def.Service) doc
 	opts := docker.CreateContainerOptions{
 		Name: "eris_exec_" + ops.DataContainerName,
 		Config: &docker.Config{
-			Image:           path.Join(version.QUAY, version.ERIS_IMG_BASE),
+			Image:           path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_BASE),
 			User:            "root",
 			WorkingDir:      dirs.ErisContainerRoot,
 			AttachStdout:    true,

--- a/perform/docker_run.go
+++ b/perform/docker_run.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/eris-ltd/eris-cli/config"
 	def "github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
+	"github.com/eris-ltd/eris-cli/version"
 
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 
@@ -427,11 +429,11 @@ func DockerPull(srv *def.Service, ops *def.Operation) error {
 	}
 
 	if log.GetLevel() > 0 {
-		if err := pullImage(srv.Image, os.Stdout); err != nil {
+		if err := PullImage(srv.Image, os.Stdout); err != nil {
 			return err
 		}
 	} else {
-		if err := pullImage(srv.Image, bytes.NewBuffer([]byte{})); err != nil {
+		if err := PullImage(srv.Image, bytes.NewBuffer([]byte{})); err != nil {
 			return err
 		}
 	}
@@ -658,7 +660,7 @@ func DataContainerExists(ops *def.Operation) (docker.APIContainers, bool) {
 // ----------------------------------------------------------------------------
 // ---------------------    Images Core    ------------------------------------
 // ----------------------------------------------------------------------------
-func pullImage(name string, writer io.Writer) error {
+func PullImage(name string, writer io.Writer) error {
 	var tag string = "latest"
 	var reg string = ""
 
@@ -720,7 +722,7 @@ func createContainer(opts docker.CreateContainerOptions) (*docker.Container, err
 				log.Warn("The marmots are approved to pull it from the repository on your behalf")
 				log.Warn("This could take a few minutes")
 			}
-			if err := pullImage(opts.Config.Image, nil); err != nil {
+			if err := PullImage(opts.Config.Image, nil); err != nil {
 				return nil, err
 			}
 			dockerContainer, err = util.DockerClient.CreateContainer(opts)
@@ -1034,7 +1036,7 @@ func configureVolumesFromContainer(ops *def.Operation, service *def.Service) doc
 	opts := docker.CreateContainerOptions{
 		Name: "eris_exec_" + ops.DataContainerName,
 		Config: &docker.Config{
-			Image:           "quay.io/eris/base",
+			Image:           path.Join(version.QUAY, version.ERIS_IMG_BASE),
 			User:            "root",
 			WorkingDir:      dirs.ErisContainerRoot,
 			AttachStdout:    true,

--- a/perform/docker_run.go
+++ b/perform/docker_run.go
@@ -12,13 +12,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/docker/docker/pkg/term"
 	"github.com/eris-ltd/eris-cli/config"
 	def "github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
 	"github.com/eris-ltd/eris-cli/version"
 
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/docker/docker/pkg/term"
 
 	dirs "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient"
@@ -429,11 +429,11 @@ func DockerPull(srv *def.Service, ops *def.Operation) error {
 	}
 
 	if log.GetLevel() > 0 {
-		if err := PullImage(srv.Image, os.Stdout); err != nil {
+		if err := pullImage(srv.Image, os.Stdout); err != nil {
 			return err
 		}
 	} else {
-		if err := PullImage(srv.Image, bytes.NewBuffer([]byte{})); err != nil {
+		if err := pullImage(srv.Image, bytes.NewBuffer([]byte{})); err != nil {
 			return err
 		}
 	}
@@ -660,7 +660,7 @@ func DataContainerExists(ops *def.Operation) (docker.APIContainers, bool) {
 // ----------------------------------------------------------------------------
 // ---------------------    Images Core    ------------------------------------
 // ----------------------------------------------------------------------------
-func PullImage(name string, writer io.Writer) error {
+func pullImage(name string, writer io.Writer) error {
 	var tag string = "latest"
 	var reg string = ""
 
@@ -722,7 +722,7 @@ func createContainer(opts docker.CreateContainerOptions) (*docker.Container, err
 				log.Warn("The marmots are approved to pull it from the repository on your behalf")
 				log.Warn("This could take a few minutes")
 			}
-			if err := PullImage(opts.Config.Image, nil); err != nil {
+			if err := pullImage(opts.Config.Image, nil); err != nil {
 				return nil, err
 			}
 			dockerContainer, err = util.DockerClient.CreateContainer(opts)

--- a/perform/docker_run.go
+++ b/perform/docker_run.go
@@ -15,7 +15,7 @@ import (
 	"github.com/eris-ltd/eris-cli/config"
 	def "github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
-	"github.com/eris-ltd/eris-cli/version"
+	ver "github.com/eris-ltd/eris-cli/version"
 
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/docker/docker/pkg/term"
@@ -1036,7 +1036,7 @@ func configureVolumesFromContainer(ops *def.Operation, service *def.Service) doc
 	opts := docker.CreateContainerOptions{
 		Name: "eris_exec_" + ops.DataContainerName,
 		Config: &docker.Config{
-			Image:           path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_BASE),
+			Image:           path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_BASE),
 			User:            "root",
 			WorkingDir:      dirs.ErisContainerRoot,
 			AttachStdout:    true,
@@ -1082,7 +1082,7 @@ func configureDataContainer(srv *def.Service, ops *def.Operation, mainContOpts *
 	//   that base image will not be present. in such cases use
 	//   the base eris data container.
 	if srv.Image == "" {
-		srv.Image = "quay.io/eris/data"
+		srv.Image = path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_DATA)
 	}
 
 	// Manipulate labels locally.

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/eris-ltd/eris-cli/loaders"
 	tests "github.com/eris-ltd/eris-cli/testutils"
 	"github.com/eris-ltd/eris-cli/util"
+	ver "github.com/eris-ltd/eris-cli/version"
 
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	logger "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
@@ -29,7 +30,7 @@ func TestMain(m *testing.M) {
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)
-	// log.SetLevel(log.DebugLevel)
+	log.SetLevel(log.DebugLevel)
 
 	tests.IfExit(testsInit())
 
@@ -55,47 +56,25 @@ func TestKnownServices(t *testing.T) {
 	tests.IfExit(list.ListAll(do, "services"))
 	k := strings.Split(do.Result, "\n") // tests output formatting.
 
-	if len(k) != 16 {
-		tests.IfExit(fmt.Errorf("Did not find expected number of service definitions files, found %v. Something is wrong.\n", len(k)))
+	if len(k) != len(ver.SERVICE_DEFINITIONS) {
+		tests.IfExit(fmt.Errorf("Did not find correct number of service definitions files, Expected %v, found %v.\n", len(ver.SERVICE_DEFINITIONS), len(k)))
 	}
+
+	servDefs := make(map[string]bool)
+
+	for _, srv := range ver.SERVICE_DEFINITIONS {
+		servDef := strings.Split(srv, ".")
+		servDefs[servDef[0]] = true
+	}
+
 	i := 0
-	for _, actFile := range k {
-		switch actFile {
-		case "btcd":
-			i++
-		case "compilers":
-			i++
-		case "eth":
-			i++
-		case "ipfs":
-			i++
-		case "keys":
-			i++
-		case "logspout":
-			i++
-		case "logsrotate":
-			i++
-		case "mindy":
-			i++
-		case "openbazaar":
-			i++
-		case "tinydns":
-			i++
-		case "tor":
-			i++
-		case "toadserver":
-			i++
-		case "watchtower":
-			i++
-		case "bitcoincore":
-			i++
-		case "bitcoinclassic":
-			i++
-		case "do_not_use":
+	for _, srvFile := range k {
+		if servDefs[srvFile] == true {
 			i++
 		}
 	}
-	if i != 16 {
+
+	if i != len(ver.SERVICE_DEFINITION) {
 		tests.IfExit(fmt.Errorf("Could not find all the expected service definition files.\n"))
 	}
 }

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -74,7 +75,7 @@ func TestKnownServices(t *testing.T) {
 		}
 	}
 
-	if i != len(ver.SERVICE_DEFINITION) {
+	if i != len(ver.SERVICE_DEFINITIONS) {
 		tests.IfExit(fmt.Errorf("Could not find all the expected service definition files.\n"))
 	}
 }
@@ -300,7 +301,7 @@ func TestImportService(t *testing.T) {
 
 [service]
 name = "ipfs"
-image = "quay.io/eris/ipfs"`
+image = "` + path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS) + `"`
 
 	// Fake IPFS server.
 	os.Setenv("ERIS_IPFS_HOST", "http://127.0.0.1")
@@ -332,7 +333,7 @@ func TestNewService(t *testing.T) {
 	do := def.NowDo()
 	servName := "keys"
 	do.Name = servName
-	do.Operations.Args = []string{"quay.io/eris/keys"}
+	do.Operations.Args = []string{path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)}
 
 	log.WithFields(log.Fields{
 		"=>":   do.Name,

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)
-	log.SetLevel(log.DebugLevel)
+	// log.SetLevel(log.DebugLevel)
 
 	tests.IfExit(testsInit())
 

--- a/util/update_tool.go
+++ b/util/update_tool.go
@@ -135,7 +135,7 @@ func CheckGitAndGo(git, gO bool) (bool, bool) {
 	if git {
 		stdOut1, err := exec.Command("git", "version").CombinedOutput()
 		if err != nil {
-			log.WithField("version", string(stdOut1)).Fatal("Ensure you have git installed or if running `eris init` use the `--skip-pull` flag")
+			log.WithField("version", string(stdOut1)).Warn("Ensure you have git installed.")
 		} else {
 			hasGit = true
 		}
@@ -143,7 +143,7 @@ func CheckGitAndGo(git, gO bool) (bool, bool) {
 	if gO {
 		stdOut2, err := exec.Command("go", "version").CombinedOutput()
 		if err != nil {
-			log.WithField("version", string(stdOut2)).Fatal("Ensure you have Go installed")
+			log.WithField("version", string(stdOut2)).Warn("Ensure you have Go installed.")
 		} else {
 			hasGo = true
 		}

--- a/version/files.go
+++ b/version/files.go
@@ -1,0 +1,34 @@
+package version
+
+var (
+	SERVICE_DEFINITIONS = []string{
+		"btcd.toml",
+		"bitcoincore.toml",
+		"bitcoinclassic.toml",
+		"compilers.toml",
+		"eth.toml",
+		"ipfs.toml",
+		"keys.toml",
+		"logspout.toml",
+		"logsrotate.toml",
+		"mindy.toml",
+		"openbazaar.toml",
+		"toadserver.toml",
+		"tinydns.toml",
+		"tor.toml",
+		"watchtower.toml",
+		"do_not_use.toml",
+	}
+
+	ACTION_DEFINITIONS = []string{
+		"chain_info.toml",
+		"dns_register.toml",
+		"keys_list.toml",
+	}
+
+	CHAIN_DEFINITIONS = []string{
+		"default.toml",
+		"config.toml",
+		"server_conf.toml",
+	}
+)

--- a/version/images.go
+++ b/version/images.go
@@ -1,0 +1,21 @@
+package version
+
+import (
+	"fmt"
+)
+
+var (
+	QUAY = "quay.io"
+	HUB  = "" //dockerhub
+
+	ERIS_IMG_BASE = "eris/base"
+	ERIS_IMG_DATA = "eris/data"
+	ERIS_IMG_KEYS = "eris/keys"
+	ERIS_IMG_DB   = fmt.Sprintf("eris/erisdb:%s", VERSION)
+	ERIS_IMG_PM   = fmt.Sprintf("eris/epm:%s", VERSION)
+	ERIS_IMG_IPFS = "eris/ipfs"
+)
+
+func getReg(imgRaw string) string {
+	return ""
+}

--- a/version/images.go
+++ b/version/images.go
@@ -5,8 +5,8 @@ import (
 )
 
 var (
-	QUAY = "quay.io"
-	HUB  = "" //dockerhub
+	ERIS_REG_DEF = "quay.io"
+	ERIS_REG_BAK = "" //dockerhub
 
 	ERIS_IMG_BASE = "eris/base"
 	ERIS_IMG_DATA = "eris/data"

--- a/version/images.go
+++ b/version/images.go
@@ -15,7 +15,3 @@ var (
 	ERIS_IMG_PM   = fmt.Sprintf("eris/epm:%s", VERSION)
 	ERIS_IMG_IPFS = "eris/ipfs"
 )
-
-func getReg(imgRaw string) string {
-	return ""
-}


### PR DESCRIPTION
- moves image names throughout the code to `version/images.go`
- moves service/action definition names to `version/files.go` ++ cleaner tests
- failover to dockerhub if err pulling from quay (but only on init)

closes #458 