### PR TITLE
chains and services tests refactor

### DIFF
--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -2,9 +2,7 @@ package chains
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -17,7 +15,6 @@ import (
 	ini "github.com/eris-ltd/eris-cli/initialize"
 	"github.com/eris-ltd/eris-cli/list"
 	"github.com/eris-ltd/eris-cli/loaders"
-	"github.com/eris-ltd/eris-cli/perform"
 	"github.com/eris-ltd/eris-cli/services"
 	tests "github.com/eris-ltd/eris-cli/testutils"
 	"github.com/eris-ltd/eris-cli/util"
@@ -28,8 +25,10 @@ import (
 	logger "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
 )
 
-var erisDir string = filepath.Join(os.TempDir(), "eris")
-var chainName string = "my_testing_chain_dot_com" // :( [csk]-> :)
+var (
+	erisDir   = filepath.Join(os.TempDir(), "eris")
+	chainName = "test-chain"
+)
 
 func TestMain(m *testing.M) {
 	runtime.GOMAXPROCS(1)
@@ -42,429 +41,526 @@ func TestMain(m *testing.M) {
 	tests.IfExit(tests.TestsInit("chain"))
 	log.Info("Test init completed. Starting main test sequence now")
 
-	layTestChainToml(chainName)
+	mockChainDefinitionFile(chainName)
 
-	fmt.Println(m.Run())
+	m.Run()
 }
 
-func TestKnownChain(t *testing.T) {
+func TestListAllChainsRunning(t *testing.T) {
+	if err := mockChainDefinitionFile("test-chain-list1"); err != nil {
+		t.Fatalf("can't create a fake service definition: %v", err)
+	}
+
+	do := def.NowDo()
+	do.Known = true
+	do.Existing = false
+	do.Running = true
+	do.Quiet = true
+	if err := list.ListAll(do, "chains"); err != nil {
+		t.Fatalf("expected list to succeed, got %v", err)
+	}
+
+	if strings.Contains(do.Result, "test-chain-list1") {
+		t.Fatalf("expected the chain not found")
+	}
+}
+
+func TestListAllChainsKnown(t *testing.T) {
+	if err := mockChainDefinitionFile("test-chain-list2"); err != nil {
+		t.Fatalf("can't create a fake service definition: %v", err)
+	}
+
 	do := def.NowDo()
 	do.Known = true
 	do.Existing = false
 	do.Running = false
 	do.Quiet = true
-	tests.IfExit(list.ListAll(do, "chains"))
+	if err := list.ListAll(do, "chains"); err != nil {
+		t.Fatalf("expected list to succeed, got %v", err)
+	}
 
-	k := strings.Split(do.Result, "\n") // tests output formatting.
-
-	// apparently these have extra space
-	if strings.TrimSpace(k[0]) != chainName {
-		log.WithField("=>", do.Result).Debug("Result")
-		tests.IfExit(fmt.Errorf("Unexpected chain definition file. Got %s, expected %s.", k[0], chainName))
+	if !strings.Contains(do.Result, "test-chain-list2") {
+		t.Fatalf("expected the chain to be found")
 	}
 }
 
 func TestChainGraduate(t *testing.T) {
 	do := def.NowDo()
 	do.Name = chainName
-	log.WithField("=>", do.Name).Info("Graduate chain (from tests)")
 	if err := GraduateChain(do); err != nil {
-		tests.IfExit(err)
+		t.Fatalf("expected chain to graduate, got %v", err)
 	}
 
 	srvDef, err := loaders.LoadServiceDefinition(chainName, false, 1)
 	if err != nil {
-		tests.IfExit(err)
+		t.Fatalf("expected service definition to be loaded")
 	}
 
-	image := path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_DB)
-	if srvDef.Service.Image != image {
-		tests.IfExit(fmt.Errorf("FAILURE: improper service image on GRADUATE. expected: %s\tgot: %s\n", image, srvDef.Service.Image))
+	if image := path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_DB); srvDef.Service.Image != image {
+		t.Fatalf("bad image on graduate, expected %s, got: %s", image, srvDef.Service.Image)
 	}
 
 	if srvDef.Service.Command != loaders.ErisChainStart {
-		tests.IfExit(fmt.Errorf("FAILURE: improper service command on GRADUATE. expected: %s\tgot: %s\n", loaders.ErisChainStart, srvDef.Service.Command))
+		t.Fatalf("improper service command on graduate, expected %s, got %s", loaders.ErisChainStart, srvDef.Service.Command)
 	}
 
 	if !srvDef.Service.AutoData {
-		tests.IfExit(fmt.Errorf("FAILURE: improper service autodata on GRADUATE. expected: %t\tgot: %t\n", true, srvDef.Service.AutoData))
+		t.Fatalf("improper service autodata value on graduae, expected %t, got %t", true, srvDef.Service.AutoData)
 	}
 
 	if len(srvDef.Dependencies.Services) != 1 {
-		tests.IfExit(fmt.Errorf("FAILURE: improper service deps on GRADUATE. expected: [\"keys\"]\tgot: %s\n", srvDef.Dependencies.Services))
+		t.Fatalf("improper service deps on graduate, expected: [%q], got %s", "keys", srvDef.Dependencies.Services)
 	}
 }
 
 func TestLoadChainDefinition(t *testing.T) {
-	var e error
-	log.WithField("=>", chainName).Info("Load chain definition (from tests)")
-	chn, e := loaders.LoadChainDefinition(chainName, false, 1)
-	if e != nil {
-		tests.IfExit(e)
+	// [pv]: this test belongs to the loaders package.
+	var err error
+	chain, err := loaders.LoadChainDefinition(chainName, false, 1)
+	if err != nil {
+		t.Fatalf("expected chain definition to be loaded, got %v", err)
 	}
 
-	if chn.Service.Name != chainName {
-		tests.IfExit(fmt.Errorf("FAILURE: improper service name on LOAD. expected: %s\tgot: %s", chainName, chn.Service.Name))
+	if chain.Service.Name != chainName {
+		t.Fatalf("improper service name on load, expected %s, got %s", chainName, chain.Service.Name)
 	}
 
-	if !chn.Service.AutoData {
-		tests.IfExit(fmt.Errorf("FAILURE: data_container not properly read on LOAD."))
+	if !chain.Service.AutoData {
+		t.Fatalf("data_container not properly read on load, expected false")
 	}
 
-	if chn.Operations.DataContainerName == "" {
-		tests.IfExit(fmt.Errorf("FAILURE: data_container_name not set."))
+	if chain.Operations.DataContainerName == "" {
+		t.Fatalf("data_container_name not set")
 	}
 }
 
-func TestStartKillChain(t *testing.T) {
-	testStartChain(t, chainName)
-	testKillChain(t, chainName)
+func TestStartChain(t *testing.T) {
+	defer tests.RemoveAllContainers()
+
+	start(t, chainName)
+	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 1 {
+		t.Fatalf("expecting 1 chain container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(chainName, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data containers, got %v", n)
+	}
+
+	kill(t, chainName)
+	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 0 {
+		t.Fatalf("expecting 0 chain container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(chainName, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 data containers, got %v", n)
+	}
 }
 
 func TestRestartChain(t *testing.T) {
-	testNewChain(chainName)
-	defer testKillChain(t, chainName)
-
-	testKillChain(t, chainName)
-	testStartChain(t, chainName)
-	testKillChain(t, chainName)
-}
-
-// TODO: this isn't actually testing much!
-func TestExecChain(t *testing.T) {
-	testStartChain(t, chainName)
-	defer testKillChain(t, chainName)
+	defer tests.RemoveAllContainers()
 
 	do := def.NowDo()
-	do.Name = chainName
-	do.Operations.Args = strings.Fields("ls -la /home/eris/.eris")
-	do.Operations.Interactive = false
-	log.WithField("=>", do.Name).Info("Executing chain (from tests)")
-	e := ExecChain(do)
-	if e != nil {
-		log.Error(e)
-		t.Fail()
-	}
-}
-
-func TestPlopChain(t *testing.T) {
-	cfgFilePath := filepath.Join(common.ChainsPath, "default", "config.toml")
-
-	do := def.NowDo()
-	do.ConfigFile = cfgFilePath
+	do.ConfigFile = filepath.Join(common.ChainsPath, "default", "config.toml")
 	do.Name = chainName
 	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
-	log.WithField("=>", chainName).Info("Creating chain (from tests)")
-	tests.IfExit(NewChain(do))
-	defer testKillChain(t, chainName)
-
-	do = def.NowDo()
-	do.Type = "config"
-	do.ChainID = chainName
-
-	newWriter := new(bytes.Buffer)
-	config.GlobalConfig.Writer = newWriter
-	e := PlopChain(do)
-	if e != nil {
-		log.Error(e)
-		t.Fail()
+	if err := NewChain(do); err != nil {
+		t.Fatalf("expected a new chain to be created, got %v", err)
 	}
 
-	cfgFile, err := ioutil.ReadFile(cfgFilePath)
-	tests.IfExit(err)
-	cfgFilePlop := newWriter.Bytes()
+	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 1 {
+		t.Fatalf("expecting 1 chain container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(chainName, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data containers, got %v", n)
+	}
 
-	// remove [13] that shows up everywhere ...
-	cfgFile = bytes.Replace(cfgFile, []byte{13}, []byte{}, -1)
-	cfgFilePlop = bytes.Replace(cfgFilePlop, []byte{13}, []byte{}, -1)
+	kill(t, chainName)
+	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 0 {
+		t.Fatalf("expecting 0 chain container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(chainName, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 data containers, got %v", n)
+	}
 
-	if !bytes.Equal(cfgFile, cfgFilePlop) {
-		log.WithFields(log.Fields{
-			"got":      string(cfgFilePlop),
-			"expected": string(cfgFile),
-		}).Error("Error comparing config files")
-		t.Fail()
+	start(t, chainName)
+	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 1 {
+		t.Fatalf("expecting 1 chain container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(chainName, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data containers, got %v", n)
+	}
+
+	kill(t, chainName)
+	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 0 {
+		t.Fatalf("expecting 0 chain container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(chainName, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 data containers, got %v", n)
 	}
 }
 
-func TestChainsNewDirGen(t *testing.T) {
-	chainID := "testChainsNewDirGen"
-	myDir := filepath.Join(common.DataContainersPath, chainID)
-	if err := os.MkdirAll(myDir, 0700); err != nil {
-		tests.IfExit(err)
+func TestExecChain(t *testing.T) {
+	start(t, chainName)
+	defer kill(t, chainName)
+
+	buf := new(bytes.Buffer)
+	config.GlobalConfig.Writer = buf
+
+	do := def.NowDo()
+	do.Name = chainName
+	do.Operations.Args = []string{"ls", common.ErisContainerRoot}
+	if err := ExecChain(do); err != nil {
+		t.Fatalf("expected chain to execute, got %v", err)
 	}
-	contents := "this is a file in the directory\n"
-	if err := ioutil.WriteFile(filepath.Join(myDir, "file.file"), []byte(contents), 0664); err != nil {
-		tests.IfExit(err)
+
+	if dir := "chains"; !strings.Contains(buf.String(), dir) {
+		t.Fatalf("expected to find %q dir in eris root", dir)
+	}
+}
+
+func TestExecChainBadCommandLine(t *testing.T) {
+	start(t, chainName)
+	defer kill(t, chainName)
+
+	do := def.NowDo()
+	do.Name = chainName
+	do.Operations.Args = strings.Fields("bad command line")
+	if err := ExecChain(do); err == nil {
+		t.Fatalf("expected chain to fail")
+	}
+}
+
+func TestCatChainLocalConfig(t *testing.T) {
+	buf := new(bytes.Buffer)
+	config.GlobalConfig.Writer = buf
+
+	do := def.NowDo()
+	do.Name = chainName
+	do.Type = "toml"
+	if err := CatChain(do); err != nil {
+		t.Fatalf("expected getting a local config to succeed, got %v", err)
+	}
+
+	if buf.String() != tests.FileContents(filepath.Join(erisDir, "chains", chainName+".toml")) {
+		t.Fatalf("expected the local config file to match, got %v", buf.String())
+	}
+}
+
+func TestCatChainContainerConfig(t *testing.T) {
+	defer tests.RemoveAllContainers()
+
+	buf := new(bytes.Buffer)
+	config.GlobalConfig.Writer = buf
+
+	do := def.NowDo()
+	do.ConfigFile = filepath.Join(common.ChainsPath, "default", "config.toml")
+	do.Name = chainName
+	do.Operations.ContainerNumber = 1
+	do.Operations.PublishAllPorts = true
+	if err := NewChain(do); err != nil {
+		t.Fatalf("expected a new chain to be created, got %v", err)
+	}
+
+	do.Type = "config"
+	if err := CatChain(do); err != nil {
+		t.Fatalf("expected getting a local config to succeed, got %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "defaulttester.com") {
+		t.Fatalf("expected the config file to contain an expected string, got %v", buf.String())
+	}
+}
+
+func TestCatChainContainerGenesis(t *testing.T) {
+	defer tests.RemoveAllContainers()
+
+	buf := new(bytes.Buffer)
+	config.GlobalConfig.Writer = buf
+
+	do := def.NowDo()
+	do.ConfigFile = filepath.Join(common.ChainsPath, "default", "config.toml")
+	do.Name = chainName
+	do.Operations.ContainerNumber = 1
+	do.Operations.PublishAllPorts = true
+	if err := NewChain(do); err != nil {
+		t.Fatalf("expected a new chain to be created, got %v", err)
+	}
+
+	do.Type = "genesis"
+	if err := CatChain(do); err != nil {
+		t.Fatalf("expected getting a local config to succeed, got %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "accounts") || !strings.Contains(buf.String(), "validators") {
+		t.Fatalf("expected the genesis file to contain expected strings, got %v", buf.String())
+	}
+}
+
+func TestChainsNewDirGenCustomFile(t *testing.T) {
+	defer tests.RemoveAllContainers()
+
+	const (
+		chain    = "test-dir-gen"
+		file     = "file.file"
+		contents = "test contents"
+	)
+
+	dir := filepath.Join(common.DataContainersPath, chain)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("could not create a directory %q: %v", dir, err)
+	}
+	if err := tests.FakeDefinitionFile(filepath.Join(common.DataContainersPath, chain), file, contents); err != nil {
+		t.Fatalf("could not create a test file %q: %v", file, err)
 	}
 
 	do := def.NowDo()
 	do.GenesisFile = filepath.Join(common.ChainsPath, "default", "genesis.json")
-	do.Name = chainID
-	do.Path = myDir
+	do.Name = chain
+	do.Path = dir
 	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
-	log.WithField("=>", do.Name).Info("Creating chain (from tests)")
-	tests.IfExit(NewChain(do))
-
-	// remove the data container
-	defer removeChainContainer(t, chainID, do.Operations.ContainerNumber)
-
-	// verify the contents of file.file - swap config writer with bytes.Buffer
-	// TODO: functions for facilitating this
-	oldWriter := config.GlobalConfig.Writer
-	newWriter := new(bytes.Buffer)
-	config.GlobalConfig.Writer = newWriter
-	ops := loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
-	util.Merge(ops, do.Operations)
-	ops.Args = []string{"cat", fmt.Sprintf("/home/eris/.eris/file.file")}
-	b, err := perform.DockerRunData(ops, nil)
-	if err != nil {
-		tests.IfExit(err)
+	if err := NewChain(do); err != nil {
+		t.Fatalf("expected a new chain to be created, got %v", err)
 	}
 
-	config.GlobalConfig.Writer = oldWriter
-	result := trimResult(string(b))
-	contents = trimResult(contents)
-	if result != contents {
-		tests.IfExit(fmt.Errorf("file not faithfully copied. Got: %s \n Expected: %s", result, contents))
-	}
-
-	// verify the chain_id got swapped in the genesis.json
-	// TODO: functions for facilitating this
-	oldWriter = config.GlobalConfig.Writer
-	newWriter = new(bytes.Buffer)
-	config.GlobalConfig.Writer = newWriter
-	ops = loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
-	util.Merge(ops, do.Operations)
-	ops.Args = []string{"cat", fmt.Sprintf("/home/eris/.eris/chains/%s/genesis.json", chainID)} //, "|", "jq", ".chain_id"}
-	b, err = perform.DockerRunData(ops, nil)
-	if err != nil {
-		tests.IfExit(err)
-	}
-
-	config.GlobalConfig.Writer = oldWriter
-	result = string(b)
-
-	s := struct {
-		ChainID string `json:"chain_id"`
-	}{}
-	if err := json.Unmarshal([]byte(result), &s); err != nil {
-		tests.IfExit(err)
-	}
-
-	if s.ChainID != chainID {
-		tests.IfExit(fmt.Errorf("ChainID mismatch: got %s, expected %s", s.ChainID, chainID))
+	args := []string{"cat", filepath.Join(common.ErisContainerRoot, file+".toml")}
+	if out := exec(t, chain, args); out != contents {
+		t.Fatalf("expected file contents, got %q", out)
 	}
 }
 
-// eris chains new -c _ -csv _
-func TestChainsNewConfigAndCSV(t *testing.T) {
-	chainID := "testChainsNewConfigAndCSV"
+func TestChainsNewDirGenesis(t *testing.T) {
+	defer tests.RemoveAllContainers()
+
+	const (
+		chain = "test-dir-gen"
+	)
+
 	do := def.NowDo()
-	do.Name = chainID
+	do.Name = chain
+	do.Operations.ContainerNumber = 1
+	do.Operations.PublishAllPorts = true
+	if err := NewChain(do); err != nil {
+		t.Fatalf("expected a new chain to be created, got %v", err)
+	}
+
+	args := []string{"cat", fmt.Sprintf("/home/eris/.eris/chains/%s/genesis.json", chain)}
+	if out := exec(t, chain, args); !strings.Contains(out, chain) {
+		t.Fatalf("expected chain_id to be equal to chain name in genesis file, got %v", out)
+	}
+}
+
+func TestChainsNewConfig(t *testing.T) {
+	defer tests.RemoveAllContainers()
+	const (
+		chain = "test-config-csv"
+	)
+
+	do := def.NowDo()
+	do.Name = chain
 	do.ConfigFile = filepath.Join(common.ChainsPath, "default", "config.toml")
 	do.CSV = filepath.Join(common.ChainsPath, "default", "genesis.csv")
 	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
-	log.WithField("=>", do.Name).Info("Creating chain (from tests)")
-	tests.IfExit(NewChain(do))
-	_, err := ioutil.ReadFile(do.ConfigFile)
-	if err != nil {
-		tests.IfExit(err)
+	if err := NewChain(do); err != nil {
+		t.Fatalf("expected to create a new chain, got %v", err)
 	}
 
-	// remove the data container
-	defer removeChainContainer(t, chainID, do.Operations.ContainerNumber)
-
-	// verify the contents of config.toml
-	ops := loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
-	util.Merge(ops, do.Operations)
-	ops.Args = []string{"cat", fmt.Sprintf("/home/eris/.eris/chains/%s/config.toml", chainID)}
-	result := trimResult(string(runContainer(t, ops)))
-
-	configDefault := filepath.Join(erisDir, "chains", "default", "config.toml")
-	read, err := ioutil.ReadFile(configDefault)
-	if err != nil {
-		tests.IfExit(err)
-	}
-	contents := trimResult(string(read))
-
-	if result != contents {
-		tests.IfExit(fmt.Errorf("config not properly copied. Got: %s \n Expected: %s", result, contents))
-	}
-
-	// verify the contents of genesis.json (should have the validator from the csv)
-	ops = loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
-	util.Merge(ops, do.Operations)
-	ops.Args = []string{"cat", fmt.Sprintf("/home/eris/.eris/chains/%s/genesis.json", chainID)}
-	result = string(runContainer(t, ops))
-	var found bool
-	for _, s := range strings.Split(result, "\n") {
-		if strings.Contains(s, ini.DefaultPubKeys[0]) {
-			found = true
-			break
-		}
-	}
-	if !found {
-		tests.IfExit(fmt.Errorf("Did not find pubkey %s in genesis.json: %s", ini.DefaultPubKeys[0], result))
+	args := []string{"cat", fmt.Sprintf("/home/eris/.eris/chains/%s/config.toml", chain)}
+	if out := exec(t, chain, args); !strings.Contains(out, "defaulttester.com") {
+		t.Fatalf("expected the config file to contain an expected string, got %v", out)
 	}
 }
 
-// eris chains new --options
-func TestChainsNewConfigOpts(t *testing.T) {
-	// XXX: need to use a different chainID or remove the local tmp/eris/data/chainID dir with each test!
-	chainID := "testChainsNewConfigOpts"
-	do := def.NowDo()
+func TestChainsNewCSV(t *testing.T) {
+	defer tests.RemoveAllContainers()
+	const (
+		chain = "test-config-csv"
+	)
 
-	do.Name = chainID
+	do := def.NowDo()
+	do.Name = chain
+	do.CSV = filepath.Join(common.ChainsPath, "default", "genesis.csv")
+	do.Operations.ContainerNumber = 1
+	do.Operations.PublishAllPorts = true
+	if err := NewChain(do); err != nil {
+		t.Fatalf("expected to create a new chain, got %v", err)
+	}
+
+	args := []string{"cat", fmt.Sprintf("/home/eris/.eris/chains/%s/genesis.json", chain)}
+	if out := exec(t, chain, args); !strings.Contains(out, ini.DefaultPubKeys[0]) {
+		t.Fatalf("expected to find a validator from csv, got %", out)
+	}
+
+}
+
+func TestChainsNewConfigOpts(t *testing.T) {
+	defer tests.RemoveAllContainers()
+	const (
+		chain = "test-config-opts"
+	)
+
+	do := def.NowDo()
+	do.Name = chain
 	do.ConfigOpts = []string{"moniker=satoshi", "p2p=1.1.1.1:42", "fast-sync=true"}
 	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
-	log.WithField("=>", do.Name).Info("Creating chain (from tests)")
-	tests.IfExit(NewChain(do))
-
-	// remove the data container
-	defer removeChainContainer(t, chainID, do.Operations.ContainerNumber)
-
-	// verify the contents of config.toml
-	ops := loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
-	util.Merge(ops, do.Operations)
-	ops.Args = []string{"cat", fmt.Sprintf("/home/eris/.eris/chains/%s/config.toml", chainID)}
-	result := string(runContainer(t, ops))
-
-	spl := strings.Split(result, "\n")
-	var found bool
-	for _, s := range spl {
-		if ensureTomlValue(t, s, "moniker", "satoshi") {
-			found = true
-		}
-		if ensureTomlValue(t, s, "node_laddr", "1.1.1.1:42") {
-			found = true
-		}
-		if ensureTomlValue(t, s, "fast_sync", "true") {
-			found = true
-		}
+	if err := NewChain(do); err != nil {
+		t.Fatalf("expected to create a new chain, got %v", err)
 	}
-	if !found {
-		tests.IfExit(fmt.Errorf("failed to find fields: %s", result))
+
+	do = def.NowDo()
+	do.Name = chain
+	do.Operations.Args = []string{"cat", fmt.Sprintf("/home/eris/.eris/chains/%s/config.toml", chain)}
+	if err := ExecChain(do); err != nil {
+		t.Fatalf("expected chain to execute, got %v", err)
+	}
+
+	args := []string{"cat", fmt.Sprintf("/home/eris/.eris/chains/%s/config.toml", chain)}
+	if out := exec(t, chain, args); !strings.Contains(out, "satoshi") || !strings.Contains(out, "1.1.1.1:42") {
+		t.Fatalf("expected to find set options in config file, got %v", out)
 	}
 }
 
 func TestLogsChain(t *testing.T) {
-	testStartChain(t, chainName)
-	defer testKillChain(t, chainName)
+	defer tests.RemoveAllContainers()
+
+	start(t, chainName)
 
 	do := def.NowDo()
 	do.Name = chainName
 	do.Follow = false
 	do.Tail = "all"
-	log.WithFields(log.Fields{
-		"=>":   do.Name,
-		"tail": do.Tail,
-	}).Info("Getting chain logs (from tests)")
-	e := LogsChain(do)
-	if e != nil {
-		tests.IfExit(e)
+	if err := LogsChain(do); err != nil {
+		t.Fatalf("failed to fetch container logs")
 	}
 }
 
 func TestUpdateChain(t *testing.T) {
-	testStartChain(t, chainName)
-	defer testKillChain(t, chainName)
+	defer tests.RemoveAllContainers()
+
+	start(t, chainName)
 
 	do := def.NowDo()
 	do.Name = chainName
 	do.Pull = false
 	do.Operations.PublishAllPorts = true
-	log.WithField("=>", do.Name).Info("Updating chain (from tests)")
-	if e := UpdateChain(do); e != nil {
-		tests.IfExit(e)
+	if err := UpdateChain(do); err != nil {
+		t.Fatalf("expected chain to update, got %v", err)
 	}
 
-	testExistAndRun(t, chainName, true, true)
+	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 1 {
+		t.Fatalf("expecting 1 chain container running, got %v", n)
+	}
 }
 
 func TestInspectChain(t *testing.T) {
-	testStartChain(t, chainName)
-	defer testKillChain(t, chainName)
+	defer tests.RemoveAllContainers()
+
+	start(t, chainName)
 
 	do := def.NowDo()
 	do.Name = chainName
 	do.Operations.Args = []string{"name"}
 	do.Operations.ContainerNumber = 1
-	log.WithFields(log.Fields{
-		"=>":   chainName,
-		"args": do.Operations.Args,
-	}).Debug("Inspecting chain (from tests)")
-	if e := InspectChain(do); e != nil {
-		tests.IfExit(fmt.Errorf("Error inspecting chain =>\t%v\n", e))
+	if err := InspectChain(do); err != nil {
+		t.Fatalf("expected chain to be inspected, got %v", err)
 	}
 }
 
 func TestRenameChain(t *testing.T) {
-	aChain := "hichain"
-	rename1 := "niahctset"
-	rename2 := chainName
-	testNewChain(aChain)
-	defer testKillChain(t, rename2)
+	defer tests.RemoveAllContainers()
+
+	const (
+		chain   = "hichain"
+		rename1 = "niahctset"
+	)
 
 	do := def.NowDo()
-	do.Name = aChain
-	do.NewName = rename1
-	log.WithFields(log.Fields{
-		"from": do.Name,
-		"to":   do.NewName,
-	}).Info("Renaming chain (from tests)")
-
-	if e := RenameChain(do); e != nil {
-		tests.IfExit(e)
+	do.Name = chain
+	do.Operations.ContainerNumber = 1
+	if err := NewChain(do); err != nil {
+		t.Fatalf("expected a new chain to be created, got %v", err)
 	}
 
-	testExistAndRun(t, rename1, true, true)
+	if n := util.HowManyContainersRunning(chain, def.TypeChain); n != 1 {
+		t.Fatalf("expecting 1 chain container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(chain, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data containers, got %v", n)
+	}
+
+	do = def.NowDo()
+	do.Name = chain
+	do.NewName = rename1
+	if err := RenameChain(do); err != nil {
+		t.Fatalf("expected chain to be renamed #1, got %v", err)
+	}
+
+	if n := util.HowManyContainersRunning(chain, def.TypeChain); n != 0 {
+		t.Fatalf("expecting 0 chain container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(chain, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 data containers, got %v", n)
+	}
+
+	if n := util.HowManyContainersRunning(rename1, def.TypeChain); n != 1 {
+		t.Fatalf("expecting 1 chain container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(rename1, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data containers, got %v", n)
+	}
 
 	do = def.NowDo()
 	do.Name = rename1
-	do.NewName = rename2
-	log.WithFields(log.Fields{
-		"from": do.Name,
-		"to":   do.NewName,
-	}).Info("Renaming chain (from tests)")
-	if e := RenameChain(do); e != nil {
-		tests.IfExit(e)
+	do.NewName = chainName
+	if err := RenameChain(do); err != nil {
+		t.Fatalf("expected chain to be renamed #2, got %v", err)
 	}
 
-	testExistAndRun(t, chainName, true, true)
+	if n := util.HowManyContainersRunning(rename1, def.TypeChain); n != 0 {
+		t.Fatalf("expecting 0 chain container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(rename1, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 data containers, got %v", n)
+	}
+
+	if n := util.HowManyContainersRunning(chainName, def.TypeChain); n != 1 {
+		t.Fatalf("expecting 1 chain container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(chainName, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data containers, got %v", n)
+	}
 }
 
 func TestRmChain(t *testing.T) {
-	testStartChain(t, chainName)
+	start(t, chainName)
 
 	do := def.NowDo()
 	do.Operations.Args, do.Rm, do.RmD = []string{"keys"}, true, true
-	log.WithField("=>", do.Name).Info("Removing keys (from tests)")
-	if e := services.KillService(do); e != nil {
-		tests.IfExit(e)
+	if err := services.KillService(do); err != nil {
+		t.Fatalf("expected service to be stopped, got %v", err)
 	}
 
 	do = def.NowDo()
 	do.Name, do.Rm, do.RmD = chainName, false, false
 	log.WithField("=>", do.Name).Info("Stopping chain (from tests)")
-	if e := KillChain(do); e != nil {
-		tests.IfExit(e)
+	if err := KillChain(do); err != nil {
+		t.Fatalf("expected chain to be stopped, got %v", err)
 	}
-	testExistAndRun(t, chainName, true, false)
+	if n := util.HowManyContainersExisting(chainName, def.TypeChain); n != 1 {
+		t.Fatalf("expecting 1 chain containers, got %v", n)
+	}
 
 	do = def.NowDo()
 	do.Name = chainName
 	do.RmD = true
 	log.WithField("=>", do.Name).Info("Removing chain (from tests)")
-	if e := RmChain(do); e != nil {
-		tests.IfExit(e)
+	if err := RmChain(do); err != nil {
+		t.Fatalf("expected chain to be removed, got %v", err)
 	}
-
-	testExistAndRun(t, chainName, false, false)
+	if n := util.HowManyContainersExisting(chainName, def.TypeChain); n != 0 {
+		t.Fatalf("expecting 0 chain containers, got %v", n)
+	}
 }
 
 func TestServiceLinkNoChain(t *testing.T) {
@@ -836,114 +932,46 @@ data_container = true
 	}
 }
 
-//------------------------------------------------------------------
-// testing utils
-
-func testStartChain(t *testing.T, chain string) {
+func start(t *testing.T, chain string) {
 	do := def.NowDo()
 	do.Name = chain
 	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
-	log.WithField("=>", do.Name).Info("Starting chain (from tests)")
-	if e := StartChain(do); e != nil {
-		log.Error(e)
-		tests.IfExit(nil)
+	if err := StartChain(do); err != nil {
+		t.Fatalf("starting chain %v failed: %v", err)
 	}
-	testExistAndRun(t, chain, true, true)
 }
 
-func testKillChain(t *testing.T, chain string) {
-	// log.SetLoggers(2, os.Stdout, os.Stderr)
-	testExistAndRun(t, chain, true, true)
-
+func kill(t *testing.T, chain string) {
 	do := def.NowDo()
 	do.Operations.Args, do.Rm, do.RmD = []string{"keys"}, true, true
-	log.WithField("=>", do.Name).Info("Stopping service (from tests)")
-	if e := services.KillService(do); e != nil {
-		tests.IfExit(e)
+	if err := services.KillService(do); err != nil {
+		t.Fatalf("killing keys service failed: %v", err)
 	}
 
 	do = def.NowDo()
 	do.Name, do.Rm, do.RmD = chain, true, true
-	log.WithField("=>", do.Name).Info("Stopping chain (from tests)")
-	if e := KillChain(do); e != nil {
-		tests.IfExit(e)
-	}
-	testExistAndRun(t, chain, false, false)
-}
-
-func testExistAndRun(t *testing.T, chainName string, toExist, toRun bool) {
-	if err := tests.TestExistAndRun(chainName, "chain", 1, toExist, toRun); err != nil {
-		tests.IfExit(nil)
-	}
-}
-
-func testNewChain(chain string) {
-	do := def.NowDo()
-	do.GenesisFile = filepath.Join(common.ChainsPath, "default", "genesis.json")
-	do.Name = chain
-	do.Operations.ContainerNumber = 1
-	do.Operations.PublishAllPorts = true
-	log.WithField("=>", chain).Info("Creating chain")
-	tests.IfExit(NewChain(do))
-}
-
-func removeChainContainer(t *testing.T, chainID string, cNum int) {
-	do := def.NowDo()
-	do.Name = chainID
-	do.Rm, do.Force, do.RmD = true, true, true
-	do.Operations.ContainerNumber = cNum
 	if err := KillChain(do); err != nil {
-		tests.IfExit(err)
+		t.Fatalf("killing chain failed: %v", err)
 	}
 }
 
-func runContainer(t *testing.T, ops *def.Operation) []byte {
-	oldWriter := config.GlobalConfig.Writer
-	newWriter := new(bytes.Buffer)
-	config.GlobalConfig.Writer = newWriter
+func exec(t *testing.T, chain string, args []string) string {
+	buf := new(bytes.Buffer)
+	config.GlobalConfig.Writer = buf
 
-	b, err := perform.DockerRunData(ops, nil)
-	if err != nil {
-		tests.IfExit(err)
+	do := def.NowDo()
+	do.Name = chain
+	do.Operations.Args = args
+	if err := ExecChain(do); err != nil {
+		t.Fatalf("expected chain to execute, got %v", err)
 	}
-	log.WithFields(log.Fields{
-		"=>":   ops.DataContainerName,
-		"args": ops.Args,
-	}).Debug("Container ran (from tests)")
-	config.GlobalConfig.Writer = oldWriter
-	return b
+
+	return buf.String()
 }
 
-func ensureTomlValue(t *testing.T, s, field, value string) bool {
-	if strings.Contains(s, field) {
-		if !strings.Contains(s, value) {
-			tests.IfExit(fmt.Errorf("Expected %s to be %s. Got: %s", field, value, s))
-		}
-		return true
-	}
-	return false
-}
+func mockChainDefinitionFile(name string) error {
+	definition := loaders.MockChainDefinition(name, name, false, 1)
 
-func trimResult(s string) string {
-	s = strings.TrimSpace(s)
-	s = strings.Trim(s, "\n")
-	spl := strings.Split(s, "\n")
-	for i, t := range spl {
-		t = strings.TrimSpace(t)
-		spl[i] = t
-	}
-	return strings.Trim(strings.Join(spl, "\n"), "\n")
-}
-
-func layTestChainToml(name string) {
-	chain := loaders.MockChainDefinition(name, name, false, 1)
-
-	// write the chain definition file ...
-	fileName := filepath.Join(erisDir, "chains", name)
-	if _, err := os.Stat(fileName); err != nil {
-		if err = WriteChainDefinitionFile(chain, fileName); err != nil {
-			panic(fmt.Errorf("error writing chain definition to file: %v", err))
-		}
-	}
+	return WriteChainDefinitionFile(definition, filepath.Join(erisDir, "chains", name))
 }

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -39,11 +39,11 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.DebugLevel)
 
 	tests.IfExit(tests.TestsInit("chain"))
-	log.Info("Test init completed. Starting main test sequence now")
-
 	mockChainDefinitionFile(chainName)
 
 	m.Run()
+
+	tests.IfExit(tests.TestsTearDown())
 }
 
 func TestListAllChainsRunning(t *testing.T) {
@@ -105,7 +105,7 @@ func TestChainGraduate(t *testing.T) {
 	}
 
 	if !srvDef.Service.AutoData {
-		t.Fatalf("improper service autodata value on graduae, expected %t, got %t", true, srvDef.Service.AutoData)
+		t.Fatalf("improper service autodata value on graduate, expected %t, got %t", true, srvDef.Service.AutoData)
 	}
 
 	if len(srvDef.Dependencies.Services) != 1 {
@@ -388,7 +388,7 @@ func TestChainsNewCSV(t *testing.T) {
 
 	args := []string{"cat", fmt.Sprintf("/home/eris/.eris/chains/%s/genesis.json", chain)}
 	if out := exec(t, chain, args); !strings.Contains(out, ini.DefaultPubKeys[0]) {
-		t.Fatalf("expected to find a validator from csv, got %", out)
+		t.Fatalf("expected to find a validator from csv, got %v", out)
 	}
 
 }
@@ -938,7 +938,7 @@ func start(t *testing.T, chain string) {
 	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
 	if err := StartChain(do); err != nil {
-		t.Fatalf("starting chain %v failed: %v", err)
+		t.Fatalf("starting chain %v failed: %v", chain, err)
 	}
 }
 

--- a/chains/operate.go
+++ b/chains/operate.go
@@ -67,7 +67,7 @@ func KillChain(do *definitions.Do) error {
 	}
 
 	if do.Rm {
-		if err := perform.DockerRemove(chain.Service, chain.Operations, do.RmD, do.Volumes); err != nil {
+		if err := perform.DockerRemove(chain.Service, chain.Operations, do.RmD, do.Volumes, do.Force); err != nil {
 			return err
 		}
 	}
@@ -514,7 +514,7 @@ func CleanUp(do *definitions.Do) error {
 
 	if do.Rm {
 		log.WithField("=>", do.Operations.SrvContainerName).Debug("Removing tmp service container")
-		perform.DockerRemove(do.Service, do.Operations, true, true)
+		perform.DockerRemove(do.Service, do.Operations, true, true, false)
 	}
 
 	return nil

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -65,8 +65,8 @@ func buildFlag(cmd *cobra.Command, do *definitions.Do, flag, typ string) { //doe
 	case "file":
 		if typ == "action" {
 			cmd.Flags().BoolVarP(&do.File, "file", "f", false, fmt.Sprintf("remove %s definition file", typ))
-		} else { //typ == "chain" || typ == "service"
-			cmd.Flags().BoolVarP(&do.File, "file", "f", false, fmt.Sprintf("remove %s definition file as well as %s container", typ, typ))
+		} else {
+			cmd.Flags().BoolVarP(&do.File, "file", "", false, fmt.Sprintf("remove %s definition file as well as %s container", typ, typ))
 		}
 	case "chain":
 		if typ == "service" {

--- a/commands/services.go
+++ b/commands/services.go
@@ -236,6 +236,7 @@ func addServicesFlags() {
 	buildFlag(servicesUpdate, do, "env", "service")
 	buildFlag(servicesUpdate, do, "links", "service")
 
+	buildFlag(servicesRm, do, "force", "service")
 	buildFlag(servicesRm, do, "file", "service")
 	buildFlag(servicesRm, do, "data", "service")
 	buildFlag(servicesRm, do, "rm-volumes", "service")

--- a/contracts/operate.go
+++ b/contracts/operate.go
@@ -287,7 +287,7 @@ func CleanUp(do *definitions.Do, app *definitions.Contracts) error {
 		doRemove := definitions.NowDo()
 		doRemove.Operations.SrvContainerName = do.Operations.DataContainerName
 		log.WithField("=>", doRemove.Operations.SrvContainerName).Debug("Removing data container")
-		if err := perform.DockerRemove(nil, doRemove.Operations, false, true); err != nil {
+		if err := perform.DockerRemove(nil, doRemove.Operations, false, true, false); err != nil {
 			return err
 		}
 	}

--- a/data/manage.go
+++ b/data/manage.go
@@ -66,7 +66,7 @@ func RmData(do *definitions.Do) (err error) {
 			srv := definitions.BlankServiceDefinition()
 			srv.Operations.SrvContainerName = util.ContainersName("data", do.Name, do.Operations.ContainerNumber)
 
-			if err = perform.DockerRemove(srv.Service, srv.Operations, false, do.Volumes); err != nil {
+			if err = perform.DockerRemove(srv.Service, srv.Operations, false, do.Volumes, false); err != nil {
 				log.Errorf("Error removing %s: %v", do.Name, err)
 				return err
 			}

--- a/keys/writers.go
+++ b/keys/writers.go
@@ -12,7 +12,6 @@ import (
 )
 
 func GenerateKey(do *definitions.Do) error {
-
 	do.Name = "keys"
 	do.Operations.ContainerNumber = 1
 

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -940,7 +940,7 @@ func TestRemoveWithoutData(t *testing.T) {
 		t.Fatalf("expecting 1 service container running (before removal), got %v", n)
 	}
 
-	if err := DockerRemove(srv.Service, srv.Operations, false, true); err != nil {
+	if err := DockerRemove(srv.Service, srv.Operations, false, true, false); err != nil {
 		t.Fatal("expected service container removed, got %v", err)
 	}
 
@@ -953,7 +953,7 @@ func TestRemoveWithoutData(t *testing.T) {
 		t.Fatalf("expecting 1 data container existing (before removal), got %v", n)
 	}
 
-	if err := DockerRemove(srv.Service, srv.Operations, false, true); err != nil {
+	if err := DockerRemove(srv.Service, srv.Operations, false, true, false); err != nil {
 		t.Fatal("expected service container removed, got %v", err)
 	}
 
@@ -995,7 +995,7 @@ func TestRemoveWithData(t *testing.T) {
 		t.Fatalf("expecting 1 data container existing (before removal), got %v", n)
 	}
 
-	if err := DockerRemove(srv.Service, srv.Operations, true, true); err != nil {
+	if err := DockerRemove(srv.Service, srv.Operations, true, true, false); err != nil {
 		t.Fatal("expected service container removed, got %v", err)
 	}
 
@@ -1029,7 +1029,7 @@ func TestRemoveServiceWithoutStopping(t *testing.T) {
 		t.Fatalf("expected service container created, got %v", err)
 	}
 
-	if err := DockerRemove(srv.Service, srv.Operations, true, true); err == nil {
+	if err := DockerRemove(srv.Service, srv.Operations, true, true, false); err == nil {
 		t.Fatal("expected service remove to fail, got nil")
 	}
 }

--- a/services/manage.go
+++ b/services/manage.go
@@ -231,7 +231,7 @@ func RmService(do *definitions.Do) error {
 			return err
 		}
 		if IsServiceExisting(service.Service, service.Operations) {
-			err = perform.DockerRemove(service.Service, service.Operations, do.RmD, do.Volumes)
+			err = perform.DockerRemove(service.Service, service.Operations, do.RmD, do.Volumes, do.Force)
 			if err != nil {
 				return err
 			}

--- a/services/operate.go
+++ b/services/operate.go
@@ -97,7 +97,7 @@ func KillService(do *definitions.Do) (err error) {
 		}
 
 		if do.Rm {
-			if err := perform.DockerRemove(service.Service, service.Operations, do.RmD, do.Volumes); err != nil {
+			if err := perform.DockerRemove(service.Service, service.Operations, do.RmD, do.Volumes, do.Force); err != nil {
 				return err
 			}
 		}

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -1,12 +1,13 @@
 package services
 
 import (
-	"fmt"
-	"io/ioutil"
+	"bytes"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -22,9 +23,7 @@ import (
 	logger "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
 )
 
-var srv *def.ServiceDefinition
-
-var servName string = "ipfs"
+const servName = "ipfs"
 
 func TestMain(m *testing.M) {
 	log.SetFormatter(logger.ErisFormatter{})
@@ -33,14 +32,13 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(testsInit())
+	tests.IfExit(tests.TestsInit("services"))
 
 	// Prevent CLI from starting IPFS.
 	os.Setenv("ERIS_SKIP_ENSURE", "true")
 
 	exitCode := m.Run()
 
-	log.Info("Tearing tests down")
 	if os.Getenv("TEST_IN_CIRCLE") != "true" {
 		tests.IfExit(tests.TestsTearDown())
 	}
@@ -54,148 +52,161 @@ func TestKnownServices(t *testing.T) {
 	do.Existing = false
 	do.Running = false
 	do.Quiet = true
-	tests.IfExit(list.ListAll(do, "services"))
-	k := strings.Split(do.Result, "\n") // tests output formatting.
-
-	if len(k) != len(ver.SERVICE_DEFINITIONS) {
-		tests.IfExit(fmt.Errorf("Did not find correct number of service definitions files, Expected %v, found %v.\n", len(ver.SERVICE_DEFINITIONS), len(k)))
+	if err := list.ListAll(do, "services"); err != nil {
+		t.Fatalf("expected list to succeed, got %v", err)
 	}
 
-	servDefs := make(map[string]bool)
+	// Join with ".toml" to avoid an extra for...range.
+	definitions := strings.Split(strings.Join(strings.Split(do.Result, "\n"), ".toml ")+".toml", " ")
 
-	for _, srv := range ver.SERVICE_DEFINITIONS {
-		servDef := strings.Split(srv, ".")
-		servDefs[servDef[0]] = true
+	sort.Strings(definitions)
+	sort.Strings(ver.SERVICE_DEFINITIONS)
+
+	if len(definitions) != len(ver.SERVICE_DEFINITIONS) {
+		t.Errorf("expected %v, got %v service definitions", len(ver.SERVICE_DEFINITIONS), len(definitions))
 	}
 
-	i := 0
-	for _, srvFile := range k {
-		if servDefs[srvFile] == true {
-			i++
-		}
-	}
-
-	if i != len(ver.SERVICE_DEFINITIONS) {
-		tests.IfExit(fmt.Errorf("Could not find all the expected service definition files.\n"))
+	if reflect.DeepEqual(definitions, ver.SERVICE_DEFINITIONS) != true {
+		t.Fatalf("did not find all expected service definitions %v, got %v", ver.SERVICE_DEFINITIONS, definitions)
 	}
 }
 
 func TestLoadServiceDefinition(t *testing.T) {
-	var e error
-	srv, e = loaders.LoadServiceDefinition(servName, true, 1)
-	if e != nil {
-		log.Error(e)
-		tests.IfExit(e)
+	// [pv]: this test belongs to the loaders package.
+	srv, err := loaders.LoadServiceDefinition(servName, true, 1)
+	if err != nil {
+		t.Fatalf("expected definition to load, got %v", err)
 	}
 
 	if srv.Name != servName {
-		log.WithFields(log.Fields{
-			"expected": servName,
-			"got":      srv.Name,
-		}).Error("Improper name on load")
+		t.Fatalf("improper name on load, expected %v, got %v", servName, srv.Name)
 	}
 
 	if srv.Service.Name != servName {
-		log.WithFields(log.Fields{
-			"expected": servName,
-			"got":      srv.Service.Name,
-		}).Error("Improper service name on load")
-
-		tests.IfExit(e)
+		t.Fatalf("improper service name on load, expected %v, got %v", servName, srv.Service.Name)
 	}
 
 	if !srv.Service.AutoData {
-		log.Error("data_container not properly read on load")
-		tests.IfExit(e)
+		t.Fatal("data_container not properly read on load")
 	}
 
 	if srv.Operations.DataContainerName == "" {
-		log.Error("data_container_name not set")
-		tests.IfExit(e)
+		t.Fatal("data_container_name not set")
 	}
 }
 
 func TestStartKillService(t *testing.T) {
-	testStartService(t, servName, false)
-	testKillService(t, servName, true)
+	defer tests.RemoveAllContainers()
+
+	start(t, servName, false)
+	if n := util.HowManyContainersRunning(servName, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(servName, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data container, got %v", n)
+	}
+
+	kill(t, servName, true)
+	if n := util.HowManyContainersRunning(servName, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(servName, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 data container, got %v", n)
+	}
+
 }
 
-func TestInspectService(t *testing.T) {
-	testStartService(t, servName, false)
-	defer testKillService(t, servName, true)
+func TestInspectService1(t *testing.T) {
+	defer tests.RemoveAllContainers()
+
+	start(t, servName, false)
 
 	do := def.NowDo()
 	do.Name = servName
 	do.Operations.Args = []string{"name"}
 	do.Operations.ContainerNumber = 1
-	log.WithFields(log.Fields{
-		"=>":   fmt.Sprintf("%s:%d", servName, do.Operations.ContainerNumber),
-		"args": do.Operations.Args,
-	}).Debug("Inspect service (from tests)")
 
-	e := InspectService(do)
-	if e != nil {
-		log.Infof("Error inspecting service: %v", e)
-		tests.IfExit(e)
+	if err := InspectService(do); err != nil {
+		t.Fatalf("expected service to be inspected, got %v", err)
 	}
+}
 
-	do = def.NowDo()
+func TestInspectService2(t *testing.T) {
+	defer tests.RemoveAllContainers()
+
+	start(t, servName, false)
+
+	do := def.NowDo()
 	do.Name = servName
 	do.Operations.Args = []string{"config.user"}
 	do.Operations.ContainerNumber = 1
-	log.WithFields(log.Fields{
-		"=>":   servName,
-		"args": do.Operations.Args,
-	}).Debug("Inspect service (from tests)")
-	e = InspectService(do)
-	if e != nil {
-		log.Infof("Error inspecting service: %v", e)
-		tests.IfExit(e)
+
+	if err := InspectService(do); err != nil {
+		t.Fatalf("expected service to be inspected, got %v", err)
 	}
 }
 
 func TestLogsService(t *testing.T) {
-	testStartService(t, servName, false)
-	defer testKillService(t, servName, true)
+	defer tests.RemoveAllContainers()
+
+	start(t, servName, false)
+
 	do := def.NowDo()
 	do.Name = servName
 	do.Follow = false
 	do.Tail = "5"
-	log.WithFields(log.Fields{
-		"=>":   servName,
-		"tail": do.Tail,
-	}).Debug("Inspect logs (from tests)")
-	e := LogsService(do)
-	if e != nil {
-		log.Error(e)
-		tests.IfExit(e)
+
+	if err := LogsService(do); err != nil {
+		t.Fatalf("expected service to return logs, got %v", err)
 	}
 }
 
 func TestExecService(t *testing.T) {
-	testStartService(t, servName, true)
-	defer testKillService(t, servName, true)
+	defer tests.RemoveAllContainers()
+
+	start(t, servName, true)
+
+	buf := new(bytes.Buffer)
+	config.GlobalConfig.Writer = buf
 
 	do := def.NowDo()
 	do.Name = servName
 	do.Operations.Interactive = false
 	do.Operations.Args = strings.Fields("ls -la /root/")
-	log.WithFields(log.Fields{
-		"=>":   servName,
-		"args": do.Operations.Args,
-	}).Debug("Executing service (from tests)")
-	e := ExecService(do)
-	if e != nil {
-		log.Error(e)
-		t.Fail()
+
+	if err := ExecService(do); err != nil {
+		t.Fatalf("expected to execute service, got %v", err)
+	}
+
+	if out := buf.String(); !strings.Contains(out, ".bashrc") {
+		t.Fatalf("expected a file in the exec output, got %v", out)
+	}
+}
+
+func TestExecServiceBadCommandLine(t *testing.T) {
+	defer tests.RemoveAllContainers()
+
+	start(t, servName, true)
+
+	buf := new(bytes.Buffer)
+	config.GlobalConfig.Writer = buf
+
+	do := def.NowDo()
+	do.Name = servName
+	do.Operations.Interactive = false
+	do.Operations.Args = strings.Fields("bad command line")
+
+	if err := ExecService(do); err == nil {
+		t.Fatal("expected executing service to fail")
 	}
 }
 
 func TestUpdateService(t *testing.T) {
-	testStartService(t, servName, false)
-	defer testKillService(t, servName, true)
+	defer tests.RemoveAllContainers()
+
+	start(t, servName, false)
 	if os.Getenv("TEST_IN_CIRCLE") == "true" {
-		log.Warn("Testing in Circle where we don't have rm privileges. Skipping test")
+		t.Log("Testing in Circle where we don't have rm privileges. Skipping test")
 		return
 	}
 
@@ -203,58 +214,86 @@ func TestUpdateService(t *testing.T) {
 	do.Name = servName
 	do.Pull = false
 	do.Timeout = 1
-	log.WithField("=>", servName).Debug("Update service (from tests)")
-	e := UpdateService(do)
-	if e != nil {
-		log.Error(e)
-		tests.IfExit(e)
+	if err := UpdateService(do); err != nil {
+		t.Fatalf("expected service to be updated, got %v", err)
 	}
 
-	testExistAndRun(t, servName, 1, true, true)
-	testNumbersExistAndRun(t, servName, 1, 1)
+	if n := util.HowManyContainersRunning(servName, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 running service container, got %v", n)
+	}
 }
 
-func TestKillRmService(t *testing.T) {
-	testStartService(t, servName, false)
+func TestKillService(t *testing.T) {
+	defer tests.RemoveAllContainers()
+
+	start(t, servName, false)
+	if n := util.HowManyContainersRunning(servName, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(servName, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data container, got %v", n)
+	}
+
 	do := def.NowDo()
 	do.Name = servName
 	do.Rm = false
 	do.RmD = false
 	do.Operations.Args = []string{servName}
-	log.WithField("=>", servName).Debug("Stopping service (from tests)")
-	if e := KillService(do); e != nil {
-		log.Error(e)
-		tests.IfExit(e)
+	if err := KillService(do); err != nil {
+		t.Fatalf("expected service to be stopped, got %v")
 	}
+	if n := util.HowManyContainersRunning(servName, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(servName, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 existing service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(servName, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data container, got %v", n)
+	}
+}
 
-	testExistAndRun(t, servName, 1, true, false)
-	testNumbersExistAndRun(t, servName, 1, 0)
+func TestRmService(t *testing.T) {
+	defer tests.RemoveAllContainers()
 
 	if os.Getenv("TEST_IN_CIRCLE") == "true" {
-		log.Warn("Testing in Circle where we don't have rm privileges. Skipping test")
-		return
+		t.Skip("Testing in Circle where we don't have rm privileges. Skipping test")
 	}
 
-	do = def.NowDo()
+	start(t, servName, false)
+	if n := util.HowManyContainersRunning(servName, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(servName, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data container, got %v", n)
+	}
+
+	do := def.NowDo()
 	do.Name = servName
 	do.Operations.Args = []string{servName}
+	do.Force = true
 	do.File = false
 	do.RmD = true
-	log.WithField("=>", servName).Debug("Removing service (from tests)")
-	if e := RmService(do); e != nil {
-		log.Error(e)
-		tests.IfExit(e)
+	if err := RmService(do); err != nil {
+		t.Fatalf("expected service to be removed, got %v", err)
 	}
 
-	testExistAndRun(t, servName, 1, false, false)
-	testNumbersExistAndRun(t, servName, 0, 0)
+	if n := util.HowManyContainersRunning(servName, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(servName, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 existing service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(servName, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 data container, got %v", n)
+	}
 }
 
 func TestExportService(t *testing.T) {
 	do := def.NowDo()
 	do.Name = "ipfs"
 
-	hash := "QmQ1LZYPNG4wSb9dojRicWCmM4gFLTPKFUhFnMTR3GKuA2"
+	const hash = "QmQ1LZYPNG4wSb9dojRicWCmM4gFLTPKFUhFnMTR3GKuA2"
 
 	// Fake IPFS server.
 	os.Setenv("ERIS_IPFS_HOST", "http://127.0.0.1")
@@ -268,23 +307,23 @@ func TestExportService(t *testing.T) {
 	defer ipfs.Close()
 
 	if err := ExportService(do); err != nil {
-		tests.IfExit(err)
+		t.Fatalf("expected service to be exported, got %v", err)
 	}
 
 	if expected := "/ipfs/"; ipfs.Path() != expected {
-		tests.IfExit(fmt.Errorf("Called the wrong endpoint; expected %v, got %v\n", expected, ipfs.Path()))
+		t.Fatalf("called the wrong endpoint; expected %v, got %v", expected, ipfs.Path())
 	}
 
 	if expected := "POST"; ipfs.Method() != expected {
-		tests.IfExit(fmt.Errorf("Used the wrong HTTP method; expected %v, got %v\n", expected, ipfs.Method()))
+		t.Fatalf("used the wrong HTTP method; expected %v, got %v", expected, ipfs.Method())
 	}
 
 	if content := tests.FileContents(FindServiceDefinitionFile(do.Name)); content != ipfs.Body() {
-		tests.IfExit(fmt.Errorf("Sent the bad file; expected %q, got %q\n", content, ipfs.Body()))
+		t.Fatalf("sent the bad file; expected %v, got %v", content, ipfs.Body())
 	}
 
 	if hash != do.Result {
-		tests.IfExit(fmt.Errorf("Hash mismatch; expected %q, got %q\n", hash, do.Result))
+		t.Fatalf("hash mismatch; expected %v, got %v", hash, do.Result)
 	}
 }
 
@@ -292,10 +331,6 @@ func TestImportService(t *testing.T) {
 	do := def.NowDo()
 	do.Name = "eth"
 	do.Hash = "QmQ1LZYPNG4wSb9dojRicWCmM4gFLTPKFUhFnMTR3GKuA2"
-	log.WithFields(log.Fields{
-		"=>":   do.Name,
-		"hash": do.Hash,
-	}).Debug("Importing service (from tests)")
 
 	content := `name = "ipfs"
 
@@ -313,164 +348,169 @@ image = "` + path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS) + `"`
 	defer ipfs.Close()
 
 	if err := ImportService(do); err != nil {
-		tests.IfExit(err)
+		t.Fatalf("expected service to be imported, got %v", err)
 	}
 
 	if expected := "/ipfs/" + do.Hash; ipfs.Path() != expected {
-		tests.IfExit(fmt.Errorf("Called the wrong endpoint; expected %v, got %v\n", expected, ipfs.Path()))
+		t.Fatalf("called the wrong endpoint; expected %v, got %v", expected, ipfs.Path())
 	}
 
 	if expected := "GET"; ipfs.Method() != expected {
-		tests.IfExit(fmt.Errorf("Used the wrong HTTP method; expected %v, got %v\n", expected, ipfs.Method()))
+		t.Fatalf("used the wrong HTTP method; expected %v, got %v\n", expected, ipfs.Method())
 	}
 
 	if imported := tests.FileContents(FindServiceDefinitionFile(do.Name)); imported != content {
-		tests.IfExit(fmt.Errorf("Returned unexpected content; expected: %q, got %q", content, imported))
+		t.Fatalf("returned unexpected content; expected: %v, got %v", content, imported)
 	}
 }
 
 func TestNewService(t *testing.T) {
+	defer tests.RemoveAllContainers()
+
 	do := def.NowDo()
 	servName := "keys"
 	do.Name = servName
 	do.Operations.Args = []string{path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)}
-
-	log.WithFields(log.Fields{
-		"=>":   do.Name,
-		"args": do.Operations.Args,
-	}).Debug("Creating a new service (from tests)")
-	e := NewService(do)
-	if e != nil {
-		log.Error(e)
-		tests.IfExit(e)
+	if err := NewService(do); err != nil {
+		t.Fatalf("expected a new service to be created, got %v", err)
 	}
 
 	do = def.NowDo()
 	do.Operations.Args = []string{servName}
-	log.WithFields(log.Fields{
-		"container number": do.Operations.ContainerNumber,
-		"args":             do.Operations.Args,
-	}).Debug("Starting service (from tests)")
-	e = StartService(do)
-	if e != nil {
-		log.Error(e)
-		tests.IfExit(e)
+	if err := StartService(do); err != nil {
+		t.Fatalf("expected service to be started, got %v", err)
 	}
 
-	testExistAndRun(t, servName, 1, true, true)
-	testNumbersExistAndRun(t, servName, 1, 1)
-	testKillService(t, servName, true)
-	testExistAndRun(t, servName, 1, false, false)
+	if n := util.HowManyContainersRunning(servName, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(servName, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data container, got %v", n)
+	}
+
+	kill(t, servName, true)
+	if n := util.HowManyContainersExisting(servName, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 service containers, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(servName, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 data container, got %v", n)
+	}
+
 }
 
 func TestRenameService(t *testing.T) {
-	testStartService(t, "keys", false)
-	testExistAndRun(t, "keys", 1, true, true)
-	testNumbersExistAndRun(t, "keys", 1, 1)
+	defer tests.RemoveAllContainers()
+
+	start(t, "keys", false)
+	if n := util.HowManyContainersRunning("keys", def.TypeService); n != 1 {
+		t.Fatalf("#1. expecting 1 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting("keys", def.TypeData); n != 1 {
+		t.Fatalf("#1. expecting 1 data container, got %v", n)
+	}
 
 	do := def.NowDo()
 	do.Name = "keys"
 	do.NewName = "syek"
-	log.WithFields(log.Fields{
-		"from": do.Name,
-		"to":   do.NewName,
-	}).Debug("Renaming service (from tests)")
-	if e := RenameService(do); e != nil {
-		tests.IfExit(fmt.Errorf("Error (tests fail) =>\t\t%v\n", e))
+	if err := RenameService(do); err != nil {
+		t.Fatalf("expected service to be renamed, got %v", err)
 	}
 
-	testExistAndRun(t, "syek", 1, true, true)
-	testExistAndRun(t, "keys", 1, false, false)
-	testNumbersExistAndRun(t, "syek", 1, 1)
-	testNumbersExistAndRun(t, "keys", 0, 0)
+	if n := util.HowManyContainersRunning("keys", def.TypeService); n != 0 {
+		t.Fatalf("#2. expecting 0 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting("keys", def.TypeData); n != 0 {
+		t.Fatalf("#2. expecting 0 data container, got %v", n)
+	}
+	if n := util.HowManyContainersRunning("syek", def.TypeService); n != 1 {
+		t.Fatalf("#3. expecting 1 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting("syek", def.TypeData); n != 1 {
+		t.Fatalf("#3. expecting 1 data container, got %v", n)
+	}
 
 	do = def.NowDo()
 	do.Name = "syek"
 	do.NewName = "keys"
-	log.WithFields(log.Fields{
-		"from": do.Name,
-		"to":   do.NewName,
-	}).Debug("Renaming service (from tests)")
-	if e := RenameService(do); e != nil {
-		log.Errorf("Error (tests fail): %v", e)
-		tests.IfExit(e)
+	if err := RenameService(do); err != nil {
+		t.Fatalf("expected service to be renamed back, got %v", err)
 	}
 
-	testExistAndRun(t, "keys", 1, true, true)
-	testExistAndRun(t, "syek", 1, false, false)
-	testNumbersExistAndRun(t, "keys", 1, 1)
-	testNumbersExistAndRun(t, "syek", 0, 0)
-
-	testKillService(t, "keys", true)
-	testExistAndRun(t, "keys", 1, false, false)
+	if n := util.HowManyContainersRunning("syek", def.TypeService); n != 0 {
+		t.Fatalf("#4. expecting 0 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting("syek", def.TypeData); n != 0 {
+		t.Fatalf("#4. expecting 0 data container, got %v", n)
+	}
+	if n := util.HowManyContainersRunning("keys", def.TypeService); n != 1 {
+		t.Fatalf("#5. expecting 1 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting("keys", def.TypeData); n != 1 {
+		t.Fatalf("#5. expecting 1 data container, got %v", n)
+	}
 }
 
 func TestCatService(t *testing.T) {
 	do := def.NowDo()
-	do.Name = "ipfs"
+	do.Name = servName
 	if err := CatService(do); err != nil {
-		tests.IfExit(err)
+		t.Fatalf("expected cat to succeed, got %v", err)
 	}
-	//if init worked properly...?
-	read, err := ioutil.ReadFile(filepath.Join(config.GlobalConfig.ErisDir, "services", "ipfs.toml"))
-	if err != nil {
-		tests.IfExit(err)
-	}
-	if do.Result != string(read) {
-		tests.IfExit(fmt.Errorf("Cat Service on ipfs does not match Default. Got %s \n Expected %s", do.Result, string(read)))
+
+	if out := tests.FileContents(filepath.Join(config.GlobalConfig.ErisDir, "services", "ipfs.toml")); out != do.Result {
+		t.Fatalf("expected local config to be returned %v, got %v", out, do.Result)
 	}
 }
 
 func TestStartKillServiceWithDependencies(t *testing.T) {
+	defer tests.RemoveAllContainers()
+
 	do := def.NowDo()
 	do.Operations.Args = []string{"do_not_use"}
-	log.WithFields(log.Fields{
-		"service":    servName,
-		"dependency": "keys",
-	}).Debug("Starting service with dependency (from tests)")
-	if e := StartService(do); e != nil {
-		log.Infof("Error starting service: %v", e)
-		tests.IfExit(e)
+	if err := StartService(do); err != nil {
+		t.Fatalf("expected service to start, got %v", err)
 	}
 
-	defer func() {
-		testKillService(t, "do_not_use", true)
+	if n := util.HowManyContainersRunning(servName, def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(servName, def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 data container, got %v", n)
+	}
+	if n := util.HowManyContainersRunning("keys", def.TypeService); n != 1 {
+		t.Fatalf("expecting 1 running dependent service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting("keys", def.TypeData); n != 1 {
+		t.Fatalf("expecting 1 dependent data container, got %v", n)
+	}
 
-		testExistAndRun(t, servName, 1, false, false)
-		testNumbersExistAndRun(t, servName, 0, 0)
+	kill(t, "do_not_use", true)
 
-		testKillService(t, "keys", true)
-	}()
-
-	testExistAndRun(t, servName, 1, true, true)
-	testExistAndRun(t, "keys", 1, true, true)
-
-	testNumbersExistAndRun(t, "keys", 1, 1)
-	testNumbersExistAndRun(t, servName, 1, 1)
+	if n := util.HowManyContainersRunning(servName, def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 running service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting(servName, def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 data container, got %v", n)
+	}
+	if n := util.HowManyContainersRunning("keys", def.TypeService); n != 0 {
+		t.Fatalf("expecting 0 running dependent service container, got %v", n)
+	}
+	if n := util.HowManyContainersExisting("keys", def.TypeData); n != 0 {
+		t.Fatalf("expecting 0 dependent data container, got %v", n)
+	}
 }
 
-//----------------------------------------------------------------------
-// test utils!
-
-func testStartService(t *testing.T, serviceName string, publishAll bool) {
+func start(t *testing.T, serviceName string, publishAll bool) {
 	do := def.NowDo()
 	do.Operations.Args = []string{serviceName}
-	do.Operations.ContainerNumber = 1 //util.AutoMagic(0, "service", true)
+	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = publishAll
-	log.WithField("=>", fmt.Sprintf("%s:%d", serviceName, do.Operations.ContainerNumber)).Debug("Starting service (from tests)")
-	e := StartService(do)
-	if e != nil {
-		log.Infof("Error starting service: %v", e)
-		tests.IfExit(e)
+	if err := StartService(do); err != nil {
+		t.Fatalf("expected service to start, got %v", err)
 	}
-
-	testExistAndRun(t, serviceName, 1, true, true)
-	testNumbersExistAndRun(t, serviceName, 1, 1)
 }
 
-func testKillService(t *testing.T, serviceName string, wipe bool) {
-	log.WithField("=>", servName).Debug("Stopping service (from tests)")
-
+func kill(t *testing.T, serviceName string, wipe bool) {
 	do := def.NowDo()
 	do.Name = serviceName
 	do.Operations.Args = []string{serviceName}
@@ -478,48 +518,7 @@ func testKillService(t *testing.T, serviceName string, wipe bool) {
 		do.Rm = true
 		do.RmD = true
 	}
-	e := KillService(do)
-	if e != nil {
-		log.Error(e)
-		tests.IfExit(e)
+	if err := KillService(do); err != nil {
+		t.Fatalf("expected service to be stopped, got %v", err)
 	}
-	testExistAndRun(t, serviceName, 1, !wipe, false)
-	testNumbersExistAndRun(t, serviceName, 0, 0)
-}
-
-func testExistAndRun(t *testing.T, servName string, containerNumber int, toExist, toRun bool) {
-	if err := tests.TestExistAndRun(servName, "services", containerNumber, toExist, toRun); err != nil {
-		tests.IfExit(nil)
-	}
-}
-
-func testNumbersExistAndRun(t *testing.T, servName string, containerExist, containerRun int) {
-	log.WithFields(log.Fields{
-		"=>":        servName,
-		"existing#": containerExist,
-		"running#":  containerRun,
-	}).Info("Checking number of containers for")
-
-	log.WithField("=>", servName).Debug("Checking existing containers for")
-	exist := util.HowManyContainersExisting(servName, "service")
-
-	log.WithField("=>", servName).Debug("Checking running containers for")
-	run := util.HowManyContainersRunning(servName, "service")
-
-	if exist != containerExist {
-		tests.IfExit(fmt.Errorf("Wrong number of containers existing for service (%s). Expected (%d). Got (%d).\n", servName, containerExist, exist))
-	}
-
-	if run != containerRun {
-		tests.IfExit(fmt.Errorf("Wrong number of containers running for service (%s). Expected (%d). Got (%d).\n", servName, containerRun, run))
-	}
-
-	log.Info("All good")
-}
-
-func testsInit() error {
-	if err := tests.TestsInit("services"); err != nil {
-		return err
-	}
-	return nil
 }

--- a/tests/machines/setup.go
+++ b/tests/machines/setup.go
@@ -72,19 +72,15 @@ func main() {
 	for _, m := range machines {
 		go startMachine(m, failOut)
 	}
-
-	go func(failOut chan bool) {
-		if _, ok := <-failOut; ok {
-			for _, m := range machines {
-				fmt.Println(m)
-			}
-			os.Exit(1)
-		}
-	}(failOut)
 	wg.Wait()
+	close(failOut)
 
 	for _, m := range machines {
 		fmt.Println(m)
+	}
+
+	if _, ok := <-failOut; ok {
+		os.Exit(1)
 	}
 }
 
@@ -227,7 +223,7 @@ func setUpMachine(machine string) error {
 	cmd.Stderr = &out
 	err = cmd.Run()
 	if err != nil {
-		return fmt.Errorf("Cannot scp into the machine (%s): (%s)\n\n%s", machine, err, out.String())
+		return fmt.Errorf("Cannot scp (%s) into the machine (%s): (%s)\n\n%s", file, machine, err, out.String())
 	}
 
 	file = filepath.Base(file)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -171,12 +171,18 @@ sort_machines() {
     then
       go run setup.go 1>/dev/null
       MACHINES=( $(docker-machine ls -q) )
+      setup_result=$?
     else
       MACHINES=( $(go run setup.go) )
+      setup_result=$?
     fi
   fi
   kill $ticker
   wait $ticker 2>/dev/null
+  if [ "$setup_result" -ne 0 ]
+  then
+    return 1
+  fi
   cd $repo
   echo
   echo "Machines sorted."


### PR DESCRIPTION
This PR contains: 

* `chains` and `services` refactoring to allow any individual test to run with the `go test -run <test>` command; making the tests smaller and removing the dependencies on the `perform` package (closes #399).

* `chains cat` now merges the behavior with the `chains plop` command; the latter is available as an alias to `cat` command (closes #452):

  ```
  $ eris chains cat simplechain
  -- local config file
  
  $ eris chains cat simplechain genesis
  -- genesis.json file from chain container
  
  $ eris chains cat simplechain config
  -- config.toml file from chain container 

  $ eris chains plop simplechain
  -- local config file
  ...
  ``` 
* `-f`, `--force` flag for `eris chains rm` and `eris services rm` commands (closes #453):

  ```
  $ eris chains new simplechain
  $ eris chains rm simplechain
  API error (409): Conflict, You cannot remove a running container. Stop the container before attempting removal or use -f
  $ eris chains rm -f simplechain

  $ eris chains rm --help
  ...
  Flags:
  -x, --data    remove data containers after stopping
      --file    remove chain definition file as well as chain container
  -f, --force   kill the container instantly without waiting to exit
  -o, --vol     remove volumes (default true)
  ...

  $ eris services start tinydns
  $ eris services rm tinydns
  API error (409): Conflict, You cannot remove a running container. Stop the container before attempting removal or use -f
  $ eris services rm -f tinydns
  ```
* small fixes for `tests/test_osx_win.sh` and `tests/machines/setup.go` to properly handle some errors (occasionally *green* thing).