### PR TITLE
Show console for interactive `chains make`

### DIFF
--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -546,6 +546,11 @@ func MakeChain(cmd *cobra.Command, args []string) {
 		cmd.Help()
 		IfExit(fmt.Errorf("\nThe --account-types and --chain-type flags are incompatible with the --known flag. Please use only one of these."))
 	}
+	if !do.Known {
+		config.GlobalConfig.InteractiveWriter = os.Stdout
+		config.GlobalConfig.InteractiveErrorWriter = os.Stderr
+	}
+
 	IfExit(chns.MakeChain(do))
 }
 


### PR DESCRIPTION
Show the interactive console for `chains make` command when it's not run with the  `--known` flag. Fixes #510.