### PR TITLE
Docker client version calculation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ language: go
 install:
 - eval "$(gimme 1.5)"
 - brew update
-- brew install docker docker-machine jq
-- echo "change the below when `docker-machine --version | cut -d ' ' -f 3` is at 0.5.4"
-- sudo bash -c "curl -sSL https://github.com/docker/machine/releases/download/v0.5.4/docker-machine_darwin-amd64 >/usr/local/bin/docker-machine"
+- brew install jq
+- sudo bash -c "curl -sSL https://get.docker.com/builds/Darwin/x86_64/docker-1.9.1 >/usr/local/bin/docker"
+- sudo chmod +x /usr/local/bin/docker
+- sudo bash -c "curl -sSL https://github.com/docker/machine/releases/download/v0.6.0/docker-machine-darwin-x86_64 >/usr/local/bin/docker-machine"
 - sudo chmod +x /usr/local/bin/docker-machine
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,9 @@ build_script:
 
     choco install -yr cygwin > nul
 
-    choco install -yr docker jq
+    choco install -yr jq
+    
+    choco install -yr docker         -version 1.9.1
 
     choco install -yr docker-machine -version 0.4.1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ build_script:
 
     choco install -yr jq
     
-    choco install -yr docker         -version 1.9.1
+    choco install -yr docker -version 1.9.1
 
     choco install -yr docker-machine -version 0.4.1
 

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
     EPM_BRANCH: develop
     MINDY_BRANCH: master
     DOCKER_VERSION: 1.9.1
-    DOCKER_MACHINE_VERSION: 0.5.4
+    DOCKER_MACHINE_VERSION: 0.6.0
   post:
     - git config --global user.email "billings@erisindustries.com"
     - git config --global user.name "Billings the Bot"
@@ -17,7 +17,7 @@ machine:
 dependencies:
   override:
     - sudo curl -sSL -o /usr/bin/docker http://s3-external-1.amazonaws.com/circle-downloads/docker-$DOCKER_VERSION-circleci; sudo chmod 0755 /usr/bin/docker
-    - sudo curl -sSL -o /usr/bin/docker-machine https://github.com/docker/machine/releases/download/v$DOCKER_MACHINE_VERSION/docker-machine_linux-amd64; sudo chmod 0755 /usr/bin/docker-machine
+    - sudo curl -sSL -o /usr/bin/docker-machine https://github.com/docker/machine/releases/download/v$DOCKER_MACHINE_VERSION/docker-machine-linux-x86_64; sudo chmod 0755 /usr/bin/docker-machine
     - sudo service docker start
     - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
     - git clone https://github.com/eris-ltd/integration-tests $INTEGRATION_TESTS_PATH

--- a/cmd/eris.go
+++ b/cmd/eris.go
@@ -52,7 +52,7 @@ Complete documentation is available at https://docs.erisindustries.com
 			IfExit(fmt.Errorf("There was an error connecting to your docker daemon.\nCome back after you have resolved and the marmots will be happy to service your blockchain management needs\n\n%v", err))
 		}
 		marmot := "Come back after you have upgraded and the marmots will be happy to service your blockchain management needs"
-		if dockerVersion < dVerMin {
+		if !util.CompareVersions(dockerVersion, dVerMin) {
 			IfExit(fmt.Errorf("Eris requires docker version >= %v\nThe marmots have detected docker version: %v\n%s", dVerMin, dockerVersion, marmot))
 		}
 	},

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -60,7 +60,7 @@ func LoadChainDefinition(chainName string, newCont bool, cNum ...int) (*definiti
 	}
 
 	// Docker 1.6 (which eris doesn't support) had different linking mechanism.
-	if ver, _ := util.DockerClientVersion(); ver >= version.DVER_MIN {
+	if util.IsMinimalDockerClientVersion() {
 		if chain.Dependencies != nil {
 			addDependencyVolumesAndLinks(chain.Dependencies, chain.Service, chain.Operations)
 		}

--- a/loaders/services.go
+++ b/loaders/services.go
@@ -8,7 +8,6 @@ import (
 	"github.com/eris-ltd/eris-cli/config"
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
-	"github.com/eris-ltd/eris-cli/version"
 
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
@@ -50,7 +49,7 @@ func LoadServiceDefinition(servName string, newCont bool, cNum ...int) (*definit
 	}
 
 	// Docker 1.6 (which eris doesn't support) had different linking mechanism.
-	if ver, _ := util.DockerClientVersion(); ver >= version.DVER_MIN {
+	if util.IsMinimalDockerClientVersion() {
 		addDependencyVolumesAndLinks(srv.Dependencies, srv.Service, srv.Operations)
 	}
 

--- a/tests/machines/setup.go
+++ b/tests/machines/setup.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -212,22 +211,16 @@ func makeMachine(machine string) error {
 }
 
 func setUpMachine(machine string) error {
-	dir, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	file := filepath.Join(dir, script)
-	cmd := exec.Command("docker-machine", "scp", file, fmt.Sprintf("%s:", machine))
+	cmd := exec.Command("docker-machine", "scp", script, fmt.Sprintf("%s:", machine))
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
-	err = cmd.Run()
+	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("Cannot scp (%s) into the machine (%s): (%s)\n\n%s", file, machine, err, out.String())
+		return fmt.Errorf("Cannot scp (%s) into the machine (%s): (%s)\n\n%s", script, machine, err, out.String())
 	}
 
-	file = filepath.Base(file)
-	cmd = exec.Command("docker-machine", "ssh", machine, fmt.Sprintf("sudo $HOME/%s", file))
+	cmd = exec.Command("docker-machine", "ssh", machine, fmt.Sprintf("sudo $HOME/%s", script))
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	err = cmd.Run()

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -171,8 +171,8 @@ sort_machines() {
     if [ "$ci" = true ]
     then
       go run setup.go 1>/dev/null
-      MACHINES=( $(docker-machine ls -q) )
       setup_result=$?
+      MACHINES=( $(docker-machine ls -q) )
     else
       MACHINES=( $(go run setup.go) )
       setup_result=$?
@@ -259,7 +259,7 @@ setup_tests() {
     build_eris $BRANCH &
     build_result=$!
   else
-    echo "Not building in Circle. Skipping docker build."
+    echo "Skipping docker build."
     build_result=$!
   fi
   sort_machines $1

--- a/tests/test_stack.sh
+++ b/tests/test_stack.sh
@@ -55,9 +55,9 @@ epm_repo=https://github.com/eris-ltd/$epm.git
 epm_dir=$repo/../$epm
 epm_branch=${EPM_BRANCH:=master}
 
-mindy_repo=https://github.com/eris-ltd/mindy.git
-mindy_dir=$repo/../mindy
-mindy_branch=${MINDY_BRANCY:=master}
+# mindy_repo=https://github.com/eris-ltd/mindy.git
+# mindy_dir=$repo/../mindy
+# mindy_branch=${MINDY_BRANCY:=master}
 
 # ----------------------------------------------------------------------------
 # Utility functions
@@ -119,25 +119,25 @@ cd $start
 # ----------------------------------------------------------------------------
 # Get Mindy
 
-echo
-if [ -d "$mindy_dir" ]; then
-  echo "mindy present on host; not cloning:$mindy_branch"
-  cd $mindy_dir
-else
-  echo -e "Cloning mindy to:\t\t$mindy_dir"
-  git clone $mindy_repo $mindy_dir &>/dev/null
-  cd $mindy_dir 1>/dev/null
-  git checkout origin/$mindy_branch &>/dev/null
-fi
-echo
+# echo
+# if [ -d "$mindy_dir" ]; then
+#  echo "mindy present on host; not cloning:$mindy_branch"
+#  cd $mindy_dir
+# else
+#  echo -e "Cloning mindy to:\t\t$mindy_dir"
+#  git clone $mindy_repo $mindy_dir &>/dev/null
+#  cd $mindy_dir 1>/dev/null
+#  git checkout origin/$mindy_branch &>/dev/null
+# fi
+# echo
 
 # ----------------------------------------------------------------------------
 # Run Mindy tests
 
-tests/test.sh
-test_exit=$?
-check_and_exit
-cd $start
+# tests/test.sh
+# test_exit=$?
+# check_and_exit
+# cd $start
 
 # ----------------------------------------------------------------------------
 # Cleanup

--- a/util/docker_client_version_test.go
+++ b/util/docker_client_version_test.go
@@ -1,0 +1,52 @@
+package util
+
+import "testing"
+
+var Tests = []struct {
+	v1   string
+	v2   string
+	want bool
+}{
+	{"1.0", "1.0", true},
+	{"1.1", "1.0", true},
+	{"1.0", "1.1", false},
+	{"1.6", "1.7", false},
+	{"10.7", "10.8", false},
+	{"1.8", "1.8", true},
+	{"10.9", "10.8", true},
+	{"1.10", "1.9", true},
+	{"2.0", "1.8", true},
+	{"1.8", "2.0", false},
+	{"10.8", "20.0", false},
+
+	{"1.0.0", "1.0", true},
+	{"1.0", "1.0.0", true},
+	{"1.0.1", "1.0", true},
+	{"1.0", "1.0.1", true},
+	{"0.4.1", "0.3.9", true},
+	{"0.3.9", "0.4.1", false},
+
+	// Unacceptable values.
+	{"0", "0", false},
+	{"0", "", false},
+	{"", "", false},
+	{"9", "0", false},
+	{"0", "9", false},
+	{"1", "2", false},
+	{"3", "4", false},
+	{"b.1", "d.0", false},
+	{"ge.ge.", ".ge.ge", false},
+	{"1.0", "b.0", false},
+	{"9.0", "+.-", false},
+	{"3.4", "3.*", false},
+	{"4.##", "1.1", false},
+	{"40.#*", "1.1", false},
+}
+
+func TestCompareVersions(t *testing.T) {
+	for _, test := range Tests {
+		if actual := CompareVersions(test.v1, test.v2); actual != test.want {
+			t.Errorf("expected %v comparing %v with %v", test.want, test.v1, test.v2)
+		}
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 const VERSION = "0.11.2"
-const DVER_MIN = 1.8
+const DVER_MIN = "1.8"


### PR DESCRIPTION
* Fixing the calculation of minimal Docker version required. Closes #493.

* Docker Machine version bump to 0.6.0 for Linux and OSX.