### PR TITLE
Remote logging to Bugsnag

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -133,6 +133,31 @@
 		{
 			"ImportPath": "github.com/docker/go-units",
 			"Rev": "f49f7ea428ed3f42a846917e4a4856fcd165f6bc"
+		},
+		{
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Comment": "v0.8.7-53-g446d1c1",
+			"Rev": "446d1c146faa8ed3f4218f056fcd165f6bcfda81"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/system",
+			"Rev": "f7e02b752bcf687aab0120e6b06ab38779371ec0"
+		},
+		{
+			"ImportPath": "github.com/Azure/go-ansiterm",
+			"Rev": "99cbe6fbe8d074bcf687aab012c3c0d5297f614a"
+		},
+		{
+			"ImportPath": "github.com/bugsnag/bugsnag-go",
+			"Rev": "ab8487ef058074bc60171a6436fabcfac287a001"
+		},
+		{
+			"ImportPath": "github.com/bugsnag/panicwrap",
+			"Rev": "40098faa760171a6436fab017853031334b3c8b9"
+		},
+		{
+			"ImportPath": "github.com/bugsnag/osext",
+			"Rev": "cd2b779537780171a6436fbc39950e081b0187bb"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/LICENSE
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/README.md
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/README.md
@@ -1,0 +1,9 @@
+# go-ansiterm
+
+This is a cross platform Ansi Terminal Emulation library.  It reads a stream of Ansi characters and produces the appropriate function calls.  The results of the function calls are platform dependent.
+
+For example the parser might receive "ESC, [, A" as a stream of three characters.  This is the code for Cursor Up (http://www.vt100.net/docs/vt510-rm/CUU).  The parser then calls the cursor up function (CUU()) on an event handler.  The event handler determines what platform specific work must be done to cause the cursor to move up one position.
+
+The parser (parser.go) is a partial implementation of this state machine (http://vt100.net/emu/vt500_parser.png).  There are also two event handler implementations, one for tests (test_event_handler.go) to validate that the expected events are being produced and called, the other is a Windows implementation (winterm/win_event_handler.go).
+
+See parser_test.go for examples exercising the state machine and generating appropriate function calls.

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/constants.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/constants.go
@@ -1,0 +1,188 @@
+package ansiterm
+
+const LogEnv = "DEBUG_TERMINAL"
+
+// ANSI constants
+// References:
+// -- http://www.ecma-international.org/publications/standards/Ecma-048.htm
+// -- http://man7.org/linux/man-pages/man4/console_codes.4.html
+// -- http://manpages.ubuntu.com/manpages/intrepid/man4/console_codes.4.html
+// -- http://en.wikipedia.org/wiki/ANSI_escape_code
+// -- http://vt100.net/emu/dec_ansi_parser
+// -- http://vt100.net/emu/vt500_parser.svg
+// -- http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+// -- http://www.inwap.com/pdp10/ansicode.txt
+const (
+	// ECMA-48 Set Graphics Rendition
+	// Note:
+	// -- Constants leading with an underscore (e.g., _ANSI_xxx) are unsupported or reserved
+	// -- Fonts could possibly be supported via SetCurrentConsoleFontEx
+	// -- Windows does not expose the per-window cursor (i.e., caret) blink times
+	ANSI_SGR_RESET              = 0
+	ANSI_SGR_BOLD               = 1
+	ANSI_SGR_DIM                = 2
+	_ANSI_SGR_ITALIC            = 3
+	ANSI_SGR_UNDERLINE          = 4
+	_ANSI_SGR_BLINKSLOW         = 5
+	_ANSI_SGR_BLINKFAST         = 6
+	ANSI_SGR_REVERSE            = 7
+	_ANSI_SGR_INVISIBLE         = 8
+	_ANSI_SGR_LINETHROUGH       = 9
+	_ANSI_SGR_FONT_00           = 10
+	_ANSI_SGR_FONT_01           = 11
+	_ANSI_SGR_FONT_02           = 12
+	_ANSI_SGR_FONT_03           = 13
+	_ANSI_SGR_FONT_04           = 14
+	_ANSI_SGR_FONT_05           = 15
+	_ANSI_SGR_FONT_06           = 16
+	_ANSI_SGR_FONT_07           = 17
+	_ANSI_SGR_FONT_08           = 18
+	_ANSI_SGR_FONT_09           = 19
+	_ANSI_SGR_FONT_10           = 20
+	_ANSI_SGR_DOUBLEUNDERLINE   = 21
+	ANSI_SGR_BOLD_DIM_OFF       = 22
+	_ANSI_SGR_ITALIC_OFF        = 23
+	ANSI_SGR_UNDERLINE_OFF      = 24
+	_ANSI_SGR_BLINK_OFF         = 25
+	_ANSI_SGR_RESERVED_00       = 26
+	ANSI_SGR_REVERSE_OFF        = 27
+	_ANSI_SGR_INVISIBLE_OFF     = 28
+	_ANSI_SGR_LINETHROUGH_OFF   = 29
+	ANSI_SGR_FOREGROUND_BLACK   = 30
+	ANSI_SGR_FOREGROUND_RED     = 31
+	ANSI_SGR_FOREGROUND_GREEN   = 32
+	ANSI_SGR_FOREGROUND_YELLOW  = 33
+	ANSI_SGR_FOREGROUND_BLUE    = 34
+	ANSI_SGR_FOREGROUND_MAGENTA = 35
+	ANSI_SGR_FOREGROUND_CYAN    = 36
+	ANSI_SGR_FOREGROUND_WHITE   = 37
+	_ANSI_SGR_RESERVED_01       = 38
+	ANSI_SGR_FOREGROUND_DEFAULT = 39
+	ANSI_SGR_BACKGROUND_BLACK   = 40
+	ANSI_SGR_BACKGROUND_RED     = 41
+	ANSI_SGR_BACKGROUND_GREEN   = 42
+	ANSI_SGR_BACKGROUND_YELLOW  = 43
+	ANSI_SGR_BACKGROUND_BLUE    = 44
+	ANSI_SGR_BACKGROUND_MAGENTA = 45
+	ANSI_SGR_BACKGROUND_CYAN    = 46
+	ANSI_SGR_BACKGROUND_WHITE   = 47
+	_ANSI_SGR_RESERVED_02       = 48
+	ANSI_SGR_BACKGROUND_DEFAULT = 49
+	// 50 - 65: Unsupported
+
+	ANSI_MAX_CMD_LENGTH = 4096
+
+	MAX_INPUT_EVENTS = 128
+	DEFAULT_WIDTH    = 80
+	DEFAULT_HEIGHT   = 24
+
+	ANSI_BEL              = 0x07
+	ANSI_BACKSPACE        = 0x08
+	ANSI_TAB              = 0x09
+	ANSI_LINE_FEED        = 0x0A
+	ANSI_VERTICAL_TAB     = 0x0B
+	ANSI_FORM_FEED        = 0x0C
+	ANSI_CARRIAGE_RETURN  = 0x0D
+	ANSI_ESCAPE_PRIMARY   = 0x1B
+	ANSI_ESCAPE_SECONDARY = 0x5B
+	ANSI_OSC_STRING_ENTRY = 0x5D
+	ANSI_COMMAND_FIRST    = 0x40
+	ANSI_COMMAND_LAST     = 0x7E
+	DCS_ENTRY             = 0x90
+	CSI_ENTRY             = 0x9B
+	OSC_STRING            = 0x9D
+	ANSI_PARAMETER_SEP    = ";"
+	ANSI_CMD_G0           = '('
+	ANSI_CMD_G1           = ')'
+	ANSI_CMD_G2           = '*'
+	ANSI_CMD_G3           = '+'
+	ANSI_CMD_DECPNM       = '>'
+	ANSI_CMD_DECPAM       = '='
+	ANSI_CMD_OSC          = ']'
+	ANSI_CMD_STR_TERM     = '\\'
+
+	KEY_CONTROL_PARAM_2 = ";2"
+	KEY_CONTROL_PARAM_3 = ";3"
+	KEY_CONTROL_PARAM_4 = ";4"
+	KEY_CONTROL_PARAM_5 = ";5"
+	KEY_CONTROL_PARAM_6 = ";6"
+	KEY_CONTROL_PARAM_7 = ";7"
+	KEY_CONTROL_PARAM_8 = ";8"
+	KEY_ESC_CSI         = "\x1B["
+	KEY_ESC_N           = "\x1BN"
+	KEY_ESC_O           = "\x1BO"
+
+	FILL_CHARACTER = ' '
+)
+
+func getByteRange(start byte, end byte) []byte {
+	bytes := make([]byte, 0, 32)
+	for i := start; i <= end; i++ {
+		bytes = append(bytes, byte(i))
+	}
+
+	return bytes
+}
+
+var ToGroundBytes = getToGroundBytes()
+var Executors = getExecuteBytes()
+
+// SPACE		  20+A0 hex  Always and everywhere a blank space
+// Intermediate	  20-2F hex   !"#$%&'()*+,-./
+var Intermeds = getByteRange(0x20, 0x2F)
+
+// Parameters	  30-3F hex  0123456789:;<=>?
+// CSI Parameters 30-39, 3B hex 0123456789;
+var CsiParams = getByteRange(0x30, 0x3F)
+
+var CsiCollectables = append(getByteRange(0x30, 0x39), getByteRange(0x3B, 0x3F)...)
+
+// Uppercase	  40-5F hex  @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
+var UpperCase = getByteRange(0x40, 0x5F)
+
+// Lowercase	  60-7E hex  `abcdefghijlkmnopqrstuvwxyz{|}~
+var LowerCase = getByteRange(0x60, 0x7E)
+
+// Alphabetics	  40-7E hex  (all of upper and lower case)
+var Alphabetics = append(UpperCase, LowerCase...)
+
+var Printables = getByteRange(0x20, 0x7F)
+
+var EscapeIntermediateToGroundBytes = getByteRange(0x30, 0x7E)
+var EscapeToGroundBytes = getEscapeToGroundBytes()
+
+// See http://www.vt100.net/emu/vt500_parser.png for description of the complex
+// byte ranges below
+
+func getEscapeToGroundBytes() []byte {
+	escapeToGroundBytes := getByteRange(0x30, 0x4F)
+	escapeToGroundBytes = append(escapeToGroundBytes, getByteRange(0x51, 0x57)...)
+	escapeToGroundBytes = append(escapeToGroundBytes, 0x59)
+	escapeToGroundBytes = append(escapeToGroundBytes, 0x5A)
+	escapeToGroundBytes = append(escapeToGroundBytes, 0x5C)
+	escapeToGroundBytes = append(escapeToGroundBytes, getByteRange(0x60, 0x7E)...)
+	return escapeToGroundBytes
+}
+
+func getExecuteBytes() []byte {
+	executeBytes := getByteRange(0x00, 0x17)
+	executeBytes = append(executeBytes, 0x19)
+	executeBytes = append(executeBytes, getByteRange(0x1C, 0x1F)...)
+	return executeBytes
+}
+
+func getToGroundBytes() []byte {
+	groundBytes := []byte{0x18}
+	groundBytes = append(groundBytes, 0x1A)
+	groundBytes = append(groundBytes, getByteRange(0x80, 0x8F)...)
+	groundBytes = append(groundBytes, getByteRange(0x91, 0x97)...)
+	groundBytes = append(groundBytes, 0x99)
+	groundBytes = append(groundBytes, 0x9A)
+	groundBytes = append(groundBytes, 0x9C)
+	return groundBytes
+}
+
+// Delete		     7F hex  Always and everywhere ignored
+// C1 Control	  80-9F hex  32 additional control characters
+// G1 Displayable A1-FE hex  94 additional displayable characters
+// Special		  A0+FF hex  Same as SPACE and DELETE

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/context.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/context.go
@@ -1,0 +1,7 @@
+package ansiterm
+
+type AnsiContext struct {
+	currentChar byte
+	paramBuffer []byte
+	interBuffer []byte
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/csi_entry_state.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/csi_entry_state.go
@@ -1,0 +1,49 @@
+package ansiterm
+
+type CsiEntryState struct {
+	BaseState
+}
+
+func (csiState CsiEntryState) Handle(b byte) (s State, e error) {
+	logger.Infof("CsiEntry::Handle %#x", b)
+
+	nextState, err := csiState.BaseState.Handle(b)
+	if nextState != nil || err != nil {
+		return nextState, err
+	}
+
+	switch {
+	case sliceContains(Alphabetics, b):
+		return csiState.parser.Ground, nil
+	case sliceContains(CsiCollectables, b):
+		return csiState.parser.CsiParam, nil
+	case sliceContains(Executors, b):
+		return csiState, csiState.parser.execute()
+	}
+
+	return csiState, nil
+}
+
+func (csiState CsiEntryState) Transition(s State) error {
+	logger.Infof("CsiEntry::Transition %s --> %s", csiState.Name(), s.Name())
+	csiState.BaseState.Transition(s)
+
+	switch s {
+	case csiState.parser.Ground:
+		return csiState.parser.csiDispatch()
+	case csiState.parser.CsiParam:
+		switch {
+		case sliceContains(CsiParams, csiState.parser.context.currentChar):
+			csiState.parser.collectParam()
+		case sliceContains(Intermeds, csiState.parser.context.currentChar):
+			csiState.parser.collectInter()
+		}
+	}
+
+	return nil
+}
+
+func (csiState CsiEntryState) Enter() error {
+	csiState.parser.clear()
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/csi_param_state.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/csi_param_state.go
@@ -1,0 +1,38 @@
+package ansiterm
+
+type CsiParamState struct {
+	BaseState
+}
+
+func (csiState CsiParamState) Handle(b byte) (s State, e error) {
+	logger.Infof("CsiParam::Handle %#x", b)
+
+	nextState, err := csiState.BaseState.Handle(b)
+	if nextState != nil || err != nil {
+		return nextState, err
+	}
+
+	switch {
+	case sliceContains(Alphabetics, b):
+		return csiState.parser.Ground, nil
+	case sliceContains(CsiCollectables, b):
+		csiState.parser.collectParam()
+		return csiState, nil
+	case sliceContains(Executors, b):
+		return csiState, csiState.parser.execute()
+	}
+
+	return csiState, nil
+}
+
+func (csiState CsiParamState) Transition(s State) error {
+	logger.Infof("CsiParam::Transition %s --> %s", csiState.Name(), s.Name())
+	csiState.BaseState.Transition(s)
+
+	switch s {
+	case csiState.parser.Ground:
+		return csiState.parser.csiDispatch()
+	}
+
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/escape_intermediate_state.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/escape_intermediate_state.go
@@ -1,0 +1,36 @@
+package ansiterm
+
+type EscapeIntermediateState struct {
+	BaseState
+}
+
+func (escState EscapeIntermediateState) Handle(b byte) (s State, e error) {
+	logger.Infof("EscapeIntermediateState::Handle %#x", b)
+	nextState, err := escState.BaseState.Handle(b)
+	if nextState != nil || err != nil {
+		return nextState, err
+	}
+
+	switch {
+	case sliceContains(Intermeds, b):
+		return escState, escState.parser.collectInter()
+	case sliceContains(Executors, b):
+		return escState, escState.parser.execute()
+	case sliceContains(EscapeIntermediateToGroundBytes, b):
+		return escState.parser.Ground, nil
+	}
+
+	return escState, nil
+}
+
+func (escState EscapeIntermediateState) Transition(s State) error {
+	logger.Infof("EscapeIntermediateState::Transition %s --> %s", escState.Name(), s.Name())
+	escState.BaseState.Transition(s)
+
+	switch s {
+	case escState.parser.Ground:
+		return escState.parser.escDispatch()
+	}
+
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/escape_state.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/escape_state.go
@@ -1,0 +1,47 @@
+package ansiterm
+
+type EscapeState struct {
+	BaseState
+}
+
+func (escState EscapeState) Handle(b byte) (s State, e error) {
+	logger.Infof("EscapeState::Handle %#x", b)
+	nextState, err := escState.BaseState.Handle(b)
+	if nextState != nil || err != nil {
+		return nextState, err
+	}
+
+	switch {
+	case b == ANSI_ESCAPE_SECONDARY:
+		return escState.parser.CsiEntry, nil
+	case b == ANSI_OSC_STRING_ENTRY:
+		return escState.parser.OscString, nil
+	case sliceContains(Executors, b):
+		return escState, escState.parser.execute()
+	case sliceContains(EscapeToGroundBytes, b):
+		return escState.parser.Ground, nil
+	case sliceContains(Intermeds, b):
+		return escState.parser.EscapeIntermediate, nil
+	}
+
+	return escState, nil
+}
+
+func (escState EscapeState) Transition(s State) error {
+	logger.Infof("Escape::Transition %s --> %s", escState.Name(), s.Name())
+	escState.BaseState.Transition(s)
+
+	switch s {
+	case escState.parser.Ground:
+		return escState.parser.escDispatch()
+	case escState.parser.EscapeIntermediate:
+		return escState.parser.collectInter()
+	}
+
+	return nil
+}
+
+func (escState EscapeState) Enter() error {
+	escState.parser.clear()
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/event_handler.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/event_handler.go
@@ -1,0 +1,90 @@
+package ansiterm
+
+type AnsiEventHandler interface {
+	// Print
+	Print(b byte) error
+
+	// Execute C0 commands
+	Execute(b byte) error
+
+	// CUrsor Up
+	CUU(int) error
+
+	// CUrsor Down
+	CUD(int) error
+
+	// CUrsor Forward
+	CUF(int) error
+
+	// CUrsor Backward
+	CUB(int) error
+
+	// Cursor to Next Line
+	CNL(int) error
+
+	// Cursor to Previous Line
+	CPL(int) error
+
+	// Cursor Horizontal position Absolute
+	CHA(int) error
+
+	// Vertical line Position Absolute
+	VPA(int) error
+
+	// CUrsor Position
+	CUP(int, int) error
+
+	// Horizontal and Vertical Position (depends on PUM)
+	HVP(int, int) error
+
+	// Text Cursor Enable Mode
+	DECTCEM(bool) error
+
+	// Origin Mode
+	DECOM(bool) error
+
+	// 132 Column Mode
+	DECCOLM(bool) error
+
+	// Erase in Display
+	ED(int) error
+
+	// Erase in Line
+	EL(int) error
+
+	// Insert Line
+	IL(int) error
+
+	// Delete Line
+	DL(int) error
+
+	// Insert Character
+	ICH(int) error
+
+	// Delete Character
+	DCH(int) error
+
+	// Set Graphics Rendition
+	SGR([]int) error
+
+	// Pan Down
+	SU(int) error
+
+	// Pan Up
+	SD(int) error
+
+	// Device Attributes
+	DA([]string) error
+
+	// Set Top and Bottom Margins
+	DECSTBM(int, int) error
+
+	// Index
+	IND() error
+
+	// Reverse Index
+	RI() error
+
+	// Flush updates from previous commands
+	Flush() error
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/ground_state.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/ground_state.go
@@ -1,0 +1,24 @@
+package ansiterm
+
+type GroundState struct {
+	BaseState
+}
+
+func (gs GroundState) Handle(b byte) (s State, e error) {
+	gs.parser.context.currentChar = b
+
+	nextState, err := gs.BaseState.Handle(b)
+	if nextState != nil || err != nil {
+		return nextState, err
+	}
+
+	switch {
+	case sliceContains(Printables, b):
+		return gs, gs.parser.print()
+
+	case sliceContains(Executors, b):
+		return gs, gs.parser.execute()
+	}
+
+	return gs, nil
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/osc_string_state.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/osc_string_state.go
@@ -1,0 +1,31 @@
+package ansiterm
+
+type OscStringState struct {
+	BaseState
+}
+
+func (oscState OscStringState) Handle(b byte) (s State, e error) {
+	logger.Infof("OscString::Handle %#x", b)
+	nextState, err := oscState.BaseState.Handle(b)
+	if nextState != nil || err != nil {
+		return nextState, err
+	}
+
+	switch {
+	case isOscStringTerminator(b):
+		return oscState.parser.Ground, nil
+	}
+
+	return oscState, nil
+}
+
+// See below for OSC string terminators for linux
+// http://man7.org/linux/man-pages/man4/console_codes.4.html
+func isOscStringTerminator(b byte) bool {
+
+	if b == ANSI_BEL || b == 0x5C {
+		return true
+	}
+
+	return false
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/parser.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/parser.go
@@ -1,0 +1,137 @@
+package ansiterm
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+)
+
+var logger *logrus.Logger
+
+type AnsiParser struct {
+	currState          State
+	eventHandler       AnsiEventHandler
+	context            *AnsiContext
+	CsiEntry           State
+	CsiParam           State
+	DcsEntry           State
+	Escape             State
+	EscapeIntermediate State
+	Error              State
+	Ground             State
+	OscString          State
+	stateMap           []State
+}
+
+func CreateParser(initialState string, evtHandler AnsiEventHandler) *AnsiParser {
+	logFile := ioutil.Discard
+
+	if isDebugEnv := os.Getenv(LogEnv); isDebugEnv == "1" {
+		logFile, _ = os.Create("ansiParser.log")
+	}
+
+	logger = &logrus.Logger{
+		Out:       logFile,
+		Formatter: new(logrus.TextFormatter),
+		Level:     logrus.InfoLevel,
+	}
+
+	parser := &AnsiParser{
+		eventHandler: evtHandler,
+		context:      &AnsiContext{},
+	}
+
+	parser.CsiEntry = CsiEntryState{BaseState{name: "CsiEntry", parser: parser}}
+	parser.CsiParam = CsiParamState{BaseState{name: "CsiParam", parser: parser}}
+	parser.DcsEntry = DcsEntryState{BaseState{name: "DcsEntry", parser: parser}}
+	parser.Escape = EscapeState{BaseState{name: "Escape", parser: parser}}
+	parser.EscapeIntermediate = EscapeIntermediateState{BaseState{name: "EscapeIntermediate", parser: parser}}
+	parser.Error = ErrorState{BaseState{name: "Error", parser: parser}}
+	parser.Ground = GroundState{BaseState{name: "Ground", parser: parser}}
+	parser.OscString = OscStringState{BaseState{name: "OscString", parser: parser}}
+
+	parser.stateMap = []State{
+		parser.CsiEntry,
+		parser.CsiParam,
+		parser.DcsEntry,
+		parser.Escape,
+		parser.EscapeIntermediate,
+		parser.Error,
+		parser.Ground,
+		parser.OscString,
+	}
+
+	parser.currState = getState(initialState, parser.stateMap)
+
+	logger.Infof("CreateParser: parser %p", parser)
+	return parser
+}
+
+func getState(name string, states []State) State {
+	for _, el := range states {
+		if el.Name() == name {
+			return el
+		}
+	}
+
+	return nil
+}
+
+func (ap *AnsiParser) Parse(bytes []byte) (int, error) {
+	for i, b := range bytes {
+		if err := ap.handle(b); err != nil {
+			return i, err
+		}
+	}
+
+	return len(bytes), ap.eventHandler.Flush()
+}
+
+func (ap *AnsiParser) handle(b byte) error {
+	ap.context.currentChar = b
+	newState, err := ap.currState.Handle(b)
+	if err != nil {
+		return err
+	}
+
+	if newState == nil {
+		logger.Warning("newState is nil")
+		return errors.New(fmt.Sprintf("New state of 'nil' is invalid."))
+	}
+
+	if newState != ap.currState {
+		if err := ap.changeState(newState); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (ap *AnsiParser) changeState(newState State) error {
+	logger.Infof("ChangeState %s --> %s", ap.currState.Name(), newState.Name())
+
+	// Exit old state
+	if err := ap.currState.Exit(); err != nil {
+		logger.Infof("Exit state '%s' failed with : '%v'", ap.currState.Name(), err)
+		return err
+	}
+
+	// Perform transition action
+	if err := ap.currState.Transition(newState); err != nil {
+		logger.Infof("Transition from '%s' to '%s' failed with: '%v'", ap.currState.Name(), newState.Name, err)
+		return err
+	}
+
+	// Enter new state
+	if err := newState.Enter(); err != nil {
+		logger.Infof("Enter state '%s' failed with: '%v'", newState.Name(), err)
+		return err
+	}
+
+	ap.currState = newState
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/parser_action_helpers.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/parser_action_helpers.go
@@ -1,0 +1,103 @@
+package ansiterm
+
+import (
+	"strconv"
+)
+
+func parseParams(bytes []byte) ([]string, error) {
+	paramBuff := make([]byte, 0, 0)
+	params := []string{}
+
+	for _, v := range bytes {
+		if v == ';' {
+			if len(paramBuff) > 0 {
+				// Completed parameter, append it to the list
+				s := string(paramBuff)
+				params = append(params, s)
+				paramBuff = make([]byte, 0, 0)
+			}
+		} else {
+			paramBuff = append(paramBuff, v)
+		}
+	}
+
+	// Last parameter may not be terminated with ';'
+	if len(paramBuff) > 0 {
+		s := string(paramBuff)
+		params = append(params, s)
+	}
+
+	logger.Infof("Parsed params: %v with length: %d", params, len(params))
+	return params, nil
+}
+
+func parseCmd(context AnsiContext) (string, error) {
+	return string(context.currentChar), nil
+}
+
+func getInt(params []string, dflt int) int {
+	i := getInts(params, 1, dflt)[0]
+	logger.Infof("getInt: %v", i)
+	return i
+}
+
+func getInts(params []string, minCount int, dflt int) []int {
+	ints := []int{}
+
+	for _, v := range params {
+		i, _ := strconv.Atoi(v)
+		// Zero is mapped to the default value in VT100.
+		if i == 0 {
+			i = dflt
+		}
+		ints = append(ints, i)
+	}
+
+	if len(ints) < minCount {
+		remaining := minCount - len(ints)
+		for i := 0; i < remaining; i++ {
+			ints = append(ints, dflt)
+		}
+	}
+
+	logger.Infof("getInts: %v", ints)
+
+	return ints
+}
+
+func (ap *AnsiParser) modeDispatch(param string, set bool) error {
+	switch param {
+	case "?3":
+		return ap.eventHandler.DECCOLM(set)
+	case "?6":
+		return ap.eventHandler.DECOM(set)
+	case "?25":
+		return ap.eventHandler.DECTCEM(set)
+	}
+	return nil
+}
+
+func (ap *AnsiParser) hDispatch(params []string) error {
+	if len(params) == 1 {
+		return ap.modeDispatch(params[0], true)
+	}
+
+	return nil
+}
+
+func (ap *AnsiParser) lDispatch(params []string) error {
+	if len(params) == 1 {
+		return ap.modeDispatch(params[0], false)
+	}
+
+	return nil
+}
+
+func getEraseParam(params []string) int {
+	param := getInt(params, 0)
+	if param < 0 || 3 < param {
+		param = 0
+	}
+
+	return param
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/parser_actions.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/parser_actions.go
@@ -1,0 +1,122 @@
+package ansiterm
+
+import (
+	"fmt"
+)
+
+func (ap *AnsiParser) collectParam() error {
+	currChar := ap.context.currentChar
+	logger.Infof("collectParam %#x", currChar)
+	ap.context.paramBuffer = append(ap.context.paramBuffer, currChar)
+	return nil
+}
+
+func (ap *AnsiParser) collectInter() error {
+	currChar := ap.context.currentChar
+	logger.Infof("collectInter %#x", currChar)
+	ap.context.paramBuffer = append(ap.context.interBuffer, currChar)
+	return nil
+}
+
+func (ap *AnsiParser) escDispatch() error {
+	cmd, _ := parseCmd(*ap.context)
+	intermeds := ap.context.interBuffer
+	logger.Infof("escDispatch currentChar: %#x", ap.context.currentChar)
+	logger.Infof("escDispatch: %v(%v)", cmd, intermeds)
+
+	switch cmd {
+	case "D": // IND
+		return ap.eventHandler.IND()
+	case "E": // NEL, equivalent to CRLF
+		err := ap.eventHandler.Execute(ANSI_CARRIAGE_RETURN)
+		if err == nil {
+			err = ap.eventHandler.Execute(ANSI_LINE_FEED)
+		}
+		return err
+	case "M": // RI
+		return ap.eventHandler.RI()
+	}
+
+	return nil
+}
+
+func (ap *AnsiParser) csiDispatch() error {
+	cmd, _ := parseCmd(*ap.context)
+	params, _ := parseParams(ap.context.paramBuffer)
+
+	logger.Infof("csiDispatch: %v(%v)", cmd, params)
+
+	switch cmd {
+	case "@":
+		return ap.eventHandler.ICH(getInt(params, 1))
+	case "A":
+		return ap.eventHandler.CUU(getInt(params, 1))
+	case "B":
+		return ap.eventHandler.CUD(getInt(params, 1))
+	case "C":
+		return ap.eventHandler.CUF(getInt(params, 1))
+	case "D":
+		return ap.eventHandler.CUB(getInt(params, 1))
+	case "E":
+		return ap.eventHandler.CNL(getInt(params, 1))
+	case "F":
+		return ap.eventHandler.CPL(getInt(params, 1))
+	case "G":
+		return ap.eventHandler.CHA(getInt(params, 1))
+	case "H":
+		ints := getInts(params, 2, 1)
+		x, y := ints[0], ints[1]
+		return ap.eventHandler.CUP(x, y)
+	case "J":
+		param := getEraseParam(params)
+		return ap.eventHandler.ED(param)
+	case "K":
+		param := getEraseParam(params)
+		return ap.eventHandler.EL(param)
+	case "L":
+		return ap.eventHandler.IL(getInt(params, 1))
+	case "M":
+		return ap.eventHandler.DL(getInt(params, 1))
+	case "P":
+		return ap.eventHandler.DCH(getInt(params, 1))
+	case "S":
+		return ap.eventHandler.SU(getInt(params, 1))
+	case "T":
+		return ap.eventHandler.SD(getInt(params, 1))
+	case "c":
+		return ap.eventHandler.DA(params)
+	case "d":
+		return ap.eventHandler.VPA(getInt(params, 1))
+	case "f":
+		ints := getInts(params, 2, 1)
+		x, y := ints[0], ints[1]
+		return ap.eventHandler.HVP(x, y)
+	case "h":
+		return ap.hDispatch(params)
+	case "l":
+		return ap.lDispatch(params)
+	case "m":
+		return ap.eventHandler.SGR(getInts(params, 1, 0))
+	case "r":
+		ints := getInts(params, 2, 1)
+		top, bottom := ints[0], ints[1]
+		return ap.eventHandler.DECSTBM(top, bottom)
+	default:
+		logger.Errorf(fmt.Sprintf("Unsupported CSI command: '%s', with full context:  %v", cmd, ap.context))
+		return nil
+	}
+
+}
+
+func (ap *AnsiParser) print() error {
+	return ap.eventHandler.Print(ap.context.currentChar)
+}
+
+func (ap *AnsiParser) clear() error {
+	ap.context = &AnsiContext{}
+	return nil
+}
+
+func (ap *AnsiParser) execute() error {
+	return ap.eventHandler.Execute(ap.context.currentChar)
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/parser_test.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/parser_test.go
@@ -1,0 +1,141 @@
+package ansiterm
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestStateTransitions(t *testing.T) {
+	stateTransitionHelper(t, "CsiEntry", "Ground", Alphabetics)
+	stateTransitionHelper(t, "CsiEntry", "CsiParam", CsiCollectables)
+	stateTransitionHelper(t, "Escape", "CsiEntry", []byte{ANSI_ESCAPE_SECONDARY})
+	stateTransitionHelper(t, "Escape", "OscString", []byte{0x5D})
+	stateTransitionHelper(t, "Escape", "Ground", EscapeToGroundBytes)
+	stateTransitionHelper(t, "Escape", "EscapeIntermediate", Intermeds)
+	stateTransitionHelper(t, "EscapeIntermediate", "EscapeIntermediate", Intermeds)
+	stateTransitionHelper(t, "EscapeIntermediate", "EscapeIntermediate", Executors)
+	stateTransitionHelper(t, "EscapeIntermediate", "Ground", EscapeIntermediateToGroundBytes)
+	stateTransitionHelper(t, "OscString", "Ground", []byte{ANSI_BEL})
+	stateTransitionHelper(t, "OscString", "Ground", []byte{0x5C})
+	stateTransitionHelper(t, "Ground", "Ground", Executors)
+}
+
+func TestAnyToX(t *testing.T) {
+	anyToXHelper(t, []byte{ANSI_ESCAPE_PRIMARY}, "Escape")
+	anyToXHelper(t, []byte{DCS_ENTRY}, "DcsEntry")
+	anyToXHelper(t, []byte{OSC_STRING}, "OscString")
+	anyToXHelper(t, []byte{CSI_ENTRY}, "CsiEntry")
+	anyToXHelper(t, ToGroundBytes, "Ground")
+}
+
+func TestCollectCsiParams(t *testing.T) {
+	parser, _ := createTestParser("CsiEntry")
+	parser.Parse(CsiCollectables)
+
+	buffer := parser.context.paramBuffer
+	bufferCount := len(buffer)
+
+	if bufferCount != len(CsiCollectables) {
+		t.Errorf("Buffer:    %v", buffer)
+		t.Errorf("CsiParams: %v", CsiCollectables)
+		t.Errorf("Buffer count failure: %d != %d", bufferCount, len(CsiParams))
+		return
+	}
+
+	for i, v := range CsiCollectables {
+		if v != buffer[i] {
+			t.Errorf("Buffer:    %v", buffer)
+			t.Errorf("CsiParams: %v", CsiParams)
+			t.Errorf("Mismatch at buffer[%d] = %d", i, buffer[i])
+		}
+	}
+}
+
+func TestParseParams(t *testing.T) {
+	parseParamsHelper(t, []byte{}, []string{})
+	parseParamsHelper(t, []byte{';'}, []string{})
+	parseParamsHelper(t, []byte{';', ';'}, []string{})
+	parseParamsHelper(t, []byte{'7'}, []string{"7"})
+	parseParamsHelper(t, []byte{'7', ';'}, []string{"7"})
+	parseParamsHelper(t, []byte{'7', ';', ';'}, []string{"7"})
+	parseParamsHelper(t, []byte{'7', ';', ';', '8'}, []string{"7", "8"})
+	parseParamsHelper(t, []byte{'7', ';', '8', ';'}, []string{"7", "8"})
+	parseParamsHelper(t, []byte{'7', ';', ';', '8', ';', ';'}, []string{"7", "8"})
+	parseParamsHelper(t, []byte{'7', '8'}, []string{"78"})
+	parseParamsHelper(t, []byte{'7', '8', ';'}, []string{"78"})
+	parseParamsHelper(t, []byte{'7', '8', ';', '9', '0'}, []string{"78", "90"})
+	parseParamsHelper(t, []byte{'7', '8', ';', ';', '9', '0'}, []string{"78", "90"})
+	parseParamsHelper(t, []byte{'7', '8', ';', '9', '0', ';'}, []string{"78", "90"})
+	parseParamsHelper(t, []byte{'7', '8', ';', '9', '0', ';', ';'}, []string{"78", "90"})
+}
+
+func TestCursor(t *testing.T) {
+	cursorSingleParamHelper(t, 'A', "CUU")
+	cursorSingleParamHelper(t, 'B', "CUD")
+	cursorSingleParamHelper(t, 'C', "CUF")
+	cursorSingleParamHelper(t, 'D', "CUB")
+	cursorSingleParamHelper(t, 'E', "CNL")
+	cursorSingleParamHelper(t, 'F', "CPL")
+	cursorSingleParamHelper(t, 'G', "CHA")
+	cursorTwoParamHelper(t, 'H', "CUP")
+	cursorTwoParamHelper(t, 'f', "HVP")
+	funcCallParamHelper(t, []byte{'?', '2', '5', 'h'}, "CsiEntry", "Ground", []string{"DECTCEM([true])"})
+	funcCallParamHelper(t, []byte{'?', '2', '5', 'l'}, "CsiEntry", "Ground", []string{"DECTCEM([false])"})
+}
+
+func TestErase(t *testing.T) {
+	// Erase in Display
+	eraseHelper(t, 'J', "ED")
+
+	// Erase in Line
+	eraseHelper(t, 'K', "EL")
+}
+
+func TestSelectGraphicRendition(t *testing.T) {
+	funcCallParamHelper(t, []byte{'m'}, "CsiEntry", "Ground", []string{"SGR([0])"})
+	funcCallParamHelper(t, []byte{'0', 'm'}, "CsiEntry", "Ground", []string{"SGR([0])"})
+	funcCallParamHelper(t, []byte{'0', ';', '1', 'm'}, "CsiEntry", "Ground", []string{"SGR([0 1])"})
+	funcCallParamHelper(t, []byte{'0', ';', '1', ';', '2', 'm'}, "CsiEntry", "Ground", []string{"SGR([0 1 2])"})
+}
+
+func TestScroll(t *testing.T) {
+	scrollHelper(t, 'S', "SU")
+	scrollHelper(t, 'T', "SD")
+}
+
+func TestPrint(t *testing.T) {
+	parser, evtHandler := createTestParser("Ground")
+	parser.Parse(Printables)
+	validateState(t, parser.currState, "Ground")
+
+	for i, v := range Printables {
+		expectedCall := fmt.Sprintf("Print([%s])", string(v))
+		actualCall := evtHandler.FunctionCalls[i]
+		if actualCall != expectedCall {
+			t.Errorf("Actual != Expected: %v != %v at %d", actualCall, expectedCall, i)
+		}
+	}
+}
+
+func TestClear(t *testing.T) {
+	p, _ := createTestParser("Ground")
+	fillContext(p.context)
+	p.clear()
+	validateEmptyContext(t, p.context)
+}
+
+func TestClearOnStateChange(t *testing.T) {
+	clearOnStateChangeHelper(t, "Ground", "Escape", []byte{ANSI_ESCAPE_PRIMARY})
+	clearOnStateChangeHelper(t, "Ground", "CsiEntry", []byte{CSI_ENTRY})
+}
+
+func TestC0(t *testing.T) {
+	expectedCall := "Execute([" + string(ANSI_LINE_FEED) + "])"
+	c0Helper(t, []byte{ANSI_LINE_FEED}, "Ground", []string{expectedCall})
+	expectedCall = "Execute([" + string(ANSI_CARRIAGE_RETURN) + "])"
+	c0Helper(t, []byte{ANSI_CARRIAGE_RETURN}, "Ground", []string{expectedCall})
+}
+
+func TestEscDispatch(t *testing.T) {
+	funcCallParamHelper(t, []byte{'M'}, "Escape", "Ground", []string{"RI([])"})
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/parser_test_helpers.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/parser_test_helpers.go
@@ -1,0 +1,114 @@
+package ansiterm
+
+import (
+	"fmt"
+	"testing"
+)
+
+func getStateNames() []string {
+	parser, _ := createTestParser("Ground")
+
+	stateNames := []string{}
+	for _, state := range parser.stateMap {
+		stateNames = append(stateNames, state.Name())
+	}
+
+	return stateNames
+}
+
+func stateTransitionHelper(t *testing.T, start string, end string, bytes []byte) {
+	for _, b := range bytes {
+		bytes := []byte{byte(b)}
+		parser, _ := createTestParser(start)
+		parser.Parse(bytes)
+		validateState(t, parser.currState, end)
+	}
+}
+
+func anyToXHelper(t *testing.T, bytes []byte, expectedState string) {
+	for _, s := range getStateNames() {
+		stateTransitionHelper(t, s, expectedState, bytes)
+	}
+}
+
+func funcCallParamHelper(t *testing.T, bytes []byte, start string, expected string, expectedCalls []string) {
+	parser, evtHandler := createTestParser(start)
+	parser.Parse(bytes)
+	validateState(t, parser.currState, expected)
+	validateFuncCalls(t, evtHandler.FunctionCalls, expectedCalls)
+}
+
+func parseParamsHelper(t *testing.T, bytes []byte, expectedParams []string) {
+	params, err := parseParams(bytes)
+
+	if err != nil {
+		t.Errorf("Parameter parse error: %v", err)
+		return
+	}
+
+	if len(params) != len(expectedParams) {
+		t.Errorf("Parsed   parameters: %v", params)
+		t.Errorf("Expected parameters: %v", expectedParams)
+		t.Errorf("Parameter length failure: %d != %d", len(params), len(expectedParams))
+		return
+	}
+
+	for i, v := range expectedParams {
+		if v != params[i] {
+			t.Errorf("Parsed   parameters: %v", params)
+			t.Errorf("Expected parameters: %v", expectedParams)
+			t.Errorf("Parameter parse failure: %s != %s at position %d", v, params[i], i)
+		}
+	}
+}
+
+func cursorSingleParamHelper(t *testing.T, command byte, funcName string) {
+	funcCallParamHelper(t, []byte{command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
+	funcCallParamHelper(t, []byte{'0', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
+	funcCallParamHelper(t, []byte{'2', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([2])", funcName)})
+	funcCallParamHelper(t, []byte{'2', '3', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([23])", funcName)})
+	funcCallParamHelper(t, []byte{'2', ';', '3', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([2])", funcName)})
+	funcCallParamHelper(t, []byte{'2', ';', '3', ';', '4', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([2])", funcName)})
+}
+
+func cursorTwoParamHelper(t *testing.T, command byte, funcName string) {
+	funcCallParamHelper(t, []byte{command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1 1])", funcName)})
+	funcCallParamHelper(t, []byte{'0', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1 1])", funcName)})
+	funcCallParamHelper(t, []byte{'2', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([2 1])", funcName)})
+	funcCallParamHelper(t, []byte{'2', '3', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([23 1])", funcName)})
+	funcCallParamHelper(t, []byte{'2', ';', '3', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([2 3])", funcName)})
+	funcCallParamHelper(t, []byte{'2', ';', '3', ';', '4', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([2 3])", funcName)})
+}
+
+func eraseHelper(t *testing.T, command byte, funcName string) {
+	funcCallParamHelper(t, []byte{command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([0])", funcName)})
+	funcCallParamHelper(t, []byte{'0', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([0])", funcName)})
+	funcCallParamHelper(t, []byte{'1', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
+	funcCallParamHelper(t, []byte{'2', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([2])", funcName)})
+	funcCallParamHelper(t, []byte{'3', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([3])", funcName)})
+	funcCallParamHelper(t, []byte{'4', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([0])", funcName)})
+	funcCallParamHelper(t, []byte{'1', ';', '2', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
+}
+
+func scrollHelper(t *testing.T, command byte, funcName string) {
+	funcCallParamHelper(t, []byte{command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
+	funcCallParamHelper(t, []byte{'0', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
+	funcCallParamHelper(t, []byte{'1', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
+	funcCallParamHelper(t, []byte{'5', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([5])", funcName)})
+	funcCallParamHelper(t, []byte{'4', ';', '6', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([4])", funcName)})
+}
+
+func clearOnStateChangeHelper(t *testing.T, start string, end string, bytes []byte) {
+	p, _ := createTestParser(start)
+	fillContext(p.context)
+	p.Parse(bytes)
+	validateState(t, p.currState, end)
+	validateEmptyContext(t, p.context)
+}
+
+func c0Helper(t *testing.T, bytes []byte, expectedState string, expectedCalls []string) {
+	parser, evtHandler := createTestParser("Ground")
+	parser.Parse(bytes)
+	validateState(t, parser.currState, expectedState)
+	validateFuncCalls(t, evtHandler.FunctionCalls, expectedCalls)
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/parser_test_utilities.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/parser_test_utilities.go
@@ -1,0 +1,66 @@
+package ansiterm
+
+import (
+	"testing"
+)
+
+func createTestParser(s string) (*AnsiParser, *TestAnsiEventHandler) {
+	evtHandler := CreateTestAnsiEventHandler()
+	parser := CreateParser(s, evtHandler)
+
+	return parser, evtHandler
+}
+
+func validateState(t *testing.T, actualState State, expectedStateName string) {
+	actualName := "Nil"
+
+	if actualState != nil {
+		actualName = actualState.Name()
+	}
+
+	if actualName != expectedStateName {
+		t.Errorf("Invalid State: '%s' != '%s'", actualName, expectedStateName)
+	}
+}
+
+func validateFuncCalls(t *testing.T, actualCalls []string, expectedCalls []string) {
+	actualCount := len(actualCalls)
+	expectedCount := len(expectedCalls)
+
+	if actualCount != expectedCount {
+		t.Errorf("Actual   calls: %v", actualCalls)
+		t.Errorf("Expected calls: %v", expectedCalls)
+		t.Errorf("Call count error: %d != %d", actualCount, expectedCount)
+		return
+	}
+
+	for i, v := range actualCalls {
+		if v != expectedCalls[i] {
+			t.Errorf("Actual   calls: %v", actualCalls)
+			t.Errorf("Expected calls: %v", expectedCalls)
+			t.Errorf("Mismatched calls: %s != %s with lengths %d and %d", v, expectedCalls[i], len(v), len(expectedCalls[i]))
+		}
+	}
+}
+
+func fillContext(context *AnsiContext) {
+	context.currentChar = 'A'
+	context.paramBuffer = []byte{'C', 'D', 'E'}
+	context.interBuffer = []byte{'F', 'G', 'H'}
+}
+
+func validateEmptyContext(t *testing.T, context *AnsiContext) {
+	var expectedCurrChar byte = 0x0
+	if context.currentChar != expectedCurrChar {
+		t.Errorf("Currentchar mismatch '%#x' != '%#x'", context.currentChar, expectedCurrChar)
+	}
+
+	if len(context.paramBuffer) != 0 {
+		t.Errorf("Non-empty parameter buffer: %v", context.paramBuffer)
+	}
+
+	if len(context.paramBuffer) != 0 {
+		t.Errorf("Non-empty intermediate buffer: %v", context.interBuffer)
+	}
+
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/states.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/states.go
@@ -1,0 +1,71 @@
+package ansiterm
+
+type StateId int
+
+type State interface {
+	Enter() error
+	Exit() error
+	Handle(byte) (State, error)
+	Name() string
+	Transition(State) error
+}
+
+type BaseState struct {
+	name   string
+	parser *AnsiParser
+}
+
+func (base BaseState) Enter() error {
+	return nil
+}
+
+func (base BaseState) Exit() error {
+	return nil
+}
+
+func (base BaseState) Handle(b byte) (s State, e error) {
+
+	switch {
+	case b == CSI_ENTRY:
+		return base.parser.CsiEntry, nil
+	case b == DCS_ENTRY:
+		return base.parser.DcsEntry, nil
+	case b == ANSI_ESCAPE_PRIMARY:
+		return base.parser.Escape, nil
+	case b == OSC_STRING:
+		return base.parser.OscString, nil
+	case sliceContains(ToGroundBytes, b):
+		return base.parser.Ground, nil
+	}
+
+	return nil, nil
+}
+
+func (base BaseState) Name() string {
+	return base.name
+}
+
+func (base BaseState) Transition(s State) error {
+	if s == base.parser.Ground {
+		execBytes := []byte{0x18}
+		execBytes = append(execBytes, 0x1A)
+		execBytes = append(execBytes, getByteRange(0x80, 0x8F)...)
+		execBytes = append(execBytes, getByteRange(0x91, 0x97)...)
+		execBytes = append(execBytes, 0x99)
+		execBytes = append(execBytes, 0x9A)
+
+		if sliceContains(execBytes, base.parser.context.currentChar) {
+			return base.parser.execute()
+		}
+	}
+
+	return nil
+}
+
+type DcsEntryState struct {
+	BaseState
+}
+
+type ErrorState struct {
+	BaseState
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/test_event_handler.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/test_event_handler.go
@@ -1,0 +1,173 @@
+package ansiterm
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type TestAnsiEventHandler struct {
+	FunctionCalls []string
+}
+
+func CreateTestAnsiEventHandler() *TestAnsiEventHandler {
+	evtHandler := TestAnsiEventHandler{}
+	evtHandler.FunctionCalls = make([]string, 0)
+	return &evtHandler
+}
+
+func (h *TestAnsiEventHandler) recordCall(call string, params []string) {
+	s := fmt.Sprintf("%s(%v)", call, params)
+	h.FunctionCalls = append(h.FunctionCalls, s)
+}
+
+func (h *TestAnsiEventHandler) Print(b byte) error {
+	h.recordCall("Print", []string{string(b)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) Execute(b byte) error {
+	h.recordCall("Execute", []string{string(b)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) CUU(param int) error {
+	h.recordCall("CUU", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) CUD(param int) error {
+	h.recordCall("CUD", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) CUF(param int) error {
+	h.recordCall("CUF", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) CUB(param int) error {
+	h.recordCall("CUB", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) CNL(param int) error {
+	h.recordCall("CNL", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) CPL(param int) error {
+	h.recordCall("CPL", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) CHA(param int) error {
+	h.recordCall("CHA", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) VPA(param int) error {
+	h.recordCall("VPA", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) CUP(x int, y int) error {
+	xS, yS := strconv.Itoa(x), strconv.Itoa(y)
+	h.recordCall("CUP", []string{xS, yS})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) HVP(x int, y int) error {
+	xS, yS := strconv.Itoa(x), strconv.Itoa(y)
+	h.recordCall("HVP", []string{xS, yS})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) DECTCEM(visible bool) error {
+	h.recordCall("DECTCEM", []string{strconv.FormatBool(visible)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) DECOM(visible bool) error {
+	h.recordCall("DECOM", []string{strconv.FormatBool(visible)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) DECCOLM(use132 bool) error {
+	h.recordCall("DECOLM", []string{strconv.FormatBool(use132)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) ED(param int) error {
+	h.recordCall("ED", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) EL(param int) error {
+	h.recordCall("EL", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) IL(param int) error {
+	h.recordCall("IL", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) DL(param int) error {
+	h.recordCall("DL", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) ICH(param int) error {
+	h.recordCall("ICH", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) DCH(param int) error {
+	h.recordCall("DCH", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) SGR(params []int) error {
+	strings := []string{}
+	for _, v := range params {
+		strings = append(strings, strconv.Itoa(v))
+	}
+
+	h.recordCall("SGR", strings)
+	return nil
+}
+
+func (h *TestAnsiEventHandler) SU(param int) error {
+	h.recordCall("SU", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) SD(param int) error {
+	h.recordCall("SD", []string{strconv.Itoa(param)})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) DA(params []string) error {
+	h.recordCall("DA", params)
+	return nil
+}
+
+func (h *TestAnsiEventHandler) DECSTBM(top int, bottom int) error {
+	topS, bottomS := strconv.Itoa(top), strconv.Itoa(bottom)
+	h.recordCall("DECSTBM", []string{topS, bottomS})
+	return nil
+}
+
+func (h *TestAnsiEventHandler) RI() error {
+	h.recordCall("RI", nil)
+	return nil
+}
+
+func (h *TestAnsiEventHandler) IND() error {
+	h.recordCall("IND", nil)
+	return nil
+}
+
+func (h *TestAnsiEventHandler) Flush() error {
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/utilities.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/utilities.go
@@ -1,0 +1,21 @@
+package ansiterm
+
+import (
+	"strconv"
+)
+
+func sliceContains(bytes []byte, b byte) bool {
+	for _, v := range bytes {
+		if v == b {
+			return true
+		}
+	}
+
+	return false
+}
+
+func convertBytesToInteger(bytes []byte) int {
+	s := string(bytes)
+	i, _ := strconv.Atoi(s)
+	return i
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/ansi.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/ansi.go
@@ -1,0 +1,182 @@
+// +build windows
+
+package winterm
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Azure/go-ansiterm"
+)
+
+// Windows keyboard constants
+// See https://msdn.microsoft.com/en-us/library/windows/desktop/dd375731(v=vs.85).aspx.
+const (
+	VK_PRIOR    = 0x21 // PAGE UP key
+	VK_NEXT     = 0x22 // PAGE DOWN key
+	VK_END      = 0x23 // END key
+	VK_HOME     = 0x24 // HOME key
+	VK_LEFT     = 0x25 // LEFT ARROW key
+	VK_UP       = 0x26 // UP ARROW key
+	VK_RIGHT    = 0x27 // RIGHT ARROW key
+	VK_DOWN     = 0x28 // DOWN ARROW key
+	VK_SELECT   = 0x29 // SELECT key
+	VK_PRINT    = 0x2A // PRINT key
+	VK_EXECUTE  = 0x2B // EXECUTE key
+	VK_SNAPSHOT = 0x2C // PRINT SCREEN key
+	VK_INSERT   = 0x2D // INS key
+	VK_DELETE   = 0x2E // DEL key
+	VK_HELP     = 0x2F // HELP key
+	VK_F1       = 0x70 // F1 key
+	VK_F2       = 0x71 // F2 key
+	VK_F3       = 0x72 // F3 key
+	VK_F4       = 0x73 // F4 key
+	VK_F5       = 0x74 // F5 key
+	VK_F6       = 0x75 // F6 key
+	VK_F7       = 0x76 // F7 key
+	VK_F8       = 0x77 // F8 key
+	VK_F9       = 0x78 // F9 key
+	VK_F10      = 0x79 // F10 key
+	VK_F11      = 0x7A // F11 key
+	VK_F12      = 0x7B // F12 key
+
+	RIGHT_ALT_PRESSED  = 0x0001
+	LEFT_ALT_PRESSED   = 0x0002
+	RIGHT_CTRL_PRESSED = 0x0004
+	LEFT_CTRL_PRESSED  = 0x0008
+	SHIFT_PRESSED      = 0x0010
+	NUMLOCK_ON         = 0x0020
+	SCROLLLOCK_ON      = 0x0040
+	CAPSLOCK_ON        = 0x0080
+	ENHANCED_KEY       = 0x0100
+)
+
+type ansiCommand struct {
+	CommandBytes []byte
+	Command      string
+	Parameters   []string
+	IsSpecial    bool
+}
+
+func newAnsiCommand(command []byte) *ansiCommand {
+
+	if isCharacterSelectionCmdChar(command[1]) {
+		// Is Character Set Selection commands
+		return &ansiCommand{
+			CommandBytes: command,
+			Command:      string(command),
+			IsSpecial:    true,
+		}
+	}
+
+	// last char is command character
+	lastCharIndex := len(command) - 1
+
+	ac := &ansiCommand{
+		CommandBytes: command,
+		Command:      string(command[lastCharIndex]),
+		IsSpecial:    false,
+	}
+
+	// more than a single escape
+	if lastCharIndex != 0 {
+		start := 1
+		// skip if double char escape sequence
+		if command[0] == ANSI_ESCAPE_PRIMARY && command[1] == ANSI_ESCAPE_SECONDARY {
+			start++
+		}
+		// convert this to GetNextParam method
+		ac.Parameters = strings.Split(string(command[start:lastCharIndex]), ANSI_PARAMETER_SEP)
+	}
+
+	return ac
+}
+
+func (ac *ansiCommand) paramAsSHORT(index int, defaultValue SHORT) SHORT {
+	if index < 0 || index >= len(ac.Parameters) {
+		return defaultValue
+	}
+
+	param, err := strconv.ParseInt(ac.Parameters[index], 10, 16)
+	if err != nil {
+		return defaultValue
+	}
+
+	return SHORT(param)
+}
+
+func (ac *ansiCommand) String() string {
+	return fmt.Sprintf("0x%v \"%v\" (\"%v\")",
+		bytesToHex(ac.CommandBytes),
+		ac.Command,
+		strings.Join(ac.Parameters, "\",\""))
+}
+
+// isAnsiCommandChar returns true if the passed byte falls within the range of ANSI commands.
+// See http://manpages.ubuntu.com/manpages/intrepid/man4/console_codes.4.html.
+func isAnsiCommandChar(b byte) bool {
+	switch {
+	case ANSI_COMMAND_FIRST <= b && b <= ANSI_COMMAND_LAST && b != ANSI_ESCAPE_SECONDARY:
+		return true
+	case b == ANSI_CMD_G1 || b == ANSI_CMD_OSC || b == ANSI_CMD_DECPAM || b == ANSI_CMD_DECPNM:
+		// non-CSI escape sequence terminator
+		return true
+	case b == ANSI_CMD_STR_TERM || b == ANSI_BEL:
+		// String escape sequence terminator
+		return true
+	}
+	return false
+}
+
+func isXtermOscSequence(command []byte, current byte) bool {
+	return (len(command) >= 2 && command[0] == ANSI_ESCAPE_PRIMARY && command[1] == ANSI_CMD_OSC && current != ANSI_BEL)
+}
+
+func isCharacterSelectionCmdChar(b byte) bool {
+	return (b == ANSI_CMD_G0 || b == ANSI_CMD_G1 || b == ANSI_CMD_G2 || b == ANSI_CMD_G3)
+}
+
+// bytesToHex converts a slice of bytes to a human-readable string.
+func bytesToHex(b []byte) string {
+	hex := make([]string, len(b))
+	for i, ch := range b {
+		hex[i] = fmt.Sprintf("%X", ch)
+	}
+	return strings.Join(hex, "")
+}
+
+// ensureInRange adjusts the passed value, if necessary, to ensure it is within
+// the passed min / max range.
+func ensureInRange(n SHORT, min SHORT, max SHORT) SHORT {
+	if n < min {
+		return min
+	} else if n > max {
+		return max
+	} else {
+		return n
+	}
+}
+
+func GetStdFile(nFile int) (*os.File, uintptr) {
+	var file *os.File
+	switch nFile {
+	case syscall.STD_INPUT_HANDLE:
+		file = os.Stdin
+	case syscall.STD_OUTPUT_HANDLE:
+		file = os.Stdout
+	case syscall.STD_ERROR_HANDLE:
+		file = os.Stderr
+	default:
+		panic(fmt.Errorf("Invalid standard handle identifier: %v", nFile))
+	}
+
+	fd, err := syscall.GetStdHandle(nFile)
+	if err != nil {
+		panic(fmt.Errorf("Invalid standard handle indentifier: %v -- %v", nFile, err))
+	}
+
+	return file, uintptr(fd)
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/api.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/api.go
@@ -1,0 +1,329 @@
+// +build windows
+
+package winterm
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+//===========================================================================================================
+// IMPORTANT NOTE:
+//
+//	The methods below make extensive use of the "unsafe" package to obtain the required pointers.
+//	Beginning in Go 1.3, the garbage collector may release local variables (e.g., incoming arguments, stack
+//	variables) the pointers reference *before* the API completes.
+//
+//  As a result, in those cases, the code must hint that the variables remain in active by invoking the
+//	dummy method "use" (see below). Newer versions of Go are planned to change the mechanism to no longer
+//	require unsafe pointers.
+//
+//	If you add or modify methods, ENSURE protection of local variables through the "use" builtin to inform
+//	the garbage collector the variables remain in use if:
+//
+//	-- The value is not a pointer (e.g., int32, struct)
+//	-- The value is not referenced by the method after passing the pointer to Windows
+//
+//	See http://golang.org/doc/go1.3.
+//===========================================================================================================
+
+var (
+	kernel32DLL = syscall.NewLazyDLL("kernel32.dll")
+
+	getConsoleCursorInfoProc       = kernel32DLL.NewProc("GetConsoleCursorInfo")
+	setConsoleCursorInfoProc       = kernel32DLL.NewProc("SetConsoleCursorInfo")
+	setConsoleCursorPositionProc   = kernel32DLL.NewProc("SetConsoleCursorPosition")
+	setConsoleModeProc             = kernel32DLL.NewProc("SetConsoleMode")
+	getConsoleScreenBufferInfoProc = kernel32DLL.NewProc("GetConsoleScreenBufferInfo")
+	setConsoleScreenBufferSizeProc = kernel32DLL.NewProc("SetConsoleScreenBufferSize")
+	scrollConsoleScreenBufferProc  = kernel32DLL.NewProc("ScrollConsoleScreenBufferA")
+	setConsoleTextAttributeProc    = kernel32DLL.NewProc("SetConsoleTextAttribute")
+	setConsoleWindowInfoProc       = kernel32DLL.NewProc("SetConsoleWindowInfo")
+	writeConsoleOutputProc         = kernel32DLL.NewProc("WriteConsoleOutputW")
+	readConsoleInputProc           = kernel32DLL.NewProc("ReadConsoleInputW")
+	waitForSingleObjectProc        = kernel32DLL.NewProc("WaitForSingleObject")
+)
+
+// Windows Console constants
+const (
+	// Console modes
+	// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx.
+	ENABLE_PROCESSED_INPUT = 0x0001
+	ENABLE_LINE_INPUT      = 0x0002
+	ENABLE_ECHO_INPUT      = 0x0004
+	ENABLE_WINDOW_INPUT    = 0x0008
+	ENABLE_MOUSE_INPUT     = 0x0010
+	ENABLE_INSERT_MODE     = 0x0020
+	ENABLE_QUICK_EDIT_MODE = 0x0040
+	ENABLE_EXTENDED_FLAGS  = 0x0080
+
+	ENABLE_PROCESSED_OUTPUT   = 0x0001
+	ENABLE_WRAP_AT_EOL_OUTPUT = 0x0002
+
+	// Character attributes
+	// Note:
+	// -- The attributes are combined to produce various colors (e.g., Blue + Green will create Cyan).
+	//    Clearing all foreground or background colors results in black; setting all creates white.
+	// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms682088(v=vs.85).aspx#_win32_character_attributes.
+	FOREGROUND_BLUE      WORD = 0x0001
+	FOREGROUND_GREEN     WORD = 0x0002
+	FOREGROUND_RED       WORD = 0x0004
+	FOREGROUND_INTENSITY WORD = 0x0008
+	FOREGROUND_MASK      WORD = 0x000F
+
+	BACKGROUND_BLUE      WORD = 0x0010
+	BACKGROUND_GREEN     WORD = 0x0020
+	BACKGROUND_RED       WORD = 0x0040
+	BACKGROUND_INTENSITY WORD = 0x0080
+	BACKGROUND_MASK      WORD = 0x00F0
+
+	COMMON_LVB_MASK          WORD = 0xFF00
+	COMMON_LVB_REVERSE_VIDEO WORD = 0x4000
+	COMMON_LVB_UNDERSCORE    WORD = 0x8000
+
+	// Input event types
+	// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms683499(v=vs.85).aspx.
+	KEY_EVENT                = 0x0001
+	MOUSE_EVENT              = 0x0002
+	WINDOW_BUFFER_SIZE_EVENT = 0x0004
+	MENU_EVENT               = 0x0008
+	FOCUS_EVENT              = 0x0010
+
+	// WaitForSingleObject return codes
+	WAIT_ABANDONED = 0x00000080
+	WAIT_FAILED    = 0xFFFFFFFF
+	WAIT_SIGNALED  = 0x0000000
+	WAIT_TIMEOUT   = 0x00000102
+
+	// WaitForSingleObject wait duration
+	WAIT_INFINITE       = 0xFFFFFFFF
+	WAIT_ONE_SECOND     = 1000
+	WAIT_HALF_SECOND    = 500
+	WAIT_QUARTER_SECOND = 250
+)
+
+// Windows API Console types
+// -- See https://msdn.microsoft.com/en-us/library/windows/desktop/aa383751(v=vs.85).aspx for core types (e.g., SHORT)
+// -- See https://msdn.microsoft.com/en-us/library/windows/desktop/ms682101(v=vs.85).aspx for Console specific types (e.g., COORD)
+// -- See https://msdn.microsoft.com/en-us/library/aa296569(v=vs.60).aspx for comments on alignment
+type (
+	SHORT int16
+	BOOL  int32
+	WORD  uint16
+	WCHAR uint16
+	DWORD uint32
+
+	CHAR_INFO struct {
+		UnicodeChar WCHAR
+		Attributes  WORD
+	}
+
+	CONSOLE_CURSOR_INFO struct {
+		Size    DWORD
+		Visible BOOL
+	}
+
+	CONSOLE_SCREEN_BUFFER_INFO struct {
+		Size              COORD
+		CursorPosition    COORD
+		Attributes        WORD
+		Window            SMALL_RECT
+		MaximumWindowSize COORD
+	}
+
+	COORD struct {
+		X SHORT
+		Y SHORT
+	}
+
+	SMALL_RECT struct {
+		Left   SHORT
+		Top    SHORT
+		Right  SHORT
+		Bottom SHORT
+	}
+
+	// INPUT_RECORD is a C/C++ union of which KEY_EVENT_RECORD is one case, it is also the largest
+	// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms683499(v=vs.85).aspx.
+	INPUT_RECORD struct {
+		EventType WORD
+		KeyEvent  KEY_EVENT_RECORD
+	}
+
+	KEY_EVENT_RECORD struct {
+		KeyDown         BOOL
+		RepeatCount     WORD
+		VirtualKeyCode  WORD
+		VirtualScanCode WORD
+		UnicodeChar     WCHAR
+		ControlKeyState DWORD
+	}
+
+	WINDOW_BUFFER_SIZE struct {
+		Size COORD
+	}
+)
+
+// boolToBOOL converts a Go bool into a Windows BOOL.
+func boolToBOOL(f bool) BOOL {
+	if f {
+		return BOOL(1)
+	} else {
+		return BOOL(0)
+	}
+}
+
+// GetConsoleCursorInfo retrieves information about the size and visiblity of the console cursor.
+// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms683163(v=vs.85).aspx.
+func GetConsoleCursorInfo(handle uintptr, cursorInfo *CONSOLE_CURSOR_INFO) error {
+	r1, r2, err := getConsoleCursorInfoProc.Call(handle, uintptr(unsafe.Pointer(cursorInfo)), 0)
+	return checkError(r1, r2, err)
+}
+
+// SetConsoleCursorInfo sets the size and visiblity of the console cursor.
+// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms686019(v=vs.85).aspx.
+func SetConsoleCursorInfo(handle uintptr, cursorInfo *CONSOLE_CURSOR_INFO) error {
+	r1, r2, err := setConsoleCursorInfoProc.Call(handle, uintptr(unsafe.Pointer(cursorInfo)), 0)
+	return checkError(r1, r2, err)
+}
+
+// SetConsoleCursorPosition location of the console cursor.
+// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms686025(v=vs.85).aspx.
+func SetConsoleCursorPosition(handle uintptr, coord COORD) error {
+	r1, r2, err := setConsoleCursorPositionProc.Call(handle, coordToPointer(coord))
+	use(coord)
+	return checkError(r1, r2, err)
+}
+
+// GetConsoleMode gets the console mode for given file descriptor
+// See http://msdn.microsoft.com/en-us/library/windows/desktop/ms683167(v=vs.85).aspx.
+func GetConsoleMode(handle uintptr) (mode uint32, err error) {
+	err = syscall.GetConsoleMode(syscall.Handle(handle), &mode)
+	return mode, err
+}
+
+// SetConsoleMode sets the console mode for given file descriptor
+// See http://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx.
+func SetConsoleMode(handle uintptr, mode uint32) error {
+	r1, r2, err := setConsoleModeProc.Call(handle, uintptr(mode), 0)
+	use(mode)
+	return checkError(r1, r2, err)
+}
+
+// GetConsoleScreenBufferInfo retrieves information about the specified console screen buffer.
+// See http://msdn.microsoft.com/en-us/library/windows/desktop/ms683171(v=vs.85).aspx.
+func GetConsoleScreenBufferInfo(handle uintptr) (*CONSOLE_SCREEN_BUFFER_INFO, error) {
+	info := CONSOLE_SCREEN_BUFFER_INFO{}
+	err := checkError(getConsoleScreenBufferInfoProc.Call(handle, uintptr(unsafe.Pointer(&info)), 0))
+	if err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+func ScrollConsoleScreenBuffer(handle uintptr, scrollRect SMALL_RECT, clipRect SMALL_RECT, destOrigin COORD, char CHAR_INFO) error {
+	r1, r2, err := scrollConsoleScreenBufferProc.Call(handle, uintptr(unsafe.Pointer(&scrollRect)), uintptr(unsafe.Pointer(&clipRect)), coordToPointer(destOrigin), uintptr(unsafe.Pointer(&char)))
+	use(scrollRect)
+	use(clipRect)
+	use(destOrigin)
+	use(char)
+	return checkError(r1, r2, err)
+}
+
+// SetConsoleScreenBufferSize sets the size of the console screen buffer.
+// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms686044(v=vs.85).aspx.
+func SetConsoleScreenBufferSize(handle uintptr, coord COORD) error {
+	r1, r2, err := setConsoleScreenBufferSizeProc.Call(handle, coordToPointer(coord))
+	use(coord)
+	return checkError(r1, r2, err)
+}
+
+// SetConsoleTextAttribute sets the attributes of characters written to the
+// console screen buffer by the WriteFile or WriteConsole function.
+// See http://msdn.microsoft.com/en-us/library/windows/desktop/ms686047(v=vs.85).aspx.
+func SetConsoleTextAttribute(handle uintptr, attribute WORD) error {
+	r1, r2, err := setConsoleTextAttributeProc.Call(handle, uintptr(attribute), 0)
+	use(attribute)
+	return checkError(r1, r2, err)
+}
+
+// SetConsoleWindowInfo sets the size and position of the console screen buffer's window.
+// Note that the size and location must be within and no larger than the backing console screen buffer.
+// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms686125(v=vs.85).aspx.
+func SetConsoleWindowInfo(handle uintptr, isAbsolute bool, rect SMALL_RECT) error {
+	r1, r2, err := setConsoleWindowInfoProc.Call(handle, uintptr(boolToBOOL(isAbsolute)), uintptr(unsafe.Pointer(&rect)))
+	use(isAbsolute)
+	use(rect)
+	return checkError(r1, r2, err)
+}
+
+// WriteConsoleOutput writes the CHAR_INFOs from the provided buffer to the active console buffer.
+// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms687404(v=vs.85).aspx.
+func WriteConsoleOutput(handle uintptr, buffer []CHAR_INFO, bufferSize COORD, bufferCoord COORD, writeRegion *SMALL_RECT) error {
+	r1, r2, err := writeConsoleOutputProc.Call(handle, uintptr(unsafe.Pointer(&buffer[0])), coordToPointer(bufferSize), coordToPointer(bufferCoord), uintptr(unsafe.Pointer(writeRegion)))
+	use(buffer)
+	use(bufferSize)
+	use(bufferCoord)
+	return checkError(r1, r2, err)
+}
+
+// ReadConsoleInput reads (and removes) data from the console input buffer.
+// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms684961(v=vs.85).aspx.
+func ReadConsoleInput(handle uintptr, buffer []INPUT_RECORD, count *uint32) error {
+	r1, r2, err := readConsoleInputProc.Call(handle, uintptr(unsafe.Pointer(&buffer[0])), uintptr(len(buffer)), uintptr(unsafe.Pointer(count)))
+	use(buffer)
+	return checkError(r1, r2, err)
+}
+
+// WaitForSingleObject waits for the passed handle to be signaled.
+// It returns true if the handle was signaled; false otherwise.
+// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms687032(v=vs.85).aspx.
+func WaitForSingleObject(handle uintptr, msWait uint32) (bool, error) {
+	r1, _, err := waitForSingleObjectProc.Call(handle, uintptr(DWORD(msWait)))
+	switch r1 {
+	case WAIT_ABANDONED, WAIT_TIMEOUT:
+		return false, nil
+	case WAIT_SIGNALED:
+		return true, nil
+	}
+	use(msWait)
+	return false, err
+}
+
+// String helpers
+func (info CONSOLE_SCREEN_BUFFER_INFO) String() string {
+	return fmt.Sprintf("Size(%v) Cursor(%v) Window(%v) Max(%v)", info.Size, info.CursorPosition, info.Window, info.MaximumWindowSize)
+}
+
+func (coord COORD) String() string {
+	return fmt.Sprintf("%v,%v", coord.X, coord.Y)
+}
+
+func (rect SMALL_RECT) String() string {
+	return fmt.Sprintf("(%v,%v),(%v,%v)", rect.Left, rect.Top, rect.Right, rect.Bottom)
+}
+
+// checkError evaluates the results of a Windows API call and returns the error if it failed.
+func checkError(r1, r2 uintptr, err error) error {
+	// Windows APIs return non-zero to indicate success
+	if r1 != 0 {
+		return nil
+	}
+
+	// Return the error if provided, otherwise default to EINVAL
+	if err != nil {
+		return err
+	}
+	return syscall.EINVAL
+}
+
+// coordToPointer converts a COORD into a uintptr (by fooling the type system).
+func coordToPointer(c COORD) uintptr {
+	// Note: This code assumes the two SHORTs are correctly laid out; the "cast" to DWORD is just to get a pointer to pass.
+	return uintptr(*((*DWORD)(unsafe.Pointer(&c))))
+}
+
+// use is a no-op, but the compiler cannot see that it is.
+// Calling use(p) ensures that p is kept live until that point.
+func use(p interface{}) {}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/attr_translation.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/attr_translation.go
@@ -1,0 +1,102 @@
+// +build windows
+
+package winterm
+
+import (
+	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Azure/go-ansiterm"
+)
+
+const (
+	FOREGROUND_COLOR_MASK = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE
+	BACKGROUND_COLOR_MASK = BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE
+)
+
+// collectAnsiIntoWindowsAttributes modifies the passed Windows text mode flags to reflect the
+// request represented by the passed ANSI mode.
+func collectAnsiIntoWindowsAttributes(windowsMode WORD, inverted bool, baseMode WORD, ansiMode SHORT) (WORD, bool) {
+	switch ansiMode {
+
+	// Mode styles
+	case ANSI_SGR_BOLD:
+		windowsMode = windowsMode | FOREGROUND_INTENSITY
+
+	case ANSI_SGR_DIM, ANSI_SGR_BOLD_DIM_OFF:
+		windowsMode &^= FOREGROUND_INTENSITY
+
+	case ANSI_SGR_UNDERLINE:
+		windowsMode = windowsMode | COMMON_LVB_UNDERSCORE
+
+	case ANSI_SGR_REVERSE:
+		inverted = true
+
+	case ANSI_SGR_REVERSE_OFF:
+		inverted = false
+
+	case ANSI_SGR_UNDERLINE_OFF:
+		windowsMode &^= COMMON_LVB_UNDERSCORE
+
+		// Foreground colors
+	case ANSI_SGR_FOREGROUND_DEFAULT:
+		windowsMode = (windowsMode &^ FOREGROUND_MASK) | (baseMode & FOREGROUND_MASK)
+
+	case ANSI_SGR_FOREGROUND_BLACK:
+		windowsMode = (windowsMode &^ FOREGROUND_COLOR_MASK)
+
+	case ANSI_SGR_FOREGROUND_RED:
+		windowsMode = (windowsMode &^ FOREGROUND_COLOR_MASK) | FOREGROUND_RED
+
+	case ANSI_SGR_FOREGROUND_GREEN:
+		windowsMode = (windowsMode &^ FOREGROUND_COLOR_MASK) | FOREGROUND_GREEN
+
+	case ANSI_SGR_FOREGROUND_YELLOW:
+		windowsMode = (windowsMode &^ FOREGROUND_COLOR_MASK) | FOREGROUND_RED | FOREGROUND_GREEN
+
+	case ANSI_SGR_FOREGROUND_BLUE:
+		windowsMode = (windowsMode &^ FOREGROUND_COLOR_MASK) | FOREGROUND_BLUE
+
+	case ANSI_SGR_FOREGROUND_MAGENTA:
+		windowsMode = (windowsMode &^ FOREGROUND_COLOR_MASK) | FOREGROUND_RED | FOREGROUND_BLUE
+
+	case ANSI_SGR_FOREGROUND_CYAN:
+		windowsMode = (windowsMode &^ FOREGROUND_COLOR_MASK) | FOREGROUND_GREEN | FOREGROUND_BLUE
+
+	case ANSI_SGR_FOREGROUND_WHITE:
+		windowsMode = (windowsMode &^ FOREGROUND_COLOR_MASK) | FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE
+
+		// Background colors
+	case ANSI_SGR_BACKGROUND_DEFAULT:
+		// Black with no intensity
+		windowsMode = (windowsMode &^ BACKGROUND_MASK) | (baseMode & BACKGROUND_MASK)
+
+	case ANSI_SGR_BACKGROUND_BLACK:
+		windowsMode = (windowsMode &^ BACKGROUND_COLOR_MASK)
+
+	case ANSI_SGR_BACKGROUND_RED:
+		windowsMode = (windowsMode &^ BACKGROUND_COLOR_MASK) | BACKGROUND_RED
+
+	case ANSI_SGR_BACKGROUND_GREEN:
+		windowsMode = (windowsMode &^ BACKGROUND_COLOR_MASK) | BACKGROUND_GREEN
+
+	case ANSI_SGR_BACKGROUND_YELLOW:
+		windowsMode = (windowsMode &^ BACKGROUND_COLOR_MASK) | BACKGROUND_RED | BACKGROUND_GREEN
+
+	case ANSI_SGR_BACKGROUND_BLUE:
+		windowsMode = (windowsMode &^ BACKGROUND_COLOR_MASK) | BACKGROUND_BLUE
+
+	case ANSI_SGR_BACKGROUND_MAGENTA:
+		windowsMode = (windowsMode &^ BACKGROUND_COLOR_MASK) | BACKGROUND_RED | BACKGROUND_BLUE
+
+	case ANSI_SGR_BACKGROUND_CYAN:
+		windowsMode = (windowsMode &^ BACKGROUND_COLOR_MASK) | BACKGROUND_GREEN | BACKGROUND_BLUE
+
+	case ANSI_SGR_BACKGROUND_WHITE:
+		windowsMode = (windowsMode &^ BACKGROUND_COLOR_MASK) | BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE
+	}
+
+	return windowsMode, inverted
+}
+
+// invertAttributes inverts the foreground and background colors of a Windows attributes value
+func invertAttributes(windowsMode WORD) WORD {
+	return (COMMON_LVB_MASK & windowsMode) | ((FOREGROUND_MASK & windowsMode) << 4) | ((BACKGROUND_MASK & windowsMode) >> 4)
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/cursor_helpers.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/cursor_helpers.go
@@ -1,0 +1,101 @@
+// +build windows
+
+package winterm
+
+const (
+	Horizontal = iota
+	Vertical
+)
+
+func (h *WindowsAnsiEventHandler) getCursorWindow(info *CONSOLE_SCREEN_BUFFER_INFO) SMALL_RECT {
+	if h.originMode {
+		sr := h.effectiveSr(info.Window)
+		return SMALL_RECT{
+			Top:    sr.top,
+			Bottom: sr.bottom,
+			Left:   0,
+			Right:  info.Size.X - 1,
+		}
+	} else {
+		return SMALL_RECT{
+			Top:    info.Window.Top,
+			Bottom: info.Window.Bottom,
+			Left:   0,
+			Right:  info.Size.X - 1,
+		}
+	}
+}
+
+// setCursorPosition sets the cursor to the specified position, bounded to the screen size
+func (h *WindowsAnsiEventHandler) setCursorPosition(position COORD, window SMALL_RECT) error {
+	position.X = ensureInRange(position.X, window.Left, window.Right)
+	position.Y = ensureInRange(position.Y, window.Top, window.Bottom)
+	err := SetConsoleCursorPosition(h.fd, position)
+	if err != nil {
+		return err
+	}
+	logger.Infof("Cursor position set: (%d, %d)", position.X, position.Y)
+	return err
+}
+
+func (h *WindowsAnsiEventHandler) moveCursorVertical(param int) error {
+	return h.moveCursor(Vertical, param)
+}
+
+func (h *WindowsAnsiEventHandler) moveCursorHorizontal(param int) error {
+	return h.moveCursor(Horizontal, param)
+}
+
+func (h *WindowsAnsiEventHandler) moveCursor(moveMode int, param int) error {
+	info, err := GetConsoleScreenBufferInfo(h.fd)
+	if err != nil {
+		return err
+	}
+
+	position := info.CursorPosition
+	switch moveMode {
+	case Horizontal:
+		position.X += SHORT(param)
+	case Vertical:
+		position.Y += SHORT(param)
+	}
+
+	if err = h.setCursorPosition(position, h.getCursorWindow(info)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *WindowsAnsiEventHandler) moveCursorLine(param int) error {
+	info, err := GetConsoleScreenBufferInfo(h.fd)
+	if err != nil {
+		return err
+	}
+
+	position := info.CursorPosition
+	position.X = 0
+	position.Y += SHORT(param)
+
+	if err = h.setCursorPosition(position, h.getCursorWindow(info)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *WindowsAnsiEventHandler) moveCursorColumn(param int) error {
+	info, err := GetConsoleScreenBufferInfo(h.fd)
+	if err != nil {
+		return err
+	}
+
+	position := info.CursorPosition
+	position.X = SHORT(param) - 1
+
+	if err = h.setCursorPosition(position, h.getCursorWindow(info)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/erase_helpers.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/erase_helpers.go
@@ -1,0 +1,86 @@
+// +build windows
+
+package winterm
+
+import (
+	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Azure/go-ansiterm"
+)
+
+func (h *WindowsAnsiEventHandler) clearRange(attributes WORD, fromCoord COORD, toCoord COORD) error {
+	// Ignore an invalid (negative area) request
+	if toCoord.Y < fromCoord.Y {
+		return nil
+	}
+
+	var err error
+
+	var coordStart = COORD{}
+	var coordEnd = COORD{}
+
+	xCurrent, yCurrent := fromCoord.X, fromCoord.Y
+	xEnd, yEnd := toCoord.X, toCoord.Y
+
+	// Clear any partial initial line
+	if xCurrent > 0 {
+		coordStart.X, coordStart.Y = xCurrent, yCurrent
+		coordEnd.X, coordEnd.Y = xEnd, yCurrent
+
+		err = h.clearRect(attributes, coordStart, coordEnd)
+		if err != nil {
+			return err
+		}
+
+		xCurrent = 0
+		yCurrent += 1
+	}
+
+	// Clear intervening rectangular section
+	if yCurrent < yEnd {
+		coordStart.X, coordStart.Y = xCurrent, yCurrent
+		coordEnd.X, coordEnd.Y = xEnd, yEnd-1
+
+		err = h.clearRect(attributes, coordStart, coordEnd)
+		if err != nil {
+			return err
+		}
+
+		xCurrent = 0
+		yCurrent = yEnd
+	}
+
+	// Clear remaining partial ending line
+	coordStart.X, coordStart.Y = xCurrent, yCurrent
+	coordEnd.X, coordEnd.Y = xEnd, yEnd
+
+	err = h.clearRect(attributes, coordStart, coordEnd)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *WindowsAnsiEventHandler) clearRect(attributes WORD, fromCoord COORD, toCoord COORD) error {
+	region := SMALL_RECT{Top: fromCoord.Y, Left: fromCoord.X, Bottom: toCoord.Y, Right: toCoord.X}
+	width := toCoord.X - fromCoord.X + 1
+	height := toCoord.Y - fromCoord.Y + 1
+	size := uint32(width) * uint32(height)
+
+	if size <= 0 {
+		return nil
+	}
+
+	buffer := make([]CHAR_INFO, size)
+
+	char := CHAR_INFO{WCHAR(FILL_CHARACTER), attributes}
+	for i := 0; i < int(size); i++ {
+		buffer[i] = char
+	}
+
+	err := WriteConsoleOutput(h.fd, buffer, COORD{X: width, Y: height}, COORD{X: 0, Y: 0}, &region)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/scroll_helper.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/scroll_helper.go
@@ -1,0 +1,118 @@
+// +build windows
+
+package winterm
+
+// effectiveSr gets the current effective scroll region in buffer coordinates
+func (h *WindowsAnsiEventHandler) effectiveSr(window SMALL_RECT) scrollRegion {
+	top := AddInRange(window.Top, h.sr.top, window.Top, window.Bottom)
+	bottom := AddInRange(window.Top, h.sr.bottom, window.Top, window.Bottom)
+	if top >= bottom {
+		top = window.Top
+		bottom = window.Bottom
+	}
+	return scrollRegion{top: top, bottom: bottom}
+}
+
+func (h *WindowsAnsiEventHandler) scrollUp(param int) error {
+	info, err := GetConsoleScreenBufferInfo(h.fd)
+	if err != nil {
+		return err
+	}
+
+	sr := h.effectiveSr(info.Window)
+	return h.scroll(param, sr, info)
+}
+
+func (h *WindowsAnsiEventHandler) scrollDown(param int) error {
+	return h.scrollUp(-param)
+}
+
+func (h *WindowsAnsiEventHandler) deleteLines(param int) error {
+	info, err := GetConsoleScreenBufferInfo(h.fd)
+	if err != nil {
+		return err
+	}
+
+	start := info.CursorPosition.Y
+	sr := h.effectiveSr(info.Window)
+	// Lines cannot be inserted or deleted outside the scrolling region.
+	if start >= sr.top && start <= sr.bottom {
+		sr.top = start
+		return h.scroll(param, sr, info)
+	} else {
+		return nil
+	}
+}
+
+func (h *WindowsAnsiEventHandler) insertLines(param int) error {
+	return h.deleteLines(-param)
+}
+
+// scroll scrolls the provided scroll region by param lines. The scroll region is in buffer coordinates.
+func (h *WindowsAnsiEventHandler) scroll(param int, sr scrollRegion, info *CONSOLE_SCREEN_BUFFER_INFO) error {
+	logger.Infof("scroll: scrollTop: %d, scrollBottom: %d", sr.top, sr.bottom)
+	logger.Infof("scroll: windowTop: %d, windowBottom: %d", info.Window.Top, info.Window.Bottom)
+
+	// Copy from and clip to the scroll region (full buffer width)
+	scrollRect := SMALL_RECT{
+		Top:    sr.top,
+		Bottom: sr.bottom,
+		Left:   0,
+		Right:  info.Size.X - 1,
+	}
+
+	// Origin to which area should be copied
+	destOrigin := COORD{
+		X: 0,
+		Y: sr.top - SHORT(param),
+	}
+
+	char := CHAR_INFO{
+		UnicodeChar: ' ',
+		Attributes:  h.attributes,
+	}
+
+	if err := ScrollConsoleScreenBuffer(h.fd, scrollRect, scrollRect, destOrigin, char); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *WindowsAnsiEventHandler) deleteCharacters(param int) error {
+	info, err := GetConsoleScreenBufferInfo(h.fd)
+	if err != nil {
+		return err
+	}
+	return h.scrollLine(param, info.CursorPosition, info)
+}
+
+func (h *WindowsAnsiEventHandler) insertCharacters(param int) error {
+	return h.deleteCharacters(-param)
+}
+
+// scrollLine scrolls a line horizontally starting at the provided position by a number of columns.
+func (h *WindowsAnsiEventHandler) scrollLine(columns int, position COORD, info *CONSOLE_SCREEN_BUFFER_INFO) error {
+	// Copy from and clip to the scroll region (full buffer width)
+	scrollRect := SMALL_RECT{
+		Top:    position.Y,
+		Bottom: position.Y,
+		Left:   position.X,
+		Right:  info.Size.X - 1,
+	}
+
+	// Origin to which area should be copied
+	destOrigin := COORD{
+		X: position.X - SHORT(columns),
+		Y: position.Y,
+	}
+
+	char := CHAR_INFO{
+		UnicodeChar: ' ',
+		Attributes:  h.attributes,
+	}
+
+	if err := ScrollConsoleScreenBuffer(h.fd, scrollRect, scrollRect, destOrigin, char); err != nil {
+		return err
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/utilities.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/utilities.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package winterm
+
+// AddInRange increments a value by the passed quantity while ensuring the values
+// always remain within the supplied min / max range.
+func AddInRange(n SHORT, increment SHORT, min SHORT, max SHORT) SHORT {
+	return ensureInRange(n+increment, min, max)
+}

--- a/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/win_event_handler.go
+++ b/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm/win_event_handler.go
@@ -1,0 +1,725 @@
+// +build windows
+
+package winterm
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"strconv"
+
+	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Azure/go-ansiterm"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+)
+
+var logger *logrus.Logger
+
+type WindowsAnsiEventHandler struct {
+	fd             uintptr
+	file           *os.File
+	infoReset      *CONSOLE_SCREEN_BUFFER_INFO
+	sr             scrollRegion
+	buffer         bytes.Buffer
+	attributes     WORD
+	inverted       bool
+	wrapNext       bool
+	drewMarginByte bool
+	originMode     bool
+	marginByte     byte
+	curInfo        *CONSOLE_SCREEN_BUFFER_INFO
+	curPos         COORD
+}
+
+func CreateWinEventHandler(fd uintptr, file *os.File) AnsiEventHandler {
+	logFile := ioutil.Discard
+
+	if isDebugEnv := os.Getenv(LogEnv); isDebugEnv == "1" {
+		logFile, _ = os.Create("winEventHandler.log")
+	}
+
+	logger = &logrus.Logger{
+		Out:       logFile,
+		Formatter: new(logrus.TextFormatter),
+		Level:     logrus.DebugLevel,
+	}
+
+	infoReset, err := GetConsoleScreenBufferInfo(fd)
+	if err != nil {
+		return nil
+	}
+
+	return &WindowsAnsiEventHandler{
+		fd:         fd,
+		file:       file,
+		infoReset:  infoReset,
+		attributes: infoReset.Attributes,
+	}
+}
+
+type scrollRegion struct {
+	top    SHORT
+	bottom SHORT
+}
+
+// simulateLF simulates a LF or CR+LF by scrolling if necessary to handle the
+// current cursor position and scroll region settings, in which case it returns
+// true. If no special handling is necessary, then it does nothing and returns
+// false.
+//
+// In the false case, the caller should ensure that a carriage return
+// and line feed are inserted or that the text is otherwise wrapped.
+func (h *WindowsAnsiEventHandler) simulateLF(includeCR bool) (bool, error) {
+	if h.wrapNext {
+		if err := h.Flush(); err != nil {
+			return false, err
+		}
+		h.clearWrap()
+	}
+	pos, info, err := h.getCurrentInfo()
+	if err != nil {
+		return false, err
+	}
+	sr := h.effectiveSr(info.Window)
+	if pos.Y == sr.bottom {
+		// Scrolling is necessary. Let Windows automatically scroll if the scrolling region
+		// is the full window.
+		if sr.top == info.Window.Top && sr.bottom == info.Window.Bottom {
+			if includeCR {
+				pos.X = 0
+				h.updatePos(pos)
+			}
+			return false, nil
+		} else {
+			// A custom scroll region is active. Scroll the window manually to simulate
+			// the LF.
+			if err := h.Flush(); err != nil {
+				return false, err
+			}
+			logger.Info("Simulating LF inside scroll region")
+			if err := h.scrollUp(1); err != nil {
+				return false, err
+			}
+			if includeCR {
+				pos.X = 0
+				if err := SetConsoleCursorPosition(h.fd, pos); err != nil {
+					return false, err
+				}
+			}
+			return true, nil
+		}
+	} else if pos.Y < info.Window.Bottom {
+		// Let Windows handle the LF.
+		pos.Y++
+		if includeCR {
+			pos.X = 0
+		}
+		h.updatePos(pos)
+		return false, nil
+	} else {
+		// The cursor is at the bottom of the screen but outside the scroll
+		// region. Skip the LF.
+		logger.Info("Simulating LF outside scroll region")
+		if includeCR {
+			if err := h.Flush(); err != nil {
+				return false, err
+			}
+			pos.X = 0
+			if err := SetConsoleCursorPosition(h.fd, pos); err != nil {
+				return false, err
+			}
+		}
+		return true, nil
+	}
+}
+
+// executeLF executes a LF without a CR.
+func (h *WindowsAnsiEventHandler) executeLF() error {
+	handled, err := h.simulateLF(false)
+	if err != nil {
+		return err
+	}
+	if !handled {
+		// Windows LF will reset the cursor column position. Write the LF
+		// and restore the cursor position.
+		pos, _, err := h.getCurrentInfo()
+		if err != nil {
+			return err
+		}
+		h.buffer.WriteByte(ANSI_LINE_FEED)
+		if pos.X != 0 {
+			if err := h.Flush(); err != nil {
+				return err
+			}
+			logger.Info("Resetting cursor position for LF without CR")
+			if err := SetConsoleCursorPosition(h.fd, pos); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (h *WindowsAnsiEventHandler) Print(b byte) error {
+	if h.wrapNext {
+		h.buffer.WriteByte(h.marginByte)
+		h.clearWrap()
+		if _, err := h.simulateLF(true); err != nil {
+			return err
+		}
+	}
+	pos, info, err := h.getCurrentInfo()
+	if err != nil {
+		return err
+	}
+	if pos.X == info.Size.X-1 {
+		h.wrapNext = true
+		h.marginByte = b
+	} else {
+		pos.X++
+		h.updatePos(pos)
+		h.buffer.WriteByte(b)
+	}
+	return nil
+}
+
+func (h *WindowsAnsiEventHandler) Execute(b byte) error {
+	switch b {
+	case ANSI_TAB:
+		logger.Info("Execute(TAB)")
+		// Move to the next tab stop, but preserve auto-wrap if already set.
+		if !h.wrapNext {
+			pos, info, err := h.getCurrentInfo()
+			if err != nil {
+				return err
+			}
+			pos.X = (pos.X + 8) - pos.X%8
+			if pos.X >= info.Size.X {
+				pos.X = info.Size.X - 1
+			}
+			if err := h.Flush(); err != nil {
+				return err
+			}
+			if err := SetConsoleCursorPosition(h.fd, pos); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	case ANSI_BEL:
+		h.buffer.WriteByte(ANSI_BEL)
+		return nil
+
+	case ANSI_BACKSPACE:
+		if h.wrapNext {
+			if err := h.Flush(); err != nil {
+				return err
+			}
+			h.clearWrap()
+		}
+		pos, _, err := h.getCurrentInfo()
+		if err != nil {
+			return err
+		}
+		if pos.X > 0 {
+			pos.X--
+			h.updatePos(pos)
+			h.buffer.WriteByte(ANSI_BACKSPACE)
+		}
+		return nil
+
+	case ANSI_VERTICAL_TAB, ANSI_FORM_FEED:
+		// Treat as true LF.
+		return h.executeLF()
+
+	case ANSI_LINE_FEED:
+		// Simulate a CR and LF for now since there is no way in go-ansiterm
+		// to tell if the LF should include CR (and more things break when it's
+		// missing than when it's incorrectly added).
+		handled, err := h.simulateLF(true)
+		if handled || err != nil {
+			return err
+		}
+		return h.buffer.WriteByte(ANSI_LINE_FEED)
+
+	case ANSI_CARRIAGE_RETURN:
+		if h.wrapNext {
+			if err := h.Flush(); err != nil {
+				return err
+			}
+			h.clearWrap()
+		}
+		pos, _, err := h.getCurrentInfo()
+		if err != nil {
+			return err
+		}
+		if pos.X != 0 {
+			pos.X = 0
+			h.updatePos(pos)
+			h.buffer.WriteByte(ANSI_CARRIAGE_RETURN)
+		}
+		return nil
+
+	default:
+		return nil
+	}
+}
+
+func (h *WindowsAnsiEventHandler) CUU(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("CUU: [%v]", []string{strconv.Itoa(param)})
+	h.clearWrap()
+	return h.moveCursorVertical(-param)
+}
+
+func (h *WindowsAnsiEventHandler) CUD(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("CUD: [%v]", []string{strconv.Itoa(param)})
+	h.clearWrap()
+	return h.moveCursorVertical(param)
+}
+
+func (h *WindowsAnsiEventHandler) CUF(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("CUF: [%v]", []string{strconv.Itoa(param)})
+	h.clearWrap()
+	return h.moveCursorHorizontal(param)
+}
+
+func (h *WindowsAnsiEventHandler) CUB(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("CUB: [%v]", []string{strconv.Itoa(param)})
+	h.clearWrap()
+	return h.moveCursorHorizontal(-param)
+}
+
+func (h *WindowsAnsiEventHandler) CNL(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("CNL: [%v]", []string{strconv.Itoa(param)})
+	h.clearWrap()
+	return h.moveCursorLine(param)
+}
+
+func (h *WindowsAnsiEventHandler) CPL(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("CPL: [%v]", []string{strconv.Itoa(param)})
+	h.clearWrap()
+	return h.moveCursorLine(-param)
+}
+
+func (h *WindowsAnsiEventHandler) CHA(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("CHA: [%v]", []string{strconv.Itoa(param)})
+	h.clearWrap()
+	return h.moveCursorColumn(param)
+}
+
+func (h *WindowsAnsiEventHandler) VPA(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("VPA: [[%d]]", param)
+	h.clearWrap()
+	info, err := GetConsoleScreenBufferInfo(h.fd)
+	if err != nil {
+		return err
+	}
+	window := h.getCursorWindow(info)
+	position := info.CursorPosition
+	position.Y = window.Top + SHORT(param) - 1
+	return h.setCursorPosition(position, window)
+}
+
+func (h *WindowsAnsiEventHandler) CUP(row int, col int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("CUP: [[%d %d]]", row, col)
+	h.clearWrap()
+	info, err := GetConsoleScreenBufferInfo(h.fd)
+	if err != nil {
+		return err
+	}
+
+	window := h.getCursorWindow(info)
+	position := COORD{window.Left + SHORT(col) - 1, window.Top + SHORT(row) - 1}
+	return h.setCursorPosition(position, window)
+}
+
+func (h *WindowsAnsiEventHandler) HVP(row int, col int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("HVP: [[%d %d]]", row, col)
+	h.clearWrap()
+	return h.CUP(row, col)
+}
+
+func (h *WindowsAnsiEventHandler) DECTCEM(visible bool) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("DECTCEM: [%v]", []string{strconv.FormatBool(visible)})
+	h.clearWrap()
+	return nil
+}
+
+func (h *WindowsAnsiEventHandler) DECOM(enable bool) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("DECOM: [%v]", []string{strconv.FormatBool(enable)})
+	h.clearWrap()
+	h.originMode = enable
+	return h.CUP(1, 1)
+}
+
+func (h *WindowsAnsiEventHandler) DECCOLM(use132 bool) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("DECCOLM: [%v]", []string{strconv.FormatBool(use132)})
+	h.clearWrap()
+	if err := h.ED(2); err != nil {
+		return err
+	}
+	info, err := GetConsoleScreenBufferInfo(h.fd)
+	if err != nil {
+		return err
+	}
+	targetWidth := SHORT(80)
+	if use132 {
+		targetWidth = 132
+	}
+	if info.Size.X < targetWidth {
+		if err := SetConsoleScreenBufferSize(h.fd, COORD{targetWidth, info.Size.Y}); err != nil {
+			logger.Info("set buffer failed:", err)
+			return err
+		}
+	}
+	window := info.Window
+	window.Left = 0
+	window.Right = targetWidth - 1
+	if err := SetConsoleWindowInfo(h.fd, true, window); err != nil {
+		logger.Info("set window failed:", err)
+		return err
+	}
+	if info.Size.X > targetWidth {
+		if err := SetConsoleScreenBufferSize(h.fd, COORD{targetWidth, info.Size.Y}); err != nil {
+			logger.Info("set buffer failed:", err)
+			return err
+		}
+	}
+	return SetConsoleCursorPosition(h.fd, COORD{0, 0})
+}
+
+func (h *WindowsAnsiEventHandler) ED(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("ED: [%v]", []string{strconv.Itoa(param)})
+	h.clearWrap()
+
+	// [J  -- Erases from the cursor to the end of the screen, including the cursor position.
+	// [1J -- Erases from the beginning of the screen to the cursor, including the cursor position.
+	// [2J -- Erases the complete display. The cursor does not move.
+	// Notes:
+	// -- Clearing the entire buffer, versus just the Window, works best for Windows Consoles
+
+	info, err := GetConsoleScreenBufferInfo(h.fd)
+	if err != nil {
+		return err
+	}
+
+	var start COORD
+	var end COORD
+
+	switch param {
+	case 0:
+		start = info.CursorPosition
+		end = COORD{info.Size.X - 1, info.Size.Y - 1}
+
+	case 1:
+		start = COORD{0, 0}
+		end = info.CursorPosition
+
+	case 2:
+		start = COORD{0, 0}
+		end = COORD{info.Size.X - 1, info.Size.Y - 1}
+	}
+
+	err = h.clearRange(h.attributes, start, end)
+	if err != nil {
+		return err
+	}
+
+	// If the whole buffer was cleared, move the window to the top while preserving
+	// the window-relative cursor position.
+	if param == 2 {
+		pos := info.CursorPosition
+		window := info.Window
+		pos.Y -= window.Top
+		window.Bottom -= window.Top
+		window.Top = 0
+		if err := SetConsoleCursorPosition(h.fd, pos); err != nil {
+			return err
+		}
+		if err := SetConsoleWindowInfo(h.fd, true, window); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *WindowsAnsiEventHandler) EL(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("EL: [%v]", strconv.Itoa(param))
+	h.clearWrap()
+
+	// [K  -- Erases from the cursor to the end of the line, including the cursor position.
+	// [1K -- Erases from the beginning of the line to the cursor, including the cursor position.
+	// [2K -- Erases the complete line.
+
+	info, err := GetConsoleScreenBufferInfo(h.fd)
+	if err != nil {
+		return err
+	}
+
+	var start COORD
+	var end COORD
+
+	switch param {
+	case 0:
+		start = info.CursorPosition
+		end = COORD{info.Size.X, info.CursorPosition.Y}
+
+	case 1:
+		start = COORD{0, info.CursorPosition.Y}
+		end = info.CursorPosition
+
+	case 2:
+		start = COORD{0, info.CursorPosition.Y}
+		end = COORD{info.Size.X, info.CursorPosition.Y}
+	}
+
+	err = h.clearRange(h.attributes, start, end)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *WindowsAnsiEventHandler) IL(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("IL: [%v]", strconv.Itoa(param))
+	h.clearWrap()
+	return h.insertLines(param)
+}
+
+func (h *WindowsAnsiEventHandler) DL(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("DL: [%v]", strconv.Itoa(param))
+	h.clearWrap()
+	return h.deleteLines(param)
+}
+
+func (h *WindowsAnsiEventHandler) ICH(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("ICH: [%v]", strconv.Itoa(param))
+	h.clearWrap()
+	return h.insertCharacters(param)
+}
+
+func (h *WindowsAnsiEventHandler) DCH(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("DCH: [%v]", strconv.Itoa(param))
+	h.clearWrap()
+	return h.deleteCharacters(param)
+}
+
+func (h *WindowsAnsiEventHandler) SGR(params []int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	strings := []string{}
+	for _, v := range params {
+		strings = append(strings, strconv.Itoa(v))
+	}
+
+	logger.Infof("SGR: [%v]", strings)
+
+	if len(params) <= 0 {
+		h.attributes = h.infoReset.Attributes
+		h.inverted = false
+	} else {
+		for _, attr := range params {
+
+			if attr == ANSI_SGR_RESET {
+				h.attributes = h.infoReset.Attributes
+				h.inverted = false
+				continue
+			}
+
+			h.attributes, h.inverted = collectAnsiIntoWindowsAttributes(h.attributes, h.inverted, h.infoReset.Attributes, SHORT(attr))
+		}
+	}
+
+	attributes := h.attributes
+	if h.inverted {
+		attributes = invertAttributes(attributes)
+	}
+	err := SetConsoleTextAttribute(h.fd, attributes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *WindowsAnsiEventHandler) SU(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("SU: [%v]", []string{strconv.Itoa(param)})
+	h.clearWrap()
+	return h.scrollUp(param)
+}
+
+func (h *WindowsAnsiEventHandler) SD(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("SD: [%v]", []string{strconv.Itoa(param)})
+	h.clearWrap()
+	return h.scrollDown(param)
+}
+
+func (h *WindowsAnsiEventHandler) DA(params []string) error {
+	logger.Infof("DA: [%v]", params)
+	// DA cannot be implemented because it must send data on the VT100 input stream,
+	// which is not available to go-ansiterm.
+	return nil
+}
+
+func (h *WindowsAnsiEventHandler) DECSTBM(top int, bottom int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("DECSTBM: [%d, %d]", top, bottom)
+
+	// Windows is 0 indexed, Linux is 1 indexed
+	h.sr.top = SHORT(top - 1)
+	h.sr.bottom = SHORT(bottom - 1)
+
+	// This command also moves the cursor to the origin.
+	h.clearWrap()
+	return h.CUP(1, 1)
+}
+
+func (h *WindowsAnsiEventHandler) RI() error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Info("RI: []")
+	h.clearWrap()
+
+	info, err := GetConsoleScreenBufferInfo(h.fd)
+	if err != nil {
+		return err
+	}
+
+	sr := h.effectiveSr(info.Window)
+	if info.CursorPosition.Y == sr.top {
+		return h.scrollDown(1)
+	} else {
+		return h.moveCursorVertical(-1)
+	}
+}
+
+func (h *WindowsAnsiEventHandler) IND() error {
+	logger.Info("IND: []")
+	return h.executeLF()
+}
+
+func (h *WindowsAnsiEventHandler) Flush() error {
+	h.curInfo = nil
+	if h.buffer.Len() > 0 {
+		logger.Infof("Flush: [%s]", h.buffer.Bytes())
+		if _, err := h.buffer.WriteTo(h.file); err != nil {
+			return err
+		}
+	}
+
+	if h.wrapNext && !h.drewMarginByte {
+		logger.Infof("Flush: drawing margin byte '%c'", h.marginByte)
+
+		info, err := GetConsoleScreenBufferInfo(h.fd)
+		if err != nil {
+			return err
+		}
+
+		charInfo := []CHAR_INFO{{UnicodeChar: WCHAR(h.marginByte), Attributes: info.Attributes}}
+		size := COORD{1, 1}
+		position := COORD{0, 0}
+		region := SMALL_RECT{Left: info.CursorPosition.X, Top: info.CursorPosition.Y, Right: info.CursorPosition.X, Bottom: info.CursorPosition.Y}
+		if err := WriteConsoleOutput(h.fd, charInfo, size, position, &region); err != nil {
+			return err
+		}
+		h.drewMarginByte = true
+	}
+	return nil
+}
+
+// cacheConsoleInfo ensures that the current console screen information has been queried
+// since the last call to Flush(). It must be called before accessing h.curInfo or h.curPos.
+func (h *WindowsAnsiEventHandler) getCurrentInfo() (COORD, *CONSOLE_SCREEN_BUFFER_INFO, error) {
+	if h.curInfo == nil {
+		info, err := GetConsoleScreenBufferInfo(h.fd)
+		if err != nil {
+			return COORD{}, nil, err
+		}
+		h.curInfo = info
+		h.curPos = info.CursorPosition
+	}
+	return h.curPos, h.curInfo, nil
+}
+
+func (h *WindowsAnsiEventHandler) updatePos(pos COORD) {
+	if h.curInfo == nil {
+		panic("failed to call getCurrentInfo before calling updatePos")
+	}
+	h.curPos = pos
+}
+
+// clearWrap clears the state where the cursor is in the margin
+// waiting for the next character before wrapping the line. This must
+// be done before most operations that act on the cursor.
+func (h *WindowsAnsiEventHandler) clearWrap() {
+	h.wrapNext = false
+	h.drewMarginByte = false
+}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/doc.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/doc.go
@@ -7,7 +7,7 @@ The simplest way to use Logrus is simply the package-level exported logger:
   package main
 
   import (
-    log "github.com/Sirupsen/logrus"
+    log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
   )
 
   func main() {
@@ -21,6 +21,6 @@ The simplest way to use Logrus is simply the package-level exported logger:
 Output:
   time="2015-09-07T08:48:33Z" level=info msg="A walrus appears" animal=walrus number=1 size=10
 
-For a full guide visit https://github.com/Sirupsen/logrus
+For a full guide visit https://github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus
 */
 package logrus

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/json_formatter.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/json_formatter.go
@@ -16,7 +16,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		switch v := v.(type) {
 		case error:
 			// Otherwise errors are ignored by `encoding/json`
-			// https://github.com/Sirupsen/logrus/issues/137
+			// https://github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus/issues/137
 			data[k] = v.Error()
 		default:
 			data[k] = v

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/.travis.yml
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: go
+
+go:
+  - 1.3
+  - 1.4
+  - 1.5
+  - tip
+
+script:
+  - make ci

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/CHANGELOG.md
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/CHANGELOG.md
@@ -1,0 +1,22 @@
+1.0.4
+-----
+
+- Fix appengine integration broken by 1.0.3
+
+1.0.3
+-----
+
+- Allow any Logger with a Printf method.
+
+1.0.2
+-----
+
+- Use bugsnag copies of dependencies to avoid potential link rot
+
+1.0.1
+-----
+
+- gofmt/golint/govet docs improvements.
+
+1.0.0
+-----

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/CONTRIBUTING.md
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+Contributing
+============
+
+-   [Fork](https://help.github.com/articles/fork-a-repo) the [notifier on github](https://github.com/bugsnag/bugsnag-go)
+-   Build and test your changes
+-   Commit and push until you are happy with your contribution
+-   [Make a pull request](https://help.github.com/articles/using-pull-requests)
+-   Thanks!
+
+
+Installing the go development environment
+-------------------------------------
+
+1.  Install homebrew
+
+    ```
+    ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+    ```
+
+1. Install go
+
+    ```
+    brew install go --cross-compile-all
+    ```
+
+1. Configure `$GOPATH` in `~/.bashrc`
+
+    ```
+    export GOPATH="$HOME/go"
+    export PATH=$PATH:$GOPATH/bin
+    ```
+
+Installing the appengine development environment
+------------------------------------------------
+
+1. Follow the [Google instructions](https://cloud.google.com/appengine/downloads).
+
+Downloading the code
+--------------------
+
+You can download the code and its dependencies using
+
+```
+go get -t github.com/bugsnag/bugsnag-go
+```
+
+It will be put into "$GOPATH/src/github.com/bugsnag/bugsnag-go"
+
+Then install depend
+
+
+Running Tests
+-------------
+
+You can run the tests with
+
+```shell
+go test
+```
+
+If you've made significant changes, please also test the appengine integration with
+
+```shell
+goapp test
+```
+
+Releasing a New Version
+-----------------------
+
+If you are a project maintainer, you can build and release a new version of
+`bugsnag-go` as follows:
+
+1. Commit all your changes.
+2. Update the version number in `bugsnag.go`.
+3. Add an entry to `CHANGELOG.md` and update the README if necessary.
+4. commit tag and push
+
+    git commit -mv1.0.x && git tag v1.0.x && git push origin v1.0.x

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/LICENSE.txt
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2014 Bugsnag
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/Makefile
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/Makefile
@@ -1,0 +1,30 @@
+TEST?=./...
+
+default: alldeps test
+
+deps:
+	go get -v -d ./...
+
+alldeps:
+	go get -v -d -t ./...
+
+updatedeps:
+	go get -v -d -u ./...
+
+test: alldeps
+	go test
+	@go vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
+		go get golang.org/x/tools/cmd/vet; \
+	fi
+	@go vet $(TEST) ; if [ $$? -eq 1 ]; then \
+		echo "go-vet: Issues running go vet ./..."; \
+		exit 1; \
+	fi
+
+ci: alldeps test
+
+bench:
+	go test --bench=.*
+
+
+.PHONY: bin checkversion ci default deps generate releasebin test testacc testrace updatedeps

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/README.md
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/README.md
@@ -1,0 +1,553 @@
+# Bugsnag Notifier for Golang
+[![Latest Version](http://img.shields.io/github/release/bugsnag/bugsnag-go.svg?style=flat-square)](https://github.com/bugsnag/bugsnag-go/releases)
+[![Build Status](https://travis-ci.org/bugsnag/bugsnag-go.svg)](https://travis-ci.org/bugsnag/bugsnag-go)
+[![Go Documentation](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/bugsnag/bugsnag-go)
+
+The Bugsnag Notifier for Golang gives you instant notification of panics, or
+unexpected errors, in your golang app. Any unhandled panics will trigger a
+notification to be sent to your Bugsnag project.
+
+[Bugsnag](http://bugsnag.com) captures errors in real-time from your web,
+mobile and desktop applications, helping you to understand and resolve them
+as fast as possible. [Create a free account](http://bugsnag.com) to start
+capturing exceptions from your applications.
+
+## How to Install
+
+1. Download the code
+
+    ```shell
+    go get github.com/bugsnag/bugsnag-go
+    ```
+
+### Using with net/http apps
+
+For a golang app based on [net/http](https://godoc.org/net/http), integrating
+Bugsnag takes two steps. You should also use these instructions if you're using
+the [gorilla toolkit](http://www.gorillatoolkit.org/), or the
+[pat](https://github.com/bmizerany/pat/) muxer.
+
+1. Configure bugsnag at the start of your `main()` function:
+
+    ```go
+    import "github.com/bugsnag/bugsnag-go"
+
+    func main() {
+        bugsnag.Configure(bugsnag.Configuration{
+            APIKey: "YOUR_API_KEY_HERE",
+            ReleaseStage: "production",
+            // more configuration options
+        })
+
+        // rest of your program.
+    }
+    ```
+
+2. Wrap your server in a [bugsnag.Handler](https://godoc.org/github.com/bugsnag/bugsnag-go/#Handler)
+
+    ```go
+    // a. If you're using the builtin http mux, you can just pass
+    //    bugsnag.Handler(nil) to http.ListenAndServer
+    http.ListenAndServe(":8080", bugsnag.Handler(nil))
+
+    // b. If you're creating a server manually yourself, you can set
+    //    its handlers the same way
+    srv := http.Server{
+        Handler: bugsnag.Handler(nil)
+    }
+
+    // c. If you're not using the builtin http mux, wrap your own handler
+    // (though make sure that it doesn't already catch panics)
+    http.ListenAndServe(":8080", bugsnag.Handler(handler))
+    ```
+
+### Using with Revel apps
+
+There are two steps to get panic handling in [revel](https://revel.github.io) apps.
+
+1. Add the `bugsnagrevel.Filter` immediately after the `revel.PanicFilter` in `app/init.go`:
+
+    ```go
+
+    import "github.com/bugsnag/bugsnag-go/revel"
+
+    revel.Filters = []revel.Filter{
+        revel.PanicFilter,
+        bugsnagrevel.Filter,
+        // ...
+    }
+    ```
+
+2. Set bugsnag.apikey in the top section of `conf/app.conf`.
+
+    ```
+    module.static=github.com/revel/revel/modules/static
+
+    bugsnag.apikey=YOUR_API_KEY_HERE
+
+    [dev]
+    ```
+
+### Using with martini apps
+
+1. Add `bugsnagmartini.AutoNotify` immediately after the `martini.Recovery` middleware in `main.go`.
+This causes unhandled panics to notify bugsnag.
+
+    ```go
+
+    import "github.com/bugsnag/bugsnag-go/martini"
+
+    func main() {
+
+        m.Use(martini.Recover()
+
+        m.Use(bugsnagmartini.AutoNotify(bugsnag.Configuration{
+            APIKey: "YOUR_API_KEY_HERE",
+        }))
+    }
+    ```
+
+2. Use `bugsnag` from the context injection if you need to notify about non-fatal errors.
+
+    ```
+    func MyHandler(r *http.Request, bugsnag *bugsnag.Notifier) string {
+        bugsnag.Notify(err);
+    }
+    ```
+
+### Using with Google App Engine
+
+1. Configure bugsnag at the start of your `init()` function:
+
+    ```go
+    import "github.com/bugsnag/bugsnag-go"
+
+    func init() {
+        bugsnag.Configure(bugsnag.Configuration{
+            APIKey: "YOUR_API_KEY_HERE",
+        })
+
+        // ...
+    }
+    ```
+
+2. Wrap *every* http.Handler or http.HandlerFunc with Bugsnag:
+
+    ```go
+    // a. If you're using HandlerFuncs
+    http.HandleFunc("/", bugsnag.HandlerFunc(
+        func (w http.ResponseWriter, r *http.Request) {
+            // ...
+        }))
+
+    // b. If you're using Handlers
+    http.Handle("/", bugsnag.Handler(myHttpHandler))
+    ```
+
+3. In order to use Bugsnag, you must provide the current
+[`appengine.Context`](https://developers.google.com/appengine/docs/go/reference#Context), or
+current `*http.Request` as rawData (This is done automatically for `bugsnag.Handler` and `bugsnag.HandlerFunc`).
+The easiest way to do this is to create a new instance of the notifier.
+
+    ```go
+    c := appengine.NewContext(r)
+    notifier := bugsnag.New(c)
+
+    if err != nil {
+        notifier.Notify(err)
+    }
+
+    go func () {
+        defer notifier.Recover()
+
+        // ...
+    }()
+    ```
+
+
+## Notifying Bugsnag manually
+
+Bugsnag will automatically handle any panics that crash your program and notify
+you of them. If you've integrated with `revel` or `net/http`, then you'll also
+be notified of any panics() that happen while processing a request.
+
+Sometimes however it's useful to manually notify Bugsnag of a problem. To do this,
+call [`bugsnag.Notify()`](https://godoc.org/github.com/bugsnag/bugsnag-go/#Notify)
+
+```go
+if err != nil {
+    bugsnag.Notify(err)
+}
+```
+
+### Manual panic handling
+
+To avoid a panic in a goroutine from crashing your entire app, you can use
+[`bugsnag.Recover()`](https://godoc.org/github.com/bugsnag/bugsnag-go/#Recover)
+to stop a panic from unwinding the stack any further. When `Recover()` is hit,
+it will send any current panic to Bugsnag and then stop panicking. This is
+most useful at the start of a goroutine:
+
+```go
+go func() {
+    defer bugsnag.Recover()
+
+    // ...
+}()
+```
+
+Alternatively you can use
+[`bugsnag.AutoNotify()`](https://godoc.org/github.com/bugsnag/bugsnag-go/#Recover)
+to notify bugsnag of a panic while letting the program continue to panic. This
+is useful if you're using a Framework that already has some handling of panics
+and you are retrofitting bugsnag support.
+
+```go
+defer bugsnag.AutoNotify()
+```
+
+## Sending Custom Data
+
+Most functions in the Bugsnag API, including `bugsnag.Notify()`,
+`bugsnag.Recover()`, `bugsnag.AutoNotify()`, and `bugsnag.Handler()` let you
+attach data to the notifications that they send. To do this you pass in rawData,
+which can be any of the supported types listed here. To add support for more
+types of rawData see [OnBeforeNotify](#custom-data-with-onbeforenotify).
+
+### Custom MetaData
+
+Custom metaData appears as tabs on Bugsnag.com. You can set it by passing
+a [`bugsnag.MetaData`](https://godoc.org/github.com/bugsnag/bugsnag-go/#MetaData)
+object as rawData.
+
+```go
+bugsnag.Notify(err,
+    bugsnag.MetaData{
+        "Account": {
+            "Name": Account.Name,
+            "Paying": Account.Plan.Premium,
+        },
+    })
+```
+
+### Request data
+
+Bugsnag can extract interesting data from
+[`*http.Request`](https://godoc.org/net/http/#Request) objects, and
+[`*revel.Controller`](https://godoc.org/github.com/revel/revel/#Controller)
+objects. These are automatically passed in when handling panics, and you can
+pass them yourself.
+
+```go
+func (w http.ResponseWriter, r *http.Request) {
+    bugsnag.Notify(err, r)
+}
+```
+
+### User data
+
+User data is searchable, and the `Id` powers the count of users affected. You
+can set which user an error affects by passing a
+[`bugsnag.User`](https://godoc.org/github.com/bugsnag/bugsnag-go/#User) object as
+rawData.
+
+```go
+bugsnag.Notify(err,
+    bugsnag.User{Id: "1234", Name: "Conrad", Email: "me@cirw.in"})
+```
+
+### Error Class
+
+Errors in your Bugsnag dashboard are grouped by their "error class" and by line number.
+You can override the error class by passing a
+[`bugsnag.ErrorClass`](https://godoc.org/github.com/bugsnag/bugsnag-go/#ErrorClass) object as
+rawData.
+
+```go
+bugsnag.Notify(err, bugsnag.ErrorClass{"I/O Timeout"})
+```
+
+### Context
+
+The context shows up prominently in the list view so that you can get an idea
+of where a problem occurred. You can set it by passing a
+[`bugsnag.Context`](https://godoc.org/github.com/bugsnag/bugsnag-go/#Context)
+object as rawData.
+
+```go
+bugsnag.Notify(err, bugsnag.Context{"backgroundJob"})
+```
+
+### Severity
+
+Bugsnag supports three severities, `SeverityError`, `SeverityWarning`, and `SeverityInfo`.
+You can set the severity of an error by passing one of these objects as rawData.
+
+```go
+bugsnag.Notify(err, bugsnag.SeverityInfo)
+```
+
+## Configuration
+
+You must call `bugsnag.Configure()` at the start of your program to use Bugsnag, you pass it
+a [`bugsnag.Configuration`](https://godoc.org/github.com/bugsnag/bugsnag-go/#Configuration) object
+containing any of the following values.
+
+### APIKey
+
+The Bugsnag API key can be found on your [Bugsnag dashboard](https://bugsnag.com) under "Settings".
+
+```go
+bugsnag.Configure(bugsnag.Configuration{
+    APIKey: "YOUR_API_KEY_HERE",
+})
+```
+
+### Endpoint
+
+The Bugsnag endpoint defaults to `https://notify.bugsnag.com/`. If you're using Bugsnag enterprise,
+you should set this to the endpoint of your local instance.
+
+```go
+bugsnag.Configure(bugsnag.Configuration{
+    Endpoint: "http://bugsnag.internal:49000/",
+})
+```
+
+### ReleaseStage
+
+The ReleaseStage tracks where your app is deployed. You should set this to `production`, `staging`,
+`development` or similar as appropriate.
+
+```go
+bugsnag.Configure(bugsnag.Configuration{
+    ReleaseStage: "development",
+})
+```
+
+### NotifyReleaseStages
+
+The list of ReleaseStages to notify in. By default Bugsnag will notify you in all release stages, but
+you can use this to silence development errors.
+
+```go
+bugsnag.Configure(bugsnag.Configuration{
+    NotifyReleaseStages: []string{"production", "staging"},
+})
+```
+
+### AppVersion
+
+If you use a versioning scheme for deploys of your app, Bugsnag can use the `AppVersion` to only
+re-open errors if they occur in later version of the app.
+
+```go
+bugsnag.Configure(bugsnag.Configuration{
+    AppVersion: "1.2.3",
+})
+```
+
+### Hostname
+
+The hostname is used to track where exceptions are coming from in the Bugsnag dashboard. The
+default value is obtained from `os.Hostname()` so you won't often need to change this.
+
+```go
+bugsnag.Configure(bugsnag.Configuration{
+    Hostname: "go1",
+})
+```
+
+### ProjectPackages
+
+In order to determine where a crash happens Bugsnag needs to know which packages you consider to
+be part of your app (as opposed to a library). By default this is set to `[]string{"main*"}`. Strings
+are matched to package names using [`filepath.Match`](http://godoc.org/path/filepath#Match).
+
+For matching subpackages within a package you may use the `**` notation. For example, `github.com/domain/package/**` will match all subpackages under `package/`.
+
+```go
+bugsnag.Configure(bugsnag.Configuration{
+    ProjectPackages: []string{"main", "github.com/domain/myapp/*"},
+}
+```
+
+### ParamsFilters
+
+Sometimes sensitive data is accidentally included in Bugsnag MetaData. You can remove it by
+setting `ParamsFilters`. Any key in the `MetaData` that includes any string in the filters
+will be redacted. The default is `[]string{"password", "secret"}`, which prevents fields like
+`password`, `password_confirmation` and `secret_answer` from being sent.
+
+```go
+bugsnag.Configure(bugsnag.Configuration{
+    ParamsFilters: []string{"password", "secret"},
+}
+```
+
+### Logger
+
+The Logger to write to in case of an error inside Bugsnag. This defaults to the global logger.
+
+```go
+bugsnag.Configure(bugsnag.Configuration{
+    Logger: app.Logger,
+}
+```
+
+### PanicHandler
+
+The first time Bugsnag is configured, it wraps the running program in a panic
+handler using [panicwrap](http://godoc.org/github.com/ConradIrwin/panicwrap). This
+forks a sub-process which monitors unhandled panics. To prevent this, set
+`PanicHandler` to `func() {}` the first time you call
+`bugsnag.Configure`. This will prevent bugsnag from being able to notify you about
+unhandled panics.
+
+```go
+bugsnag.Configure(bugsnag.Configuration{
+    PanicHandler: func() {},
+})
+```
+
+### Synchronous
+
+Bugsnag usually starts a new goroutine before sending notifications. This means
+that notifications can be lost if you do a bugsnag.Notify and then immediately
+os.Exit. To avoid this problem, set Bugsnag to Synchronous (or just `panic()`
+instead ;).
+
+```go
+bugsnag.Configure(bugsnag.Configuration{
+    Synchronous: true
+})
+```
+
+Or just for one error:
+
+```go
+bugsnag.Notify(err, bugsnag.Configuration{Synchronous: true})
+```
+
+### Transport
+
+The transport configures how Bugsnag makes http requests. By default we use
+[`http.DefaultTransport`](http://godoc.org/net/http#RoundTripper) which handles
+HTTP proxies automatically using the `$HTTP_PROXY` environment variable.
+
+```go
+bugsnag.Configure(bugsnag.Configuration{
+    Transport: http.DefaultTransport,
+})
+```
+
+## Custom data with OnBeforeNotify
+
+While it's nice that you can pass `MetaData` directly into `bugsnag.Notify`,
+`bugsnag.AutoNotify`, and `bugsnag.Recover`, this can be a bit cumbersome and
+inefficient — you're constructing the meta-data whether or not it will actually
+be used.  A better idea is to pass raw data in to these functions, and add an
+`OnBeforeNotify` filter that converts them into `MetaData`.
+
+For example, lets say our system processes jobs:
+
+```go
+type Job struct{
+    Retry     bool
+    UserId    string
+    UserEmail string
+    Name      string
+    Params    map[string]string
+}
+```
+
+You can pass a job directly into Bugsnag.notify:
+
+```go
+bugsnag.Notify(err, job)
+```
+
+And then add a filter to extract information from that job and attach it to the
+Bugsnag event:
+
+```go
+bugsnag.OnBeforeNotify(
+    func(event *bugsnag.Event, config *bugsnag.Configuration) error {
+
+        // Search all the RawData for any *Job pointers that we're passed in
+        // to bugsnag.Notify() and friends.
+        for _, datum := range event.RawData {
+            if job, ok := datum.(*Job); ok {
+                // don't notify bugsnag about errors in retries
+                if job.Retry {
+                    return fmt.Errorf("not notifying about retried jobs")
+                }
+
+                // add the job as a tab on Bugsnag.com
+                event.MetaData.AddStruct("Job", job)
+
+                // set the user correctly
+                event.User = &User{Id: job.UserId, Email: job.UserEmail}
+            }
+        }
+
+        // continue notifying as normal
+        return nil
+    })
+```
+
+## Advanced Usage
+
+If you want to have multiple different configurations around in one program,
+you can use `bugsnag.New()` to create multiple independent instances of
+Bugsnag. You can use these without calling `bugsnag.Configure()`, but bear in
+mind that until you call `bugsnag.Configure()` unhandled panics will not be
+sent to bugsnag.
+
+```go
+notifier := bugsnag.New(bugsnag.Configuration{
+    APIKey: "YOUR_OTHER_API_KEY",
+})
+```
+
+In fact any place that lets you pass in `rawData` also allows you to pass in
+configuration.  For example to send http errors to one bugsnag project, you
+could do:
+
+```go
+bugsnag.Handler(nil, bugsnag.Configuration{APIKey: "YOUR_OTHER_API_KEY"})
+```
+
+### GroupingHash
+
+If you need to override Bugsnag's grouping algorithm, you can set the
+`GroupingHash` in an `OnBeforeNotify`:
+
+```go
+bugsnag.OnBeforeNotify(
+    func (event *bugsnag.Event, config *bugsnag.Configuration) error {
+        event.GroupingHash = calculateGroupingHash(event)
+        return nil
+    })
+```
+
+### Skipping lines in stacktrace
+
+If you have your own logging wrapper all of your errors will appear to
+originate from inside it. You can avoid this problem by constructing
+an error with a stacktrace manually, and then passing that to Bugsnag.notify:
+
+```go
+import (
+    "github.com/bugsnag/bugsnag-go"
+    "github.com/bugsnag/bugsnag-go/errors"
+)
+
+func LogError(e error) {
+    // 1 removes one line of stacktrace, so the caller of LogError
+    // will be at the top.
+    e = errors.New(e, 1)
+    bugsnag.Notify(e)
+}
+```
+

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/appengine.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/appengine.go
@@ -1,0 +1,81 @@
+// +build appengine
+
+package bugsnag
+
+import (
+	"appengine"
+	"appengine/urlfetch"
+	"appengine/user"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func defaultPanicHandler() {}
+
+func init() {
+	OnBeforeNotify(appengineMiddleware)
+}
+
+func appengineMiddleware(event *Event, config *Configuration) (err error) {
+	var c appengine.Context
+
+	for _, datum := range event.RawData {
+		if r, ok := datum.(*http.Request); ok {
+			c = appengine.NewContext(r)
+			break
+		} else if context, ok := datum.(appengine.Context); ok {
+			c = context
+			break
+		}
+	}
+
+	if c == nil {
+		return fmt.Errorf("No appengine context given")
+	}
+
+	// You can only use the builtin http library if you pay for appengine,
+	// so we use the appengine urlfetch service instead.
+	config.Transport = &urlfetch.Transport{
+		Context: c,
+	}
+
+	// Anything written to stderr/stdout is discarded, so lets log to the request.
+
+	if configuredLogger, ok := config.Logger.(*log.Logger); ok {
+		config.Logger = log.New(appengineWriter{c}, configuredLogger.Prefix(), configuredLogger.Flags())
+	} else {
+		config.Logger = log.New(appengineWriter{c}, log.Prefix(), log.Flags())
+	}
+
+	// Set the releaseStage appropriately
+	if config.ReleaseStage == "" {
+		if appengine.IsDevAppServer() {
+			config.ReleaseStage = "development"
+		} else {
+			config.ReleaseStage = "production"
+		}
+	}
+
+	if event.User == nil {
+		u := user.Current(c)
+		if u != nil {
+			event.User = &User{
+				Id:    u.ID,
+				Email: u.Email,
+			}
+		}
+	}
+
+	return nil
+}
+
+// Convert an appengine.Context into an io.Writer so we can create a log.Logger.
+type appengineWriter struct {
+	appengine.Context
+}
+
+func (c appengineWriter) Write(b []byte) (int, error) {
+	c.Warningf(string(b))
+	return len(b), nil
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/appengine_test.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/appengine_test.go
@@ -1,0 +1,21 @@
+// +build appengine
+
+package bugsnag
+
+import (
+	"appengine/aetest"
+)
+
+func init() {
+	c, err := aetest.NewContext(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	OnBeforeNotify(func(event *Event, config *Configuration) error {
+
+		event.RawData = append(event.RawData, c)
+
+		return nil
+	})
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/bugsnag.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/bugsnag.go
@@ -1,0 +1,131 @@
+package bugsnag
+
+import (
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+
+	// Fixes a bug with SHA-384 intermediate certs on some platforms.
+	// - https://github.com/bugsnag/bugsnag-go/issues/9
+	_ "crypto/sha512"
+)
+
+// The current version of bugsnag-go.
+const VERSION = "1.0.3"
+
+var once sync.Once
+var middleware middlewareStack
+
+// The configuration for the default bugsnag notifier.
+var Config Configuration
+
+var defaultNotifier = Notifier{&Config, nil}
+
+// Configure Bugsnag. The only required setting is the APIKey, which can be
+// obtained by clicking on "Settings" in your Bugsnag dashboard. This function
+// is also responsible for installing the global panic handler, so it should be
+// called as early as possible in your initialization process.
+func Configure(config Configuration) {
+	Config.update(&config)
+	once.Do(Config.PanicHandler)
+}
+
+// Notify sends an error to Bugsnag along with the current stack trace. The
+// rawData is used to send extra information along with the error. For example
+// you can pass the current http.Request to Bugsnag to see information about it
+// in the dashboard, or set the severity of the notification.
+func Notify(err error, rawData ...interface{}) error {
+	return defaultNotifier.Notify(errors.New(err, 1), rawData...)
+}
+
+// AutoNotify logs a panic on a goroutine and then repanics.
+// It should only be used in places that have existing panic handlers further
+// up the stack. See bugsnag.Recover().  The rawData is used to send extra
+// information along with any panics that are handled this way.
+// Usage: defer bugsnag.AutoNotify()
+func AutoNotify(rawData ...interface{}) {
+	if err := recover(); err != nil {
+		rawData = defaultNotifier.addDefaultSeverity(rawData, SeverityError)
+		defaultNotifier.Notify(errors.New(err, 2), rawData...)
+		panic(err)
+	}
+}
+
+// Recover logs a panic on a goroutine and then recovers.
+// The rawData is used to send extra information along with
+// any panics that are handled this way
+// Usage: defer bugsnag.Recover()
+func Recover(rawData ...interface{}) {
+	if err := recover(); err != nil {
+		rawData = defaultNotifier.addDefaultSeverity(rawData, SeverityWarning)
+		defaultNotifier.Notify(errors.New(err, 2), rawData...)
+	}
+}
+
+// OnBeforeNotify adds a callback to be run before a notification is sent to
+// Bugsnag.  It can be used to modify the event or its MetaData. Changes made
+// to the configuration are local to notifying about this event. To prevent the
+// event from being sent to Bugsnag return an error, this error will be
+// returned from bugsnag.Notify() and the event will not be sent.
+func OnBeforeNotify(callback func(event *Event, config *Configuration) error) {
+	middleware.OnBeforeNotify(callback)
+}
+
+// Handler creates an http Handler that notifies Bugsnag any panics that
+// happen. It then repanics so that the default http Server panic handler can
+// handle the panic too. The rawData is used to send extra information along
+// with any panics that are handled this way.
+func Handler(h http.Handler, rawData ...interface{}) http.Handler {
+	notifier := New(rawData...)
+	if h == nil {
+		h = http.DefaultServeMux
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer notifier.AutoNotify(r)
+		h.ServeHTTP(w, r)
+	})
+}
+
+// HandlerFunc creates an http HandlerFunc that notifies Bugsnag about any
+// panics that happen. It then repanics so that the default http Server panic
+// handler can handle the panic too. The rawData is used to send extra
+// information along with any panics that are handled this way. If you have
+// already wrapped your http server using bugsnag.Handler() you don't also need
+// to wrap each HandlerFunc.
+func HandlerFunc(h http.HandlerFunc, rawData ...interface{}) http.HandlerFunc {
+	notifier := New(rawData...)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer notifier.AutoNotify(r)
+		h(w, r)
+	}
+}
+
+func init() {
+	// Set up builtin middlewarez
+	OnBeforeNotify(httpRequestMiddleware)
+
+	// Default configuration
+	Config.update(&Configuration{
+		APIKey:        "",
+		Endpoint:      "https://notify.bugsnag.com/",
+		Hostname:      "",
+		AppVersion:    "",
+		ReleaseStage:  "",
+		ParamsFilters: []string{"password", "secret"},
+		// * for app-engine
+		ProjectPackages:     []string{"main*"},
+		NotifyReleaseStages: nil,
+		Logger:              log.New(os.Stdout, log.Prefix(), log.Flags()),
+		PanicHandler:        defaultPanicHandler,
+		Transport:           http.DefaultTransport,
+	})
+
+	hostname, err := os.Hostname()
+	if err == nil {
+		Config.Hostname = hostname
+	}
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/bugsnag_test.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/bugsnag_test.go
@@ -1,0 +1,478 @@
+package bugsnag
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bitly/go-simplejson"
+)
+
+func TestConfigure(t *testing.T) {
+	Configure(Configuration{
+		APIKey: testAPIKey,
+	})
+
+	if Config.APIKey != testAPIKey {
+		t.Errorf("Setting APIKey didn't work")
+	}
+
+	if New().Config.APIKey != testAPIKey {
+		t.Errorf("Setting APIKey didn't work for new notifiers")
+	}
+}
+
+var postedJSON = make(chan []byte, 10)
+var testOnce sync.Once
+var testEndpoint string
+var testAPIKey = "166f5ad3590596f9aa8d601ea89af845"
+
+func startTestServer() {
+	testOnce.Do(func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				panic(err)
+			}
+			postedJSON <- body
+		})
+
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			panic(err)
+		}
+		testEndpoint = "http://" + l.Addr().String() + "/"
+
+		go http.Serve(l, mux)
+	})
+}
+
+type _recurse struct {
+	*_recurse
+}
+
+func TestNotify(t *testing.T) {
+	startTestServer()
+
+	recurse := _recurse{}
+	recurse._recurse = &recurse
+
+	OnBeforeNotify(func(event *Event, config *Configuration) error {
+		if event.Context == "testing" {
+			event.GroupingHash = "lol"
+		}
+		return nil
+	})
+
+	Notify(fmt.Errorf("hello world"),
+		Configuration{
+			APIKey:          testAPIKey,
+			Endpoint:        testEndpoint,
+			ReleaseStage:    "test",
+			AppVersion:      "1.2.3",
+			Hostname:        "web1",
+			ProjectPackages: []string{"github.com/bugsnag/bugsnag-go"},
+		},
+		User{Id: "123", Name: "Conrad", Email: "me@cirw.in"},
+		Context{"testing"},
+		MetaData{"test": {
+			"password": "sneaky",
+			"value":    "able",
+			"broken":   complex(1, 2),
+			"recurse":  recurse,
+		}},
+	)
+
+	json, err := simplejson.NewJson(<-postedJSON)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if json.Get("apiKey").MustString() != testAPIKey {
+		t.Errorf("Wrong api key in payload")
+	}
+
+	if json.GetPath("notifier", "name").MustString() != "Bugsnag Go" {
+		t.Errorf("Wrong notifier name in payload")
+	}
+
+	event := json.Get("events").GetIndex(0)
+
+	for k, value := range map[string]string{
+		"payloadVersion":                 "2",
+		"severity":                       "warning",
+		"context":                        "testing",
+		"groupingHash":                   "lol",
+		"app.releaseStage":               "test",
+		"app.version":                    "1.2.3",
+		"device.hostname":                "web1",
+		"user.id":                        "123",
+		"user.name":                      "Conrad",
+		"user.email":                     "me@cirw.in",
+		"metaData.test.password":         "[REDACTED]",
+		"metaData.test.value":            "able",
+		"metaData.test.broken":           "[complex128]",
+		"metaData.test.recurse._recurse": "[RECURSION]",
+	} {
+		key := strings.Split(k, ".")
+		if event.GetPath(key...).MustString() != value {
+			t.Errorf("Wrong %v: %v != %v", key, event.GetPath(key...).MustString(), value)
+		}
+	}
+
+	exception := event.Get("exceptions").GetIndex(0)
+
+	if exception.Get("message").MustString() != "hello world" {
+		t.Errorf("Wrong message in payload")
+	}
+
+	if exception.Get("errorClass").MustString() != "*errors.errorString" {
+		t.Errorf("Wrong errorClass in payload: %v", exception.Get("errorClass").MustString())
+	}
+
+	frame0 := exception.Get("stacktrace").GetIndex(0)
+	if frame0.Get("file").MustString() != "bugsnag_test.go" ||
+		frame0.Get("method").MustString() != "TestNotify" ||
+		frame0.Get("inProject").MustBool() != true ||
+		frame0.Get("lineNumber").MustInt() == 0 {
+		t.Errorf("Wrong frame0")
+	}
+
+	frame1 := exception.Get("stacktrace").GetIndex(1)
+
+	if frame1.Get("file").MustString() != "testing/testing.go" ||
+		frame1.Get("method").MustString() != "tRunner" ||
+		frame1.Get("inProject").MustBool() != false ||
+		frame1.Get("lineNumber").MustInt() == 0 {
+		t.Errorf("Wrong frame1")
+	}
+}
+
+func crashyHandler(w http.ResponseWriter, r *http.Request) {
+	c := make(chan int)
+	close(c)
+	c <- 1
+}
+
+func runCrashyServer(rawData ...interface{}) (net.Listener, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", crashyHandler)
+	srv := http.Server{
+		Addr:     l.Addr().String(),
+		Handler:  Handler(mux, rawData...),
+		ErrorLog: log.New(ioutil.Discard, log.Prefix(), 0),
+	}
+
+	go srv.Serve(l)
+	return l, err
+}
+
+func TestHandler(t *testing.T) {
+	startTestServer()
+
+	l, err := runCrashyServer(Configuration{
+		APIKey:          testAPIKey,
+		Endpoint:        testEndpoint,
+		ProjectPackages: []string{"github.com/bugsnag/bugsnag-go"},
+		Logger:          log.New(ioutil.Discard, log.Prefix(), log.Flags()),
+	}, SeverityInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	http.Get("http://" + l.Addr().String() + "/ok?foo=bar")
+	l.Close()
+
+	json, err := simplejson.NewJson(<-postedJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if json.Get("apiKey").MustString() != testAPIKey {
+		t.Errorf("Wrong api key in payload")
+	}
+
+	if json.GetPath("notifier", "name").MustString() != "Bugsnag Go" {
+		t.Errorf("Wrong notifier name in payload")
+	}
+
+	event := json.Get("events").GetIndex(0)
+
+	for k, value := range map[string]string{
+		"payloadVersion":          "2",
+		"severity":                "info",
+		"user.id":                 "127.0.0.1",
+		"metaData.Request.Url":    "http://" + l.Addr().String() + "/ok?foo=bar",
+		"metaData.Request.Method": "GET",
+	} {
+		key := strings.Split(k, ".")
+		if event.GetPath(key...).MustString() != value {
+			t.Errorf("Wrong %v: %v != %v", key, event.GetPath(key...).MustString(), value)
+		}
+	}
+
+	if event.GetPath("metaData", "Request", "Params", "foo").GetIndex(0).MustString() != "bar" {
+		t.Errorf("missing GET params in request metadata")
+	}
+
+	if event.GetPath("metaData", "Headers", "Accept-Encoding").GetIndex(0).MustString() != "gzip" {
+		t.Errorf("missing GET params in request metadata: %v", event.GetPath("metaData", "Headers"))
+	}
+
+	exception := event.Get("exceptions").GetIndex(0)
+
+	if !strings.Contains(exception.Get("message").MustString(), "send on closed channel") {
+		t.Errorf("Wrong message in payload: %v '%v'", exception.Get("message").MustString(), "runtime error: send on closed channel")
+	}
+
+	errorClass := exception.Get("errorClass").MustString()
+	if errorClass != "runtime.errorCString" && errorClass != "*errors.errorString" {
+		t.Errorf("Wrong errorClass in payload: %v, '%v'", exception.Get("errorClass").MustString(), "runtime.errorCString")
+	}
+
+	frame0 := exception.Get("stacktrace").GetIndex(0)
+
+	file0 := frame0.Get("file").MustString()
+	if !strings.HasPrefix(file0, "runtime/panic") ||
+		frame0.Get("inProject").MustBool() != false {
+		t.Errorf("Wrong frame0: %v", frame0)
+	}
+
+	frame3 := exception.Get("stacktrace").GetIndex(3)
+
+	if frame3.Get("file").MustString() != "bugsnag_test.go" ||
+		frame3.Get("method").MustString() != "crashyHandler" ||
+		frame3.Get("inProject").MustBool() != true ||
+		frame3.Get("lineNumber").MustInt() == 0 {
+		t.Errorf("Wrong frame3: %v", frame3)
+	}
+}
+
+func TestAutoNotify(t *testing.T) {
+
+	var panicked interface{}
+
+	func() {
+		defer func() {
+			panicked = recover()
+		}()
+		defer AutoNotify(Configuration{Endpoint: testEndpoint, APIKey: testAPIKey})
+
+		panic("eggs")
+	}()
+
+	if panicked.(string) != "eggs" {
+		t.Errorf("didn't re-panic")
+	}
+
+	json, err := simplejson.NewJson(<-postedJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event := json.Get("events").GetIndex(0)
+
+	if event.Get("severity").MustString() != "error" {
+		t.Errorf("severity should be error")
+	}
+	exception := event.Get("exceptions").GetIndex(0)
+
+	if exception.Get("message").MustString() != "eggs" {
+		t.Errorf("caught wrong panic")
+	}
+}
+
+func TestRecover(t *testing.T) {
+	var panicked interface{}
+
+	func() {
+		defer func() {
+			panicked = recover()
+		}()
+		defer Recover(Configuration{Endpoint: testEndpoint, APIKey: testAPIKey})
+
+		panic("ham")
+	}()
+
+	if panicked != nil {
+		t.Errorf("re-panick'd")
+	}
+
+	json, err := simplejson.NewJson(<-postedJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event := json.Get("events").GetIndex(0)
+
+	if event.Get("severity").MustString() != "warning" {
+		t.Errorf("severity should be warning")
+	}
+	exception := event.Get("exceptions").GetIndex(0)
+
+	if exception.Get("message").MustString() != "ham" {
+		t.Errorf("caught wrong panic")
+	}
+}
+
+func handleGet(w http.ResponseWriter, r *http.Request) {
+	fmt.Println("Handling GET")
+}
+
+var createAccount = handleGet
+
+type _job struct {
+	Name    string
+	Process func()
+}
+
+func ExampleAutoNotify() {
+	f := func(w http.ResponseWriter, request *http.Request) {
+		defer AutoNotify(request, Context{"createAccount"})
+
+		createAccount(w, request)
+	}
+	var w http.ResponseWriter
+	var request *http.Request
+	f(w, request)
+	// Output:
+	// Handling GET
+}
+
+func ExampleRecover() {
+	job := _job{
+		Name: "Example",
+		Process: func() {
+			fmt.Println("About to panic")
+			panic("Oh noes")
+		},
+	}
+
+	func() {
+		defer Recover(Configuration{Endpoint: testEndpoint, APIKey: testAPIKey})
+		job.Process()
+	}()
+	fmt.Println("Panic recovered")
+	// Output:
+	// About to panic
+	// Panic recovered
+}
+
+func ExampleConfigure() {
+	Configure(Configuration{
+		APIKey: "YOUR_API_KEY_HERE",
+
+		ReleaseStage: "production",
+
+		// See Configuration{} for other fields
+	})
+}
+
+func ExampleHandler() {
+	// Set up your http handlers as usual
+	http.HandleFunc("/", handleGet)
+
+	// use bugsnag.Handler(nil) to wrap the default http handlers
+	// so that Bugsnag is automatically notified about panics.
+	http.ListenAndServe(":1234", Handler(nil))
+}
+
+func ExampleHandler_customServer() {
+	// If you're using a custom server, set the handlers explicitly.
+	http.HandleFunc("/", handleGet)
+
+	srv := http.Server{
+		Addr:        ":1234",
+		ReadTimeout: 10 * time.Second,
+		// use bugsnag.Handler(nil) to wrap the default http handlers
+		// so that Bugsnag is automatically notified about panics.
+		Handler: Handler(nil),
+	}
+	srv.ListenAndServe()
+}
+
+func ExampleHandler_customHandlers() {
+	// If you're using custom handlers, wrap the handlers explicitly.
+	handler := http.NewServeMux()
+	http.HandleFunc("/", handleGet)
+	// use bugsnag.Handler(handler) to wrap the handlers so that Bugsnag is
+	// automatically notified about panics
+	http.ListenAndServe(":1234", Handler(handler))
+}
+
+func ExampleNotify() {
+	_, err := net.Listen("tcp", ":80")
+
+	if err != nil {
+		Notify(err)
+	}
+}
+
+func ExampleNotify_details() {
+	_, err := net.Listen("tcp", ":80")
+	userID := "123456789"
+
+	if err != nil {
+		Notify(err,
+			// show as low-severity
+			SeverityInfo,
+			// set the context
+			Context{"createlistener"},
+			// pass the user id in to count users affected.
+			User{Id: userID},
+			// custom meta-data tab
+			MetaData{
+				"Listen": {
+					"Protocol": "tcp",
+					"Port":     "80",
+				},
+			},
+		)
+	}
+
+}
+
+type Job struct {
+	Retry     bool
+	UserId    string
+	UserEmail string
+	Name      string
+	Params    map[string]string
+}
+
+func ExampleOnBeforeNotify() {
+	OnBeforeNotify(func(event *Event, config *Configuration) error {
+
+		// Search all the RawData for any *Job pointers that we're passed in
+		// to bugsnag.Notify() and friends.
+		for _, datum := range event.RawData {
+			if job, ok := datum.(*Job); ok {
+				// don't notify bugsnag about errors in retries
+				if job.Retry {
+					return fmt.Errorf("bugsnag middleware: not notifying about job retry")
+				}
+
+				// add the job as a tab on Bugsnag.com
+				event.MetaData.AddStruct("Job", job)
+
+				// set the user correctly
+				event.User = &User{Id: job.UserId, Email: job.UserEmail}
+			}
+		}
+
+		// continue notifying as normal
+		return nil
+	})
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/configuration.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/configuration.go
@@ -1,0 +1,169 @@
+package bugsnag
+
+import (
+	"log"
+	"net/http"
+	"path/filepath"
+	"strings"
+)
+
+// Configuration sets up and customizes communication with the Bugsnag API.
+type Configuration struct {
+	// Your Bugsnag API key, e.g. "c9d60ae4c7e70c4b6c4ebd3e8056d2b8". You can
+	// find this by clicking Settings on https://bugsnag.com/.
+	APIKey string
+	// The Endpoint to notify about crashes. This defaults to
+	// "https://notify.bugsnag.com/", if you're using Bugsnag Enterprise then
+	// set it to your internal Bugsnag endpoint.
+	Endpoint string
+
+	// The current release stage. This defaults to "production" and is used to
+	// filter errors in the Bugsnag dashboard.
+	ReleaseStage string
+	// The currently running version of the app. This is used to filter errors
+	// in the Bugsnag dasboard. If you set this then Bugsnag will only re-open
+	// resolved errors if they happen in different app versions.
+	AppVersion string
+	// The hostname of the current server. This defaults to the return value of
+	// os.Hostname() and is graphed in the Bugsnag dashboard.
+	Hostname string
+
+	// The Release stages to notify in. If you set this then bugsnag-go will
+	// only send notifications to Bugsnag if the ReleaseStage is listed here.
+	NotifyReleaseStages []string
+
+	// packages that are part of your app. Bugsnag uses this to determine how
+	// to group errors and how to display them on your dashboard. You should
+	// include any packages that are part of your app, and exclude libraries
+	// and helpers. You can list wildcards here, and they'll be expanded using
+	// filepath.Glob. The default value is []string{"main*"}
+	ProjectPackages []string
+
+	// Any meta-data that matches these filters will be marked as [REDACTED]
+	// before sending a Notification to Bugsnag. It defaults to
+	// []string{"password", "secret"} so that request parameters like password,
+	// password_confirmation and auth_secret will not be sent to Bugsnag.
+	ParamsFilters []string
+
+	// The PanicHandler is used by Bugsnag to catch unhandled panics in your
+	// application. The default panicHandler uses mitchellh's panicwrap library,
+	// and you can disable this feature by passing an empty: func() {}
+	PanicHandler func()
+
+	// The logger that Bugsnag should log to. Uses the same defaults as go's
+	// builtin logging package. bugsnag-go logs whenever it notifies Bugsnag
+	// of an error, and when any error occurs inside the library itself.
+	Logger interface {
+		Printf(format string, v ...interface{}) // limited to the functions used
+	}
+	// The http Transport to use, defaults to the default http Transport. This
+	// can be configured if you are in an environment like Google App Engine
+	// that has stringent conditions on making http requests.
+	Transport http.RoundTripper
+	// Whether bugsnag should notify synchronously. This defaults to false which
+	// causes bugsnag-go to spawn a new goroutine for each notification.
+	Synchronous bool
+	// TODO: remember to update the update() function when modifying this struct
+}
+
+func (config *Configuration) update(other *Configuration) *Configuration {
+	if other.APIKey != "" {
+		config.APIKey = other.APIKey
+	}
+	if other.Endpoint != "" {
+		config.Endpoint = other.Endpoint
+	}
+	if other.Hostname != "" {
+		config.Hostname = other.Hostname
+	}
+	if other.AppVersion != "" {
+		config.AppVersion = other.AppVersion
+	}
+	if other.ReleaseStage != "" {
+		config.ReleaseStage = other.ReleaseStage
+	}
+	if other.ParamsFilters != nil {
+		config.ParamsFilters = other.ParamsFilters
+	}
+	if other.ProjectPackages != nil {
+		config.ProjectPackages = other.ProjectPackages
+	}
+	if other.Logger != nil {
+		config.Logger = other.Logger
+	}
+	if other.NotifyReleaseStages != nil {
+		config.NotifyReleaseStages = other.NotifyReleaseStages
+	}
+	if other.PanicHandler != nil {
+		config.PanicHandler = other.PanicHandler
+	}
+	if other.Transport != nil {
+		config.Transport = other.Transport
+	}
+	if other.Synchronous {
+		config.Synchronous = true
+	}
+
+	return config
+}
+
+func (config *Configuration) merge(other *Configuration) *Configuration {
+	return config.clone().update(other)
+}
+
+func (config *Configuration) clone() *Configuration {
+	clone := *config
+	return &clone
+}
+
+func (config *Configuration) isProjectPackage(pkg string) bool {
+	for _, p := range config.ProjectPackages {
+		if d, f := filepath.Split(p); f == "**" {
+			if strings.HasPrefix(pkg, d) {
+				return true
+			}
+		}
+
+		if match, _ := filepath.Match(p, pkg); match {
+			return true
+		}
+	}
+	return false
+}
+
+func (config *Configuration) stripProjectPackages(file string) string {
+	for _, p := range config.ProjectPackages {
+		if len(p) > 2 && p[len(p)-2] == '/' && p[len(p)-1] == '*' {
+			p = p[:len(p)-1]
+		} else if p[len(p)-1] == '*' && p[len(p)-2] == '*' {
+			p = p[:len(p)-2]
+		} else {
+			p = p + "/"
+		}
+		if strings.HasPrefix(file, p) {
+			return strings.TrimPrefix(file, p)
+		}
+	}
+
+	return file
+}
+
+func (config *Configuration) logf(fmt string, args ...interface{}) {
+	if config != nil && config.Logger != nil {
+		config.Logger.Printf(fmt, args...)
+	} else {
+		log.Printf(fmt, args...)
+	}
+}
+
+func (config *Configuration) notifyInReleaseStage() bool {
+	if config.NotifyReleaseStages == nil {
+		return true
+	}
+	for _, r := range config.NotifyReleaseStages {
+		if r == config.ReleaseStage {
+			return true
+		}
+	}
+	return false
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/configuration_test.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/configuration_test.go
@@ -1,0 +1,168 @@
+package bugsnag
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/juju/loggo"
+)
+
+func TestNotifyReleaseStages(t *testing.T) {
+
+	var testCases = []struct {
+		stage      string
+		configured []string
+		notify     bool
+		msg        string
+	}{
+		{
+			stage:  "production",
+			notify: true,
+			msg:    "Should notify in all release stages by default",
+		},
+		{
+			stage:      "production",
+			configured: []string{"development", "production"},
+			notify:     true,
+			msg:        "Failed to notify in configured release stage",
+		},
+		{
+			stage:      "staging",
+			configured: []string{"development", "production"},
+			notify:     false,
+			msg:        "Failed to prevent notification in excluded release stage",
+		},
+	}
+
+	for _, testCase := range testCases {
+		Configure(Configuration{ReleaseStage: testCase.stage, NotifyReleaseStages: testCase.configured})
+
+		if Config.notifyInReleaseStage() != testCase.notify {
+			t.Error(testCase.msg)
+		}
+	}
+}
+
+func TestIsProjectPackage(t *testing.T) {
+
+	Configure(Configuration{ProjectPackages: []string{
+		"main",
+		"star*",
+		"example.com/a",
+		"example.com/b/*",
+		"example.com/c/*/*",
+		"example.com/d/**",
+		"example.com/e",
+	}})
+
+	var testCases = []struct {
+		Path     string
+		Included bool
+	}{
+		{"", false},
+		{"main", true},
+		{"runtime", false},
+
+		{"star", true},
+		{"sta", false},
+		{"starred", true},
+		{"star/foo", false},
+
+		{"example.com/a", true},
+
+		{"example.com/b", false},
+		{"example.com/b/", true},
+		{"example.com/b/foo", true},
+		{"example.com/b/foo/bar", false},
+
+		{"example.com/c/foo/bar", true},
+		{"example.com/c/foo/bar/baz", false},
+
+		{"example.com/d/foo/bar", true},
+		{"example.com/d/foo/bar/baz", true},
+
+		{"example.com/e", true},
+	}
+
+	for _, s := range testCases {
+		if Config.isProjectPackage(s.Path) != s.Included {
+			t.Error("literal project package doesn't work:", s.Path, s.Included)
+		}
+	}
+}
+
+func TestStripProjectPackage(t *testing.T) {
+
+	Configure(Configuration{ProjectPackages: []string{
+		"main",
+		"star*",
+		"example.com/a",
+		"example.com/b/*",
+		"example.com/c/**",
+	}})
+
+	var testCases = []struct {
+		File     string
+		Stripped string
+	}{
+		{"main.go", "main.go"},
+		{"runtime.go", "runtime.go"},
+		{"star.go", "star.go"},
+
+		{"example.com/a/foo.go", "foo.go"},
+
+		{"example.com/b/foo/bar.go", "foo/bar.go"},
+		{"example.com/b/foo.go", "foo.go"},
+
+		{"example.com/x/a/b/foo.go", "example.com/x/a/b/foo.go"},
+
+		{"example.com/c/a/b/foo.go", "a/b/foo.go"},
+	}
+
+	for _, tc := range testCases {
+		if s := Config.stripProjectPackages(tc.File); s != tc.Stripped {
+			t.Error("stripProjectPackage did not remove expected path:", tc.File, tc.Stripped, "was:", s)
+		}
+	}
+}
+
+type LoggoWrapper struct {
+	loggo.Logger
+}
+
+func (lw *LoggoWrapper) Printf(format string, v ...interface{}) {
+	lw.Logger.Warningf(format, v...)
+}
+
+func TestConfiguringCustomLogger(t *testing.T) {
+
+	l1 := log.New(os.Stdout, "", log.Lshortfile)
+
+	l2 := &LoggoWrapper{loggo.GetLogger("test")}
+
+	var testCases = []struct {
+		config Configuration
+		notify bool
+		msg    string
+	}{
+		{
+			config: Configuration{ReleaseStage: "production", NotifyReleaseStages: []string{"development", "production"}, Logger: l1},
+			notify: true,
+			msg:    "Failed to assign log.Logger",
+		},
+		{
+			config: Configuration{ReleaseStage: "production", NotifyReleaseStages: []string{"development", "production"}, Logger: l2},
+			notify: true,
+			msg:    "Failed to assign LoggoWrapper",
+		},
+	}
+
+	for _, testCase := range testCases {
+		Configure(testCase.config)
+
+		// call printf just to illustrate it is present as the compiler does most of the hard work
+		testCase.config.Logger.Printf("hello %s", "bugsnag")
+
+	}
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/doc.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/doc.go
@@ -1,0 +1,69 @@
+/*
+Package bugsnag captures errors in real-time and reports them to Bugsnag (http://bugsnag.com).
+
+Using bugsnag-go is a three-step process.
+
+1. As early as possible in your program configure the notifier with your APIKey. This sets up
+handling of panics that would otherwise crash your app.
+
+	func init() {
+		bugsnag.Configure(bugsnag.Configuration{
+			APIKey: "YOUR_API_KEY_HERE",
+		})
+	}
+
+2. Add bugsnag to places that already catch panics. For example you should add it to the HTTP server
+when you call ListenAndServer:
+
+	http.ListenAndServe(":8080", bugsnag.Handler(nil))
+
+If that's not possible, for example because you're using Google App Engine, you can also wrap each
+HTTP handler manually:
+
+	http.HandleFunc("/" bugsnag.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+		...
+	})
+
+3. To notify Bugsnag of an error that is not a panic, pass it to bugsnag.Notify. This will also
+log the error message using the configured Logger.
+
+	if err != nil {
+		bugsnag.Notify(err)
+	}
+
+For detailed integration instructions see https://bugsnag.com/docs/notifiers/go.
+
+Configuration
+
+The only required configuration is the Bugsnag API key which can be obtained by clicking "Settings"
+on the top of https://bugsnag.com/ after signing up. We also recommend you set the ReleaseStage
+and AppVersion if these make sense for your deployment workflow.
+
+RawData
+
+If you need to attach extra data to Bugsnag notifications you can do that using
+the rawData mechanism.  Most of the functions that send errors to Bugsnag allow
+you to pass in any number of interface{} values as rawData. The rawData can
+consist of the Severity, Context, User or MetaData types listed below, and
+there is also builtin support for *http.Requests.
+
+	bugsnag.Notify(err, bugsnag.SeverityError)
+
+If you want to add custom tabs to your bugsnag dashboard you can pass any value in as rawData,
+and then process it into the event's metadata using a bugsnag.OnBeforeNotify() hook.
+
+	bugsnag.Notify(err, account)
+
+	bugsnag.OnBeforeNotify(func (e *bugsnag.Event, c *bugsnag.Configuration) {
+		for datum := range e.RawData {
+			if account, ok := datum.(Account); ok {
+				e.MetaData.Add("account", "name", account.Name)
+				e.MetaData.Add("account", "url", account.URL)
+			}
+		}
+	})
+
+If necessary you can pass Configuration in as rawData, or modify the Configuration object passed
+into OnBeforeNotify hooks. Configuration passed in this way only affects the current notification.
+*/
+package bugsnag

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors/README.md
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors/README.md
@@ -1,0 +1,6 @@
+Adds stacktraces to errors in golang.
+
+This was made to help build the Bugsnag notifier but can be used standalone if
+you like to have stacktraces on errors.
+
+See [Godoc](https://godoc.org/github.com/bugsnag/bugsnag-go/errors) for the API docs.

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors/error.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors/error.go
@@ -1,0 +1,90 @@
+// Package errors provides errors that have stack-traces.
+package errors
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"runtime"
+)
+
+// The maximum number of stackframes on any error.
+var MaxStackDepth = 50
+
+// Error is an error with an attached stacktrace. It can be used
+// wherever the builtin error interface is expected.
+type Error struct {
+	Err    error
+	stack  []uintptr
+	frames []StackFrame
+}
+
+// New makes an Error from the given value. If that value is already an
+// error then it will be used directly, if not, it will be passed to
+// fmt.Errorf("%v"). The skip parameter indicates how far up the stack
+// to start the stacktrace. 0 is from the current call, 1 from its caller, etc.
+func New(e interface{}, skip int) *Error {
+	var err error
+
+	switch e := e.(type) {
+	case *Error:
+		return e
+	case error:
+		err = e
+	default:
+		err = fmt.Errorf("%v", e)
+	}
+
+	stack := make([]uintptr, MaxStackDepth)
+	length := runtime.Callers(2+skip, stack[:])
+	return &Error{
+		Err:   err,
+		stack: stack[:length],
+	}
+}
+
+// Errorf creates a new error with the given message. You can use it
+// as a drop-in replacement for fmt.Errorf() to provide descriptive
+// errors in return values.
+func Errorf(format string, a ...interface{}) *Error {
+	return New(fmt.Errorf(format, a...), 1)
+}
+
+// Error returns the underlying error's message.
+func (err *Error) Error() string {
+	return err.Err.Error()
+}
+
+// Stack returns the callstack formatted the same way that go does
+// in runtime/debug.Stack()
+func (err *Error) Stack() []byte {
+	buf := bytes.Buffer{}
+
+	for _, frame := range err.StackFrames() {
+		buf.WriteString(frame.String())
+	}
+
+	return buf.Bytes()
+}
+
+// StackFrames returns an array of frames containing information about the
+// stack.
+func (err *Error) StackFrames() []StackFrame {
+	if err.frames == nil {
+		err.frames = make([]StackFrame, len(err.stack))
+
+		for i, pc := range err.stack {
+			err.frames[i] = NewStackFrame(pc)
+		}
+	}
+
+	return err.frames
+}
+
+// TypeName returns the type this error. e.g. *errors.stringError.
+func (err *Error) TypeName() string {
+	if _, ok := err.Err.(uncaughtPanic); ok {
+		return "panic"
+	}
+	return reflect.TypeOf(err.Err).String()
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors/error_test.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors/error_test.go
@@ -1,0 +1,126 @@
+package errors
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"runtime/debug"
+	"testing"
+)
+
+func TestStackFormatMatches(t *testing.T) {
+
+	defer func() {
+		err := recover()
+		if err != 'a' {
+			t.Fatal(err)
+		}
+
+		bs := [][]byte{Errorf("hi").Stack(), debug.Stack()}
+
+		// Ignore the first line (as it contains the PC of the .Stack() call)
+		bs[0] = bytes.SplitN(bs[0], []byte("\n"), 2)[1]
+		bs[1] = bytes.SplitN(bs[1], []byte("\n"), 2)[1]
+
+		if bytes.Compare(bs[0], bs[1]) != 0 {
+			t.Errorf("Stack didn't match")
+			t.Errorf("%s", bs[0])
+			t.Errorf("%s", bs[1])
+		}
+	}()
+
+	a()
+}
+
+func TestSkipWorks(t *testing.T) {
+
+	defer func() {
+		err := recover()
+		if err != 'a' {
+			t.Fatal(err)
+		}
+
+		bs := [][]byte{New("hi", 2).Stack(), debug.Stack()}
+
+		if !bytes.HasSuffix(bs[1], bs[0]) {
+			t.Errorf("Stack didn't match")
+			t.Errorf("%s", bs[0])
+			t.Errorf("%s", bs[1])
+		}
+	}()
+
+	a()
+}
+
+func TestNewError(t *testing.T) {
+
+	e := func() error {
+		return New("hi", 1)
+	}()
+
+	if e.Error() != "hi" {
+		t.Errorf("Constructor with a string failed")
+	}
+
+	if New(fmt.Errorf("yo"), 0).Error() != "yo" {
+		t.Errorf("Constructor with an error failed")
+	}
+
+	if New(e, 0) != e {
+		t.Errorf("Constructor with an Error failed")
+	}
+
+	if New(nil, 0).Error() != "<nil>" {
+		t.Errorf("Constructor with nil failed")
+	}
+}
+
+func ExampleErrorf() {
+	for i := 1; i <= 2; i++ {
+		if i%2 == 1 {
+			e := Errorf("can only halve even numbers, got %d", i)
+			fmt.Printf("Error: %+v", e)
+		}
+	}
+	// Output:
+	// Error: can only halve even numbers, got 1
+}
+
+func ExampleNew() {
+	// Wrap io.EOF with the current stack-trace and return it
+	e := New(io.EOF, 0)
+	fmt.Printf("%+v", e)
+	// Output:
+	// EOF
+}
+
+func ExampleNew_skip() {
+	defer func() {
+		if err := recover(); err != nil {
+			// skip 1 frame (the deferred function) and then return the wrapped err
+			err = New(err, 1)
+		}
+	}()
+}
+
+func ExampleError_Stack() {
+	e := New("Oh noes!", 1)
+	fmt.Printf("Error: %s\n", e.Error())
+	fmt.Printf("Stack is %d bytes", len(e.Stack()))
+	// Output:
+	// Error: Oh noes!
+	// Stack is 589 bytes
+}
+
+func a() error {
+	b(5)
+	return nil
+}
+
+func b(i int) {
+	c()
+}
+
+func c() {
+	panic('a')
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors/parse_panic.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors/parse_panic.go
@@ -1,0 +1,127 @@
+package errors
+
+import (
+	"strconv"
+	"strings"
+)
+
+type uncaughtPanic struct{ message string }
+
+func (p uncaughtPanic) Error() string {
+	return p.message
+}
+
+// ParsePanic allows you to get an error object from the output of a go program
+// that panicked. This is particularly useful with https://github.com/mitchellh/panicwrap.
+func ParsePanic(text string) (*Error, error) {
+	lines := strings.Split(text, "\n")
+
+	state := "start"
+
+	var message string
+	var stack []StackFrame
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+
+		if state == "start" {
+			if strings.HasPrefix(line, "panic: ") {
+				message = strings.TrimPrefix(line, "panic: ")
+				state = "seek"
+			} else {
+				return nil, Errorf("bugsnag.panicParser: Invalid line (no prefix): %s", line)
+			}
+
+		} else if state == "seek" {
+			if strings.HasPrefix(line, "goroutine ") && strings.HasSuffix(line, "[running]:") {
+				state = "parsing"
+			}
+
+		} else if state == "parsing" {
+			if line == "" {
+				state = "done"
+				break
+			}
+			createdBy := false
+			if strings.HasPrefix(line, "created by ") {
+				line = strings.TrimPrefix(line, "created by ")
+				createdBy = true
+			}
+
+			i++
+
+			if i >= len(lines) {
+				return nil, Errorf("bugsnag.panicParser: Invalid line (unpaired): %s", line)
+			}
+
+			frame, err := parsePanicFrame(line, lines[i], createdBy)
+			if err != nil {
+				return nil, err
+			}
+
+			stack = append(stack, *frame)
+			if createdBy {
+				state = "done"
+				break
+			}
+		}
+	}
+
+	if state == "done" || state == "parsing" {
+		return &Error{Err: uncaughtPanic{message}, frames: stack}, nil
+	}
+	return nil, Errorf("could not parse panic: %v", text)
+}
+
+// The lines we're passing look like this:
+//
+//     main.(*foo).destruct(0xc208067e98)
+//             /0/go/src/github.com/bugsnag/bugsnag-go/pan/main.go:22 +0x151
+func parsePanicFrame(name string, line string, createdBy bool) (*StackFrame, error) {
+	idx := strings.LastIndex(name, "(")
+	if idx == -1 && !createdBy {
+		return nil, Errorf("bugsnag.panicParser: Invalid line (no call): %s", name)
+	}
+	if idx != -1 {
+		name = name[:idx]
+	}
+	pkg := ""
+
+	if lastslash := strings.LastIndex(name, "/"); lastslash >= 0 {
+		pkg += name[:lastslash] + "/"
+		name = name[lastslash+1:]
+	}
+	if period := strings.Index(name, "."); period >= 0 {
+		pkg += name[:period]
+		name = name[period+1:]
+	}
+
+	name = strings.Replace(name, "·", ".", -1)
+
+	if !strings.HasPrefix(line, "\t") {
+		return nil, Errorf("bugsnag.panicParser: Invalid line (no tab): %s", line)
+	}
+
+	idx = strings.LastIndex(line, ":")
+	if idx == -1 {
+		return nil, Errorf("bugsnag.panicParser: Invalid line (no line number): %s", line)
+	}
+	file := line[1:idx]
+
+	number := line[idx+1:]
+	if idx = strings.Index(number, " +"); idx > -1 {
+		number = number[:idx]
+	}
+
+	lno, err := strconv.ParseInt(number, 10, 32)
+	if err != nil {
+		return nil, Errorf("bugsnag.panicParser: Invalid line (bad line number): %s", line)
+	}
+
+	return &StackFrame{
+		File:       file,
+		LineNumber: int(lno),
+		Package:    pkg,
+		Name:       name,
+	}, nil
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors/parse_panic_test.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors/parse_panic_test.go
@@ -1,0 +1,142 @@
+package errors
+
+import (
+	"reflect"
+	"testing"
+)
+
+var createdBy = `panic: hello!
+
+goroutine 54 [running]:
+runtime.panic(0x35ce40, 0xc208039db0)
+	/0/c/go/src/pkg/runtime/panic.c:279 +0xf5
+github.com/loopj/bugsnag-example-apps/go/revelapp/app/controllers.func·001()
+	/0/go/src/github.com/loopj/bugsnag-example-apps/go/revelapp/app/controllers/app.go:13 +0x74
+net/http.(*Server).Serve(0xc20806c780, 0x910c88, 0xc20803e168, 0x0, 0x0)
+	/0/c/go/src/pkg/net/http/server.go:1698 +0x91
+created by github.com/loopj/bugsnag-example-apps/go/revelapp/app/controllers.App.Index
+	/0/go/src/github.com/loopj/bugsnag-example-apps/go/revelapp/app/controllers/app.go:14 +0x3e
+
+goroutine 16 [IO wait]:
+net.runtime_pollWait(0x911c30, 0x72, 0x0)
+	/0/c/go/src/pkg/runtime/netpoll.goc:146 +0x66
+net.(*pollDesc).Wait(0xc2080ba990, 0x72, 0x0, 0x0)
+	/0/c/go/src/pkg/net/fd_poll_runtime.go:84 +0x46
+net.(*pollDesc).WaitRead(0xc2080ba990, 0x0, 0x0)
+	/0/c/go/src/pkg/net/fd_poll_runtime.go:89 +0x42
+net.(*netFD).accept(0xc2080ba930, 0x58be30, 0x0, 0x9103f0, 0x23)
+	/0/c/go/src/pkg/net/fd_unix.go:409 +0x343
+net.(*TCPListener).AcceptTCP(0xc20803e168, 0x8, 0x0, 0x0)
+	/0/c/go/src/pkg/net/tcpsock_posix.go:234 +0x5d
+net.(*TCPListener).Accept(0xc20803e168, 0x0, 0x0, 0x0, 0x0)
+	/0/c/go/src/pkg/net/tcpsock_posix.go:244 +0x4b
+github.com/revel/revel.Run(0xe6d9)
+	/0/go/src/github.com/revel/revel/server.go:113 +0x926
+main.main()
+	/0/go/src/github.com/loopj/bugsnag-example-apps/go/revelapp/app/tmp/main.go:109 +0xe1a
+`
+
+var normalSplit = `panic: hello!
+
+goroutine 54 [running]:
+runtime.panic(0x35ce40, 0xc208039db0)
+	/0/c/go/src/pkg/runtime/panic.c:279 +0xf5
+github.com/loopj/bugsnag-example-apps/go/revelapp/app/controllers.func·001()
+	/0/go/src/github.com/loopj/bugsnag-example-apps/go/revelapp/app/controllers/app.go:13 +0x74
+net/http.(*Server).Serve(0xc20806c780, 0x910c88, 0xc20803e168, 0x0, 0x0)
+	/0/c/go/src/pkg/net/http/server.go:1698 +0x91
+
+goroutine 16 [IO wait]:
+net.runtime_pollWait(0x911c30, 0x72, 0x0)
+	/0/c/go/src/pkg/runtime/netpoll.goc:146 +0x66
+net.(*pollDesc).Wait(0xc2080ba990, 0x72, 0x0, 0x0)
+	/0/c/go/src/pkg/net/fd_poll_runtime.go:84 +0x46
+net.(*pollDesc).WaitRead(0xc2080ba990, 0x0, 0x0)
+	/0/c/go/src/pkg/net/fd_poll_runtime.go:89 +0x42
+net.(*netFD).accept(0xc2080ba930, 0x58be30, 0x0, 0x9103f0, 0x23)
+	/0/c/go/src/pkg/net/fd_unix.go:409 +0x343
+net.(*TCPListener).AcceptTCP(0xc20803e168, 0x8, 0x0, 0x0)
+	/0/c/go/src/pkg/net/tcpsock_posix.go:234 +0x5d
+net.(*TCPListener).Accept(0xc20803e168, 0x0, 0x0, 0x0, 0x0)
+	/0/c/go/src/pkg/net/tcpsock_posix.go:244 +0x4b
+github.com/revel/revel.Run(0xe6d9)
+	/0/go/src/github.com/revel/revel/server.go:113 +0x926
+main.main()
+	/0/go/src/github.com/loopj/bugsnag-example-apps/go/revelapp/app/tmp/main.go:109 +0xe1a
+`
+
+var lastGoroutine = `panic: hello!
+
+goroutine 16 [IO wait]:
+net.runtime_pollWait(0x911c30, 0x72, 0x0)
+	/0/c/go/src/pkg/runtime/netpoll.goc:146 +0x66
+net.(*pollDesc).Wait(0xc2080ba990, 0x72, 0x0, 0x0)
+	/0/c/go/src/pkg/net/fd_poll_runtime.go:84 +0x46
+net.(*pollDesc).WaitRead(0xc2080ba990, 0x0, 0x0)
+	/0/c/go/src/pkg/net/fd_poll_runtime.go:89 +0x42
+net.(*netFD).accept(0xc2080ba930, 0x58be30, 0x0, 0x9103f0, 0x23)
+	/0/c/go/src/pkg/net/fd_unix.go:409 +0x343
+net.(*TCPListener).AcceptTCP(0xc20803e168, 0x8, 0x0, 0x0)
+	/0/c/go/src/pkg/net/tcpsock_posix.go:234 +0x5d
+net.(*TCPListener).Accept(0xc20803e168, 0x0, 0x0, 0x0, 0x0)
+	/0/c/go/src/pkg/net/tcpsock_posix.go:244 +0x4b
+github.com/revel/revel.Run(0xe6d9)
+	/0/go/src/github.com/revel/revel/server.go:113 +0x926
+main.main()
+	/0/go/src/github.com/loopj/bugsnag-example-apps/go/revelapp/app/tmp/main.go:109 +0xe1a
+
+goroutine 54 [running]:
+runtime.panic(0x35ce40, 0xc208039db0)
+	/0/c/go/src/pkg/runtime/panic.c:279 +0xf5
+github.com/loopj/bugsnag-example-apps/go/revelapp/app/controllers.func·001()
+	/0/go/src/github.com/loopj/bugsnag-example-apps/go/revelapp/app/controllers/app.go:13 +0x74
+net/http.(*Server).Serve(0xc20806c780, 0x910c88, 0xc20803e168, 0x0, 0x0)
+	/0/c/go/src/pkg/net/http/server.go:1698 +0x91
+`
+
+var result = []StackFrame{
+	StackFrame{File: "/0/c/go/src/pkg/runtime/panic.c", LineNumber: 279, Name: "panic", Package: "runtime"},
+	StackFrame{File: "/0/go/src/github.com/loopj/bugsnag-example-apps/go/revelapp/app/controllers/app.go", LineNumber: 13, Name: "func.001", Package: "github.com/loopj/bugsnag-example-apps/go/revelapp/app/controllers"},
+	StackFrame{File: "/0/c/go/src/pkg/net/http/server.go", LineNumber: 1698, Name: "(*Server).Serve", Package: "net/http"},
+}
+
+var resultCreatedBy = append(result,
+	StackFrame{File: "/0/go/src/github.com/loopj/bugsnag-example-apps/go/revelapp/app/controllers/app.go", LineNumber: 14, Name: "App.Index", Package: "github.com/loopj/bugsnag-example-apps/go/revelapp/app/controllers", ProgramCounter: 0x0})
+
+func TestParsePanic(t *testing.T) {
+
+	todo := map[string]string{
+		"createdBy":     createdBy,
+		"normalSplit":   normalSplit,
+		"lastGoroutine": lastGoroutine,
+	}
+
+	for key, val := range todo {
+		Err, err := ParsePanic(val)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if Err.TypeName() != "panic" {
+			t.Errorf("Wrong type: %s", Err.TypeName())
+		}
+
+		if Err.Error() != "hello!" {
+			t.Errorf("Wrong message: %s", Err.TypeName())
+		}
+
+		if Err.StackFrames()[0].Func() != nil {
+			t.Errorf("Somehow managed to find a func...")
+		}
+
+		result := result
+		if key == "createdBy" {
+			result = resultCreatedBy
+		}
+
+		if !reflect.DeepEqual(Err.StackFrames(), result) {
+			t.Errorf("Wrong stack for %s: %#v", key, Err.StackFrames())
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors/stackframe.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors/stackframe.go
@@ -1,0 +1,97 @@
+package errors
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"runtime"
+	"strings"
+)
+
+// A StackFrame contains all necessary information about to generate a line
+// in a callstack.
+type StackFrame struct {
+	File           string
+	LineNumber     int
+	Name           string
+	Package        string
+	ProgramCounter uintptr
+}
+
+// NewStackFrame popoulates a stack frame object from the program counter.
+func NewStackFrame(pc uintptr) (frame StackFrame) {
+
+	frame = StackFrame{ProgramCounter: pc}
+	if frame.Func() == nil {
+		return
+	}
+	frame.Package, frame.Name = packageAndName(frame.Func())
+
+	// pc -1 because the program counters we use are usually return addresses,
+	// and we want to show the line that corresponds to the function call
+	frame.File, frame.LineNumber = frame.Func().FileLine(pc - 1)
+	return
+
+}
+
+// Func returns the function that this stackframe corresponds to
+func (frame *StackFrame) Func() *runtime.Func {
+	if frame.ProgramCounter == 0 {
+		return nil
+	}
+	return runtime.FuncForPC(frame.ProgramCounter)
+}
+
+// String returns the stackframe formatted in the same way as go does
+// in runtime/debug.Stack()
+func (frame *StackFrame) String() string {
+	str := fmt.Sprintf("%s:%d (0x%x)\n", frame.File, frame.LineNumber, frame.ProgramCounter)
+
+	source, err := frame.SourceLine()
+	if err != nil {
+		return str
+	}
+
+	return str + fmt.Sprintf("\t%s: %s\n", frame.Name, source)
+}
+
+// SourceLine gets the line of code (from File and Line) of the original source if possible
+func (frame *StackFrame) SourceLine() (string, error) {
+	data, err := ioutil.ReadFile(frame.File)
+
+	if err != nil {
+		return "", err
+	}
+
+	lines := bytes.Split(data, []byte{'\n'})
+	if frame.LineNumber <= 0 || frame.LineNumber >= len(lines) {
+		return "???", nil
+	}
+	// -1 because line-numbers are 1 based, but our array is 0 based
+	return string(bytes.Trim(lines[frame.LineNumber-1], " \t")), nil
+}
+
+func packageAndName(fn *runtime.Func) (string, string) {
+	name := fn.Name()
+	pkg := ""
+
+	// The name includes the path name to the package, which is unnecessary
+	// since the file name is already included.  Plus, it has center dots.
+	// That is, we see
+	//  runtime/debug.*T·ptrmethod
+	// and want
+	//  *T.ptrmethod
+	// Since the package path might contains dots (e.g. code.google.com/...),
+	// we first remove the path prefix if there is one.
+	if lastslash := strings.LastIndex(name, "/"); lastslash >= 0 {
+		pkg += name[:lastslash] + "/"
+		name = name[lastslash+1:]
+	}
+	if period := strings.Index(name, "."); period >= 0 {
+		pkg += name[:period]
+		name = name[period+1:]
+	}
+
+	name = strings.Replace(name, "·", ".", -1)
+	return pkg, name
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/event.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/event.go
@@ -1,0 +1,143 @@
+package bugsnag
+
+import (
+	"strings"
+
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors"
+)
+
+// Context is the context of the error in Bugsnag.
+// This can be passed to Notify, Recover or AutoNotify as rawData.
+type Context struct {
+	String string
+}
+
+// User represents the searchable user-data on Bugsnag. The Id is also used
+// to determine the number of users affected by a bug. This can be
+// passed to Notify, Recover or AutoNotify as rawData.
+type User struct {
+	Id    string `json:"id,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
+}
+
+// ErrorClass overrides the error class in Bugsnag.
+// This struct enables you to group errors as you like.
+type ErrorClass struct {
+	Name string
+}
+
+// Sets the severity of the error on Bugsnag. These values can be
+// passed to Notify, Recover or AutoNotify as rawData.
+var (
+	SeverityError   = severity{"error"}
+	SeverityWarning = severity{"warning"}
+	SeverityInfo    = severity{"info"}
+)
+
+// The severity tag type, private so that people can only use Error,Warning,Info
+type severity struct {
+	String string
+}
+
+// The form of stacktrace that Bugsnag expects
+type stackFrame struct {
+	Method     string `json:"method"`
+	File       string `json:"file"`
+	LineNumber int    `json:"lineNumber"`
+	InProject  bool   `json:"inProject,omitempty"`
+}
+
+// Event represents a payload of data that gets sent to Bugsnag.
+// This is passed to each OnBeforeNotify hook.
+type Event struct {
+
+	// The original error that caused this event, not sent to Bugsnag.
+	Error *errors.Error
+
+	// The rawData affecting this error, not sent to Bugsnag.
+	RawData []interface{}
+
+	// The error class to be sent to Bugsnag. This defaults to the type name of the Error, for
+	// example *error.String
+	ErrorClass string
+	// The error message to be sent to Bugsnag. This defaults to the return value of Error.Error()
+	Message string
+	// The stacktrrace of the error to be sent to Bugsnag.
+	Stacktrace []stackFrame
+
+	// The context to be sent to Bugsnag. This should be set to the part of the app that was running,
+	// e.g. for http requests, set it to the path.
+	Context string
+	// The severity of the error. Can be SeverityError, SeverityWarning or SeverityInfo.
+	Severity severity
+	// The grouping hash is used to override Bugsnag's grouping. Set this if you'd like all errors with
+	// the same grouping hash to group together in the dashboard.
+	GroupingHash string
+
+	// User data to send to Bugsnag. This is searchable on the dashboard.
+	User *User
+	// Other MetaData to send to Bugsnag. Appears as a set of tabbed tables in the dashboard.
+	MetaData MetaData
+}
+
+func newEvent(err *errors.Error, rawData []interface{}, notifier *Notifier) (*Event, *Configuration) {
+
+	config := notifier.Config
+	event := &Event{
+		Error:   err,
+		RawData: append(notifier.RawData, rawData...),
+
+		ErrorClass: err.TypeName(),
+		Message:    err.Error(),
+		Stacktrace: make([]stackFrame, len(err.StackFrames())),
+
+		Severity: SeverityWarning,
+
+		MetaData: make(MetaData),
+	}
+
+	for _, datum := range event.RawData {
+		switch datum := datum.(type) {
+		case severity:
+			event.Severity = datum
+
+		case Context:
+			event.Context = datum.String
+
+		case Configuration:
+			config = config.merge(&datum)
+
+		case MetaData:
+			event.MetaData.Update(datum)
+
+		case User:
+			event.User = &datum
+
+		case ErrorClass:
+			event.ErrorClass = datum.Name
+		}
+	}
+
+	for i, frame := range err.StackFrames() {
+		file := frame.File
+		inProject := config.isProjectPackage(frame.Package)
+
+		// remove $GOROOT and $GOHOME from other frames
+		if idx := strings.Index(file, frame.Package); idx > -1 {
+			file = file[idx:]
+		}
+		if inProject {
+			file = config.stripProjectPackages(file)
+		}
+
+		event.Stacktrace[i] = stackFrame{
+			Method:     frame.Name,
+			File:       file,
+			LineNumber: frame.LineNumber,
+			InProject:  inProject,
+		}
+	}
+
+	return event, config
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/json_tags.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/json_tags.go
@@ -1,0 +1,43 @@
+// The code is stripped from:
+// http://golang.org/src/pkg/encoding/json/tags.go?m=text
+
+package bugsnag
+
+import (
+	"strings"
+)
+
+// tagOptions is the string following a comma in a struct field's "json"
+// tag, or the empty string. It does not include the leading comma.
+type tagOptions string
+
+// parseTag splits a struct field's json tag into its name and
+// comma-separated options.
+func parseTag(tag string) (string, tagOptions) {
+	if idx := strings.Index(tag, ","); idx != -1 {
+		return tag[:idx], tagOptions(tag[idx+1:])
+	}
+	return tag, tagOptions("")
+}
+
+// Contains reports whether a comma-separated list of options
+// contains a particular substr flag. substr must be surrounded by a
+// string boundary or commas.
+func (o tagOptions) Contains(optionName string) bool {
+	if len(o) == 0 {
+		return false
+	}
+	s := string(o)
+	for s != "" {
+		var next string
+		i := strings.Index(s, ",")
+		if i >= 0 {
+			s, next = s[:i], s[i+1:]
+		}
+		if s == optionName {
+			return true
+		}
+		s = next
+	}
+	return false
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/metadata.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/metadata.go
@@ -1,0 +1,189 @@
+package bugsnag
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// MetaData is added to the Bugsnag dashboard in tabs. Each tab is
+// a map of strings -> values. You can pass MetaData to Notify, Recover
+// and AutoNotify as rawData.
+type MetaData map[string]map[string]interface{}
+
+// Update the meta-data with more information. Tabs are merged together such
+// that unique keys from both sides are preserved, and duplicate keys end up
+// with the provided values.
+func (meta MetaData) Update(other MetaData) {
+	for name, tab := range other {
+
+		if meta[name] == nil {
+			meta[name] = make(map[string]interface{})
+		}
+
+		for key, value := range tab {
+			meta[name][key] = value
+		}
+	}
+}
+
+// Add creates a tab of Bugsnag meta-data.
+// If the tab doesn't yet exist it will be created.
+// If the key already exists, it will be overwritten.
+func (meta MetaData) Add(tab string, key string, value interface{}) {
+	if meta[tab] == nil {
+		meta[tab] = make(map[string]interface{})
+	}
+
+	meta[tab][key] = value
+}
+
+// AddStruct creates a tab of Bugsnag meta-data.
+// The struct will be converted to an Object using the
+// reflect library so any private fields will not be exported.
+// As a safety measure, if you pass a non-struct the value will be
+// sent to Bugsnag under the "Extra data" tab.
+func (meta MetaData) AddStruct(tab string, obj interface{}) {
+	val := sanitizer{}.Sanitize(obj)
+	content, ok := val.(map[string]interface{})
+	if ok {
+		meta[tab] = content
+	} else {
+		// Wasn't a struct
+		meta.Add("Extra data", tab, obj)
+	}
+
+}
+
+// Remove any values from meta-data that have keys matching the filters,
+// and any that are recursive data-structures
+func (meta MetaData) sanitize(filters []string) interface{} {
+	return sanitizer{
+		Filters: filters,
+		Seen:    make([]interface{}, 0),
+	}.Sanitize(meta)
+
+}
+
+// The sanitizer is used to remove filtered params and recursion from meta-data.
+type sanitizer struct {
+	Filters []string
+	Seen    []interface{}
+}
+
+func (s sanitizer) Sanitize(data interface{}) interface{} {
+	for _, s := range s.Seen {
+		// TODO: we don't need deep equal here, just type-ignoring equality
+		if reflect.DeepEqual(data, s) {
+			return "[RECURSION]"
+		}
+	}
+
+	// Sanitizers are passed by value, so we can modify s and it only affects
+	// s.Seen for nested calls.
+	s.Seen = append(s.Seen, data)
+
+	t := reflect.TypeOf(data)
+	v := reflect.ValueOf(data)
+
+	if t == nil {
+		return "<nil>"
+	}
+
+	switch t.Kind() {
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64:
+		return data
+
+	case reflect.String:
+		return data
+
+	case reflect.Interface, reflect.Ptr:
+		return s.Sanitize(v.Elem().Interface())
+
+	case reflect.Array, reflect.Slice:
+		ret := make([]interface{}, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			ret[i] = s.Sanitize(v.Index(i).Interface())
+		}
+		return ret
+
+	case reflect.Map:
+		return s.sanitizeMap(v)
+
+	case reflect.Struct:
+		return s.sanitizeStruct(v, t)
+
+		// Things JSON can't serialize:
+		// case t.Chan, t.Func, reflect.Complex64, reflect.Complex128, reflect.UnsafePointer:
+	default:
+		return "[" + t.String() + "]"
+
+	}
+
+}
+
+func (s sanitizer) sanitizeMap(v reflect.Value) interface{} {
+	ret := make(map[string]interface{})
+
+	for _, key := range v.MapKeys() {
+		val := s.Sanitize(v.MapIndex(key).Interface())
+		newKey := fmt.Sprintf("%v", key.Interface())
+
+		if s.shouldRedact(newKey) {
+			val = "[REDACTED]"
+		}
+
+		ret[newKey] = val
+	}
+
+	return ret
+}
+
+func (s sanitizer) sanitizeStruct(v reflect.Value, t reflect.Type) interface{} {
+	ret := make(map[string]interface{})
+
+	for i := 0; i < v.NumField(); i++ {
+
+		val := v.Field(i)
+		// Don't export private fields
+		if !val.CanInterface() {
+			continue
+		}
+
+		name := t.Field(i).Name
+		var opts tagOptions
+
+		// Parse JSON tags. Supports name and "omitempty"
+		if jsonTag := t.Field(i).Tag.Get("json"); len(jsonTag) != 0 {
+			name, opts = parseTag(jsonTag)
+		}
+
+		if s.shouldRedact(name) {
+			ret[name] = "[REDACTED]"
+		} else {
+			sanitized := s.Sanitize(val.Interface())
+			if str, ok := sanitized.(string); ok {
+				if !(opts.Contains("omitempty") && len(str) == 0) {
+					ret[name] = str
+				}
+			} else {
+				ret[name] = sanitized
+			}
+
+		}
+	}
+
+	return ret
+}
+
+func (s sanitizer) shouldRedact(key string) bool {
+	for _, filter := range s.Filters {
+		if strings.Contains(strings.ToLower(filter), strings.ToLower(key)) {
+			return true
+		}
+	}
+	return false
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/metadata_test.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/metadata_test.go
@@ -1,0 +1,182 @@
+package bugsnag
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/bugsnag/bugsnag-go/errors"
+)
+
+type _account struct {
+	ID   string
+	Name string
+	Plan struct {
+		Premium bool
+	}
+	Password      string
+	secret        string
+	Email         string `json:"email"`
+	EmptyEmail    string `json:"emptyemail,omitempty"`
+	NotEmptyEmail string `json:"not_empty_email,omitempty"`
+}
+
+type _broken struct {
+	Me   *_broken
+	Data string
+}
+
+var account = _account{}
+var notifier = New(Configuration{})
+
+func TestMetaDataAdd(t *testing.T) {
+	m := MetaData{
+		"one": {
+			"key":      "value",
+			"override": false,
+		}}
+
+	m.Add("one", "override", true)
+	m.Add("one", "new", "key")
+	m.Add("new", "tab", account)
+
+	m.AddStruct("lol", "not really a struct")
+	m.AddStruct("account", account)
+
+	if !reflect.DeepEqual(m, MetaData{
+		"one": {
+			"key":      "value",
+			"override": true,
+			"new":      "key",
+		},
+		"new": {
+			"tab": account,
+		},
+		"Extra data": {
+			"lol": "not really a struct",
+		},
+		"account": {
+			"ID":   "",
+			"Name": "",
+			"Plan": map[string]interface{}{
+				"Premium": false,
+			},
+			"Password": "",
+			"email":    "",
+		},
+	}) {
+		t.Errorf("metadata.Add didn't work: %#v", m)
+	}
+}
+
+func TestMetaDataUpdate(t *testing.T) {
+
+	m := MetaData{
+		"one": {
+			"key":      "value",
+			"override": false,
+		}}
+
+	m.Update(MetaData{
+		"one": {
+			"override": true,
+			"new":      "key",
+		},
+		"new": {
+			"tab": account,
+		},
+	})
+
+	if !reflect.DeepEqual(m, MetaData{
+		"one": {
+			"key":      "value",
+			"override": true,
+			"new":      "key",
+		},
+		"new": {
+			"tab": account,
+		},
+	}) {
+		t.Errorf("metadata.Update didn't work: %#v", m)
+	}
+}
+
+func TestMetaDataSanitize(t *testing.T) {
+
+	var broken = _broken{}
+	broken.Me = &broken
+	broken.Data = "ohai"
+	account.Name = "test"
+	account.ID = "test"
+	account.secret = "hush"
+	account.Email = "example@example.com"
+	account.EmptyEmail = ""
+	account.NotEmptyEmail = "not_empty_email@example.com"
+
+	m := MetaData{
+		"one": {
+			"bool":     true,
+			"int":      7,
+			"float":    7.1,
+			"complex":  complex(1, 1),
+			"func":     func() {},
+			"unsafe":   unsafe.Pointer(broken.Me),
+			"string":   "string",
+			"password": "secret",
+			"array": []hash{{
+				"creditcard": "1234567812345678",
+				"broken":     broken,
+			}},
+			"broken":  broken,
+			"account": account,
+		},
+	}
+
+	n := m.sanitize([]string{"password", "creditcard"})
+
+	if !reflect.DeepEqual(n, map[string]interface{}{
+		"one": map[string]interface{}{
+			"bool":     true,
+			"int":      7,
+			"float":    7.1,
+			"complex":  "[complex128]",
+			"string":   "string",
+			"unsafe":   "[unsafe.Pointer]",
+			"func":     "[func()]",
+			"password": "[REDACTED]",
+			"array": []interface{}{map[string]interface{}{
+				"creditcard": "[REDACTED]",
+				"broken": map[string]interface{}{
+					"Me":   "[RECURSION]",
+					"Data": "ohai",
+				},
+			}},
+			"broken": map[string]interface{}{
+				"Me":   "[RECURSION]",
+				"Data": "ohai",
+			},
+			"account": map[string]interface{}{
+				"ID":   "test",
+				"Name": "test",
+				"Plan": map[string]interface{}{
+					"Premium": false,
+				},
+				"Password":        "[REDACTED]",
+				"email":           "example@example.com",
+				"not_empty_email": "not_empty_email@example.com",
+			},
+		},
+	}) {
+		t.Errorf("metadata.Sanitize didn't work: %#v", n)
+	}
+
+}
+
+func ExampleMetaData() {
+	notifier.Notify(errors.Errorf("hi world"),
+		MetaData{"Account": {
+			"id":      account.ID,
+			"name":    account.Name,
+			"paying?": account.Plan.Premium,
+		}})
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/middleware.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/middleware.go
@@ -1,0 +1,96 @@
+package bugsnag
+
+import (
+	"net/http"
+	"strings"
+)
+
+type (
+	beforeFunc func(*Event, *Configuration) error
+
+	// MiddlewareStacks keep middleware in the correct order. They are
+	// called in reverse order, so if you add a new middleware it will
+	// be called before all existing middleware.
+	middlewareStack struct {
+		before []beforeFunc
+	}
+)
+
+// AddMiddleware adds a new middleware to the outside of the existing ones,
+// when the middlewareStack is Run it will be run before all middleware that
+// have been added before.
+func (stack *middlewareStack) OnBeforeNotify(middleware beforeFunc) {
+	stack.before = append(stack.before, middleware)
+}
+
+// Run causes all the middleware to be run. If they all permit it the next callback
+// will be called with all the middleware on the stack.
+func (stack *middlewareStack) Run(event *Event, config *Configuration, next func() error) error {
+	// run all the before filters in reverse order
+	for i := range stack.before {
+		before := stack.before[len(stack.before)-i-1]
+
+		err := stack.runBeforeFilter(before, event, config)
+		if err != nil {
+			return err
+		}
+	}
+
+	return next()
+}
+
+func (stack *middlewareStack) runBeforeFilter(f beforeFunc, event *Event, config *Configuration) error {
+	defer func() {
+		if err := recover(); err != nil {
+			config.logf("bugsnag/middleware: unexpected panic: %v", err)
+		}
+	}()
+
+	return f(event, config)
+}
+
+// catchMiddlewarePanic is used to log any panics that happen inside Middleware,
+// we wouldn't want to not notify Bugsnag in this case.
+func catchMiddlewarePanic(event *Event, config *Configuration, next func() error) {
+}
+
+// httpRequestMiddleware is added OnBeforeNotify by default. It takes information
+// from an http.Request passed in as rawData, and adds it to the Event. You can
+// use this as a template for writing your own Middleware.
+func httpRequestMiddleware(event *Event, config *Configuration) error {
+	for _, datum := range event.RawData {
+		if request, ok := datum.(*http.Request); ok {
+			proto := "http://"
+			if request.TLS != nil {
+				proto = "https://"
+			}
+
+			event.MetaData.Update(MetaData{
+				"Request": {
+					"RemoteAddr": request.RemoteAddr,
+					"Method":     request.Method,
+					"Url":        proto + request.Host + request.RequestURI,
+					"Params":     request.URL.Query(),
+				},
+			})
+
+			// Add headers as a separate tab.
+			event.MetaData.AddStruct("Headers", request.Header)
+
+			// Default context to Path
+			if event.Context == "" {
+				event.Context = request.URL.Path
+			}
+
+			// Default user.id to IP so that users-affected works.
+			if event.User == nil {
+				ip := request.RemoteAddr
+				if idx := strings.LastIndex(ip, ":"); idx != -1 {
+					ip = ip[:idx]
+				}
+				event.User = &User{Id: ip}
+			}
+		}
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/middleware_test.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/middleware_test.go
@@ -1,0 +1,88 @@
+package bugsnag
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"reflect"
+	"testing"
+)
+
+func TestMiddlewareOrder(t *testing.T) {
+
+	result := make([]int, 0, 7)
+	stack := middlewareStack{}
+	stack.OnBeforeNotify(func(e *Event, c *Configuration) error {
+		result = append(result, 2)
+		return nil
+	})
+	stack.OnBeforeNotify(func(e *Event, c *Configuration) error {
+		result = append(result, 1)
+		return nil
+	})
+	stack.OnBeforeNotify(func(e *Event, c *Configuration) error {
+		result = append(result, 0)
+		return nil
+	})
+
+	stack.Run(nil, nil, func() error {
+		result = append(result, 3)
+		return nil
+	})
+
+	if !reflect.DeepEqual(result, []int{0, 1, 2, 3}) {
+		t.Errorf("unexpected middleware order %v", result)
+	}
+}
+
+func TestBeforeNotifyReturnErr(t *testing.T) {
+
+	stack := middlewareStack{}
+	err := fmt.Errorf("test")
+
+	stack.OnBeforeNotify(func(e *Event, c *Configuration) error {
+		return err
+	})
+
+	called := false
+
+	e := stack.Run(nil, nil, func() error {
+		called = true
+		return nil
+	})
+
+	if e != err {
+		t.Errorf("Middleware didn't return the error")
+	}
+
+	if called == true {
+		t.Errorf("Notify was called when BeforeNotify returned False")
+	}
+}
+
+func TestBeforeNotifyPanic(t *testing.T) {
+
+	stack := middlewareStack{}
+
+	stack.OnBeforeNotify(func(e *Event, c *Configuration) error {
+		panic("oops")
+	})
+
+	called := false
+	b := &bytes.Buffer{}
+
+	stack.Run(nil, &Configuration{Logger: log.New(b, log.Prefix(), 0)}, func() error {
+		called = true
+		return nil
+	})
+
+	logged := b.String()
+
+	if logged != "bugsnag/middleware: unexpected panic: oops\n" {
+		t.Errorf("Logged: %s", logged)
+	}
+
+	if called == false {
+		t.Errorf("Notify was not called when BeforeNotify panicked")
+	}
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/notifier.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/notifier.go
@@ -1,0 +1,102 @@
+package bugsnag
+
+import (
+	"fmt"
+
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors"
+)
+
+// Notifier sends errors to Bugsnag.
+type Notifier struct {
+	Config  *Configuration
+	RawData []interface{}
+}
+
+// New creates a new notifier.
+// You can pass an instance of bugsnag.Configuration in rawData to change the configuration.
+// Other values of rawData will be passed to Notify.
+func New(rawData ...interface{}) *Notifier {
+	config := Config.clone()
+	for i, datum := range rawData {
+		if c, ok := datum.(Configuration); ok {
+			config.update(&c)
+			rawData[i] = nil
+		}
+	}
+
+	return &Notifier{
+		Config:  config,
+		RawData: rawData,
+	}
+}
+
+// Notify sends an error to Bugsnag. Any rawData you pass here will be sent to
+// Bugsnag after being converted to JSON. e.g. bugsnag.SeverityError, bugsnag.Context,
+// or bugsnag.MetaData.
+func (notifier *Notifier) Notify(err error, rawData ...interface{}) (e error) {
+	event, config := newEvent(errors.New(err, 1), rawData, notifier)
+
+	// Never block, start throwing away errors if we have too many.
+	e = middleware.Run(event, config, func() error {
+		config.logf("notifying bugsnag: %s", event.Message)
+		if config.notifyInReleaseStage() {
+			if config.Synchronous {
+				return (&payload{event, config}).deliver()
+			}
+			// Ensure that any errors are logged if they occur in a goroutine.
+			go func(event *Event, config *Configuration) {
+				err := (&payload{event, config}).deliver()
+				if err != nil {
+					config.logf("bugsnag.Notify: %v", err)
+				}
+			}(event, config)
+
+			return nil
+		}
+		return fmt.Errorf("not notifying in %s", config.ReleaseStage)
+	})
+
+	if e != nil {
+		config.logf("bugsnag.Notify: %v", e)
+	}
+	return e
+}
+
+// AutoNotify notifies Bugsnag of any panics, then repanics.
+// It sends along any rawData that gets passed in.
+// Usage: defer AutoNotify()
+func (notifier *Notifier) AutoNotify(rawData ...interface{}) {
+	if err := recover(); err != nil {
+		rawData = notifier.addDefaultSeverity(rawData, SeverityError)
+		notifier.Notify(errors.New(err, 2), rawData...)
+		panic(err)
+	}
+}
+
+// Recover logs any panics, then recovers.
+// It sends along any rawData that gets passed in.
+// Usage: defer Recover()
+func (notifier *Notifier) Recover(rawData ...interface{}) {
+	if err := recover(); err != nil {
+		rawData = notifier.addDefaultSeverity(rawData, SeverityWarning)
+		notifier.Notify(errors.New(err, 2), rawData...)
+	}
+}
+
+func (notifier *Notifier) dontPanic() {
+	if err := recover(); err != nil {
+		notifier.Config.logf("bugsnag/notifier.Notify: panic! %s", err)
+	}
+}
+
+// Add a severity to raw data only if the default is not set.
+func (notifier *Notifier) addDefaultSeverity(rawData []interface{}, s severity) []interface{} {
+
+	for _, datum := range append(notifier.RawData, rawData...) {
+		if _, ok := datum.(severity); ok {
+			return rawData
+		}
+	}
+
+	return append(rawData, s)
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/panicwrap.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/panicwrap.go
@@ -1,0 +1,27 @@
+// +build !appengine
+
+package bugsnag
+
+import (
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/errors"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/bugsnag/panicwrap"
+)
+
+// NOTE: this function does not return when you call it, instead it
+// re-exec()s the current process with panic monitoring.
+func defaultPanicHandler() {
+	defer defaultNotifier.dontPanic()
+
+	err := panicwrap.BasicMonitor(func(output string) {
+		toNotify, err := errors.ParsePanic(output)
+
+		if err != nil {
+			defaultNotifier.Config.logf("bugsnag.handleUncaughtPanic: %v", err)
+		}
+		Notify(toNotify, SeverityError, Configuration{Synchronous: true})
+	})
+
+	if err != nil {
+		defaultNotifier.Config.logf("bugsnag.handleUncaughtPanic: %v", err)
+	}
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/panicwrap_test.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/panicwrap_test.go
@@ -1,0 +1,78 @@
+// +build !appengine
+
+package bugsnag
+
+import (
+	"github.com/bitly/go-simplejson"
+	"github.com/bugsnag/osext"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestPanicHandler(t *testing.T) {
+	startTestServer()
+
+	exePath, err := osext.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Use the same trick as panicwrap() to re-run ourselves.
+	// In the init() block below, we will then panic.
+	cmd := exec.Command(exePath, os.Args[1:]...)
+	cmd.Env = append(os.Environ(), "BUGSNAG_API_KEY="+testAPIKey, "BUGSNAG_ENDPOINT="+testEndpoint, "please_panic=please_panic")
+
+	if err = cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = cmd.Wait(); err.Error() != "exit status 2" {
+		t.Fatal(err)
+	}
+
+	json, err := simplejson.NewJson(<-postedJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event := json.Get("events").GetIndex(0)
+
+	if event.Get("severity").MustString() != "error" {
+		t.Errorf("severity should be error")
+	}
+	exception := event.Get("exceptions").GetIndex(0)
+
+	if exception.Get("message").MustString() != "ruh roh" {
+		t.Errorf("caught wrong panic")
+	}
+
+	if exception.Get("errorClass").MustString() != "panic" {
+		t.Errorf("caught wrong panic")
+	}
+
+	frame := exception.Get("stacktrace").GetIndex(1)
+
+	// Yeah, we just caught a panic from the init() function below and sent it to the server running above (mindblown)
+	if frame.Get("inProject").MustBool() != true ||
+		frame.Get("file").MustString() != "panicwrap_test.go" ||
+		frame.Get("lineNumber").MustInt() == 0 {
+		t.Errorf("stack trace seemed wrong: %v", frame)
+	}
+}
+
+func init() {
+	if os.Getenv("please_panic") != "" {
+		Configure(Configuration{APIKey: os.Getenv("BUGSNAG_API_KEY"), Endpoint: os.Getenv("BUGSNAG_ENDPOINT"), ProjectPackages: []string{"github.com/bugsnag/bugsnag-go"}})
+		go func() {
+			panick()
+		}()
+		// Plenty of time to crash, it shouldn't need any of it.
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func panick() {
+	panic("ruh roh")
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/payload.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go/payload.go
@@ -1,0 +1,96 @@
+package bugsnag
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type payload struct {
+	*Event
+	*Configuration
+}
+
+type hash map[string]interface{}
+
+func (p *payload) deliver() error {
+
+	if len(p.APIKey) != 32 {
+		return fmt.Errorf("bugsnag/payload.deliver: invalid api key")
+	}
+
+	buf, err := json.Marshal(p)
+
+	if err != nil {
+		return fmt.Errorf("bugsnag/payload.deliver: %v", err)
+	}
+
+	client := http.Client{
+		Transport: p.Transport,
+	}
+
+	resp, err := client.Post(p.Endpoint, "application/json", bytes.NewBuffer(buf))
+
+	if err != nil {
+		return fmt.Errorf("bugsnag/payload.deliver: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("bugsnag/payload.deliver: Got HTTP %s\n", resp.Status)
+	}
+
+	return nil
+}
+
+func (p *payload) MarshalJSON() ([]byte, error) {
+
+	data := hash{
+		"apiKey": p.APIKey,
+
+		"notifier": hash{
+			"name":    "Bugsnag Go",
+			"url":     "https://github.com/bugsnag/bugsnag-go",
+			"version": VERSION,
+		},
+
+		"events": []hash{
+			{
+				"payloadVersion": "2",
+				"exceptions": []hash{
+					{
+						"errorClass": p.ErrorClass,
+						"message":    p.Message,
+						"stacktrace": p.Stacktrace,
+					},
+				},
+				"severity": p.Severity.String,
+				"app": hash{
+					"releaseStage": p.ReleaseStage,
+				},
+				"user":     p.User,
+				"metaData": p.MetaData.sanitize(p.ParamsFilters),
+			},
+		},
+	}
+
+	event := data["events"].([]hash)[0]
+
+	if p.Context != "" {
+		event["context"] = p.Context
+	}
+	if p.GroupingHash != "" {
+		event["groupingHash"] = p.GroupingHash
+	}
+	if p.Hostname != "" {
+		event["device"] = hash{
+			"hostname": p.Hostname,
+		}
+	}
+	if p.AppVersion != "" {
+		event["app"].(hash)["version"] = p.AppVersion
+	}
+	return json.Marshal(data)
+
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/osext/LICENSE
+++ b/Godeps/_workspace/src/github.com/bugsnag/osext/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2012 Daniel Theophanes
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+   1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+
+   2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+
+   3. This notice may not be removed or altered from any source
+   distribution.

--- a/Godeps/_workspace/src/github.com/bugsnag/osext/osext.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/osext/osext.go
@@ -1,0 +1,32 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Extensions to the standard "os" package.
+package osext
+
+import "path/filepath"
+
+// Executable returns an absolute path that can be used to
+// re-invoke the current program.
+// It may not be valid after the current program exits.
+func Executable() (string, error) {
+	p, err := executable()
+	return filepath.Clean(p), err
+}
+
+// Returns same path as Executable, returns just the folder
+// path. Excludes the executable name.
+func ExecutableFolder() (string, error) {
+	p, err := Executable()
+	if err != nil {
+		return "", err
+	}
+	folder, _ := filepath.Split(p)
+	return folder, nil
+}
+
+// Depricated. Same as Executable().
+func GetExePath() (exePath string, err error) {
+	return Executable()
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/osext/osext_plan9.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/osext/osext_plan9.go
@@ -1,0 +1,16 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package osext
+
+import "syscall"
+
+func executable() (string, error) {
+	f, err := Open("/proc/" + itoa(Getpid()) + "/text")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	return syscall.Fd2path(int(f.Fd()))
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/osext/osext_procfs.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/osext/osext_procfs.go
@@ -1,0 +1,25 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux netbsd openbsd
+
+package osext
+
+import (
+	"errors"
+	"os"
+	"runtime"
+)
+
+func executable() (string, error) {
+	switch runtime.GOOS {
+	case "linux":
+		return os.Readlink("/proc/self/exe")
+	case "netbsd":
+		return os.Readlink("/proc/curproc/exe")
+	case "openbsd":
+		return os.Readlink("/proc/curproc/file")
+	}
+	return "", errors.New("ExecPath not implemented for " + runtime.GOOS)
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/osext/osext_sysctl.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/osext/osext_sysctl.go
@@ -1,0 +1,64 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin freebsd
+
+package osext
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+var startUpcwd, getwdError = os.Getwd()
+
+func executable() (string, error) {
+	var mib [4]int32
+	switch runtime.GOOS {
+	case "freebsd":
+		mib = [4]int32{1 /* CTL_KERN */, 14 /* KERN_PROC */, 12 /* KERN_PROC_PATHNAME */, -1}
+	case "darwin":
+		mib = [4]int32{1 /* CTL_KERN */, 38 /* KERN_PROCARGS */, int32(os.Getpid()), -1}
+	}
+
+	n := uintptr(0)
+	// get length
+	_, _, err := syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, 0, uintptr(unsafe.Pointer(&n)), 0, 0)
+	if err != 0 {
+		return "", err
+	}
+	if n == 0 { // shouldn't happen
+		return "", nil
+	}
+	buf := make([]byte, n)
+	_, _, err = syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, uintptr(unsafe.Pointer(&buf[0])), uintptr(unsafe.Pointer(&n)), 0, 0)
+	if err != 0 {
+		return "", err
+	}
+	if n == 0 { // shouldn't happen
+		return "", nil
+	}
+	for i, v := range buf {
+		if v == 0 {
+			buf = buf[:i]
+			break
+		}
+	}
+	if buf[0] != '/' {
+		if getwdError != nil {
+			return string(buf), getwdError
+		} else {
+			if buf[0] == '.' {
+				buf = buf[1:]
+			}
+			if startUpcwd[len(startUpcwd)-1] != '/' {
+				return startUpcwd + "/" + string(buf), nil
+			}
+			return startUpcwd + string(buf), nil
+		}
+	}
+	return string(buf), nil
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/osext/osext_test.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/osext/osext_test.go
@@ -1,0 +1,79 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin linux freebsd netbsd windows
+
+package osext
+
+import (
+	"fmt"
+	"os"
+	oexec "os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const execPath_EnvVar = "OSTEST_OUTPUT_EXECPATH"
+
+func TestExecPath(t *testing.T) {
+	ep, err := Executable()
+	if err != nil {
+		t.Fatalf("ExecPath failed: %v", err)
+	}
+	// we want fn to be of the form "dir/prog"
+	dir := filepath.Dir(filepath.Dir(ep))
+	fn, err := filepath.Rel(dir, ep)
+	if err != nil {
+		t.Fatalf("filepath.Rel: %v", err)
+	}
+	cmd := &oexec.Cmd{}
+	// make child start with a relative program path
+	cmd.Dir = dir
+	cmd.Path = fn
+	// forge argv[0] for child, so that we can verify we could correctly
+	// get real path of the executable without influenced by argv[0].
+	cmd.Args = []string{"-", "-test.run=XXXX"}
+	cmd.Env = []string{fmt.Sprintf("%s=1", execPath_EnvVar)}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("exec(self) failed: %v", err)
+	}
+	outs := string(out)
+	if !filepath.IsAbs(outs) {
+		t.Fatalf("Child returned %q, want an absolute path", out)
+	}
+	if !sameFile(outs, ep) {
+		t.Fatalf("Child returned %q, not the same file as %q", out, ep)
+	}
+}
+
+func sameFile(fn1, fn2 string) bool {
+	fi1, err := os.Stat(fn1)
+	if err != nil {
+		return false
+	}
+	fi2, err := os.Stat(fn2)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(fi1, fi2)
+}
+
+func init() {
+	if e := os.Getenv(execPath_EnvVar); e != "" {
+		// first chdir to another path
+		dir := "/"
+		if runtime.GOOS == "windows" {
+			dir = filepath.VolumeName(".")
+		}
+		os.Chdir(dir)
+		if ep, err := Executable(); err != nil {
+			fmt.Fprint(os.Stderr, "ERROR: ", err)
+		} else {
+			fmt.Fprint(os.Stderr, ep)
+		}
+		os.Exit(0)
+	}
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/osext/osext_windows.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/osext/osext_windows.go
@@ -1,0 +1,34 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package osext
+
+import (
+	"syscall"
+	"unicode/utf16"
+	"unsafe"
+)
+
+var (
+	kernel                = syscall.MustLoadDLL("kernel32.dll")
+	getModuleFileNameProc = kernel.MustFindProc("GetModuleFileNameW")
+)
+
+// GetModuleFileName() with hModule = NULL
+func executable() (exePath string, err error) {
+	return getModuleFileName()
+}
+
+func getModuleFileName() (string, error) {
+	var n uint32
+	b := make([]uint16, syscall.MAX_PATH)
+	size := uint32(len(b))
+
+	r0, _, e1 := getModuleFileNameProc.Call(0, uintptr(unsafe.Pointer(&b[0])), uintptr(size))
+	n = uint32(r0)
+	if n == 0 {
+		return "", e1
+	}
+	return string(utf16.Decode(b[0:n])), nil
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/panicwrap/CHANGELOG.md
+++ b/Godeps/_workspace/src/github.com/bugsnag/panicwrap/CHANGELOG.md
@@ -1,0 +1,11 @@
+## 1.1.0 (2016-01-18)
+
+* Add ARM64 support
+  [liusdu](https://github.com/liusdu)
+  [#1](https://github.com/bugsnag/panicwrap/pull/1)
+
+## 1.0.0 (2014-11-10)
+
+### Enhancements
+
+* Add ability to monitor a process

--- a/Godeps/_workspace/src/github.com/bugsnag/panicwrap/LICENSE
+++ b/Godeps/_workspace/src/github.com/bugsnag/panicwrap/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/bugsnag/panicwrap/README.md
+++ b/Godeps/_workspace/src/github.com/bugsnag/panicwrap/README.md
@@ -1,0 +1,101 @@
+# panicwrap
+
+panicwrap is a Go library that re-executes a Go binary and monitors stderr
+output from the binary for a panic. When it find a panic, it executes a
+user-defined handler function. Stdout, stderr, stdin, signals, and exit
+codes continue to work as normal, making the existence of panicwrap mostly
+invisble to the end user until a panic actually occurs.
+
+Since a panic is truly a bug in the program meant to crash the runtime,
+globally catching panics within Go applications is not supposed to be possible.
+Despite this, it is often useful to have a way to know when panics occur.
+panicwrap allows you to do something with these panics, such as writing them
+to a file, so that you can track when panics occur.
+
+panicwrap is ***not a panic recovery system***. Panics indicate serious
+problems with your application and _should_ crash the runtime. panicwrap
+is just meant as a way to monitor for panics. If you still think this is
+the worst idea ever, read the section below on why.
+
+## Features
+
+* **SIMPLE!**
+* Works with all Go applications on all platforms Go supports
+* Custom behavior when a panic occurs
+* Stdout, stderr, stdin, exit codes, and signals continue to work as
+  expected.
+
+## Usage
+
+Using panicwrap is simple. It behaves a lot like `fork`, if you know
+how that works. A basic example is shown below.
+
+Because it would be sad to panic while capturing a panic, it is recommended
+that the handler functions for panicwrap remain relatively simple and well
+tested. panicwrap itself contains many tests.
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/mitchellh/panicwrap"
+	"os"
+)
+
+func main() {
+	exitStatus, err := panicwrap.BasicWrap(panicHandler)
+	if err != nil {
+		// Something went wrong setting up the panic wrapper. Unlikely,
+		// but possible.
+		panic(err)
+	}
+
+	// If exitStatus >= 0, then we're the parent process and the panicwrap
+	// re-executed ourselves and completed. Just exit with the proper status.
+	if exitStatus >= 0 {
+		os.Exit(exitStatus)
+	}
+
+	// Otherwise, exitStatus < 0 means we're the child. Continue executing as
+	// normal...
+
+	// Let's say we panic
+	panic("oh shucks")
+}
+
+func panicHandler(output string) {
+	// output contains the full output (including stack traces) of the
+	// panic. Put it in a file or something.
+	fmt.Printf("The child panicked:\n\n%s\n", output)
+	os.Exit(1)
+}
+```
+
+## How Does it Work?
+
+panicwrap works by re-executing the running program (retaining arguments,
+environmental variables, etc.) and monitoring the stderr of the program.
+Since Go always outputs panics in a predictable way with a predictable
+exit code, panicwrap is able to reliably detect panics and allow the parent
+process to handle them.
+
+## WHY?! Panics should CRASH!
+
+Yes, panics _should_ crash. They are 100% always indicative of bugs.
+However, in some cases, such as user-facing programs (programs like
+[Packer](http://github.com/mitchellh/packer) or
+[Docker](http://github.com/dotcloud/docker)), it is up to the user to
+report such panics. This is unreliable, at best, and it would be better if the
+program could have a way to automatically report panics. panicwrap provides
+a way to do this.
+
+For backend applications, it is easier to detect crashes (since the application
+exits). However, it is still nice sometimes to more intelligently log
+panics in some way. For example, at [HashiCorp](http://www.hashicorp.com),
+we use panicwrap to log panics to timestamped files with some additional
+data (configuration settings at the time, environmental variables, etc.)
+
+The goal of panicwrap is _not_ to hide panics. It is instead to provide
+a clean mechanism for handling them before bubbling the up to the user
+and ultimately crashing.

--- a/Godeps/_workspace/src/github.com/bugsnag/panicwrap/dup2.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/panicwrap/dup2.go
@@ -1,0 +1,11 @@
+// +build darwin dragonfly freebsd linux,!arm64 netbsd openbsd
+
+package panicwrap
+
+import (
+	"syscall"
+)
+
+func dup2(oldfd, newfd int) error {
+	return syscall.Dup2(oldfd, newfd)
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/panicwrap/dup3.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/panicwrap/dup3.go
@@ -1,0 +1,11 @@
+// +build linux,arm64
+
+package panicwrap
+
+import (
+	"syscall"
+)
+
+func dup2(oldfd, newfd int) error {
+	return syscall.Dup3(oldfd, newfd, 0)
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/panicwrap/monitor.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/panicwrap/monitor.go
@@ -1,0 +1,62 @@
+// +build !windows
+
+package panicwrap
+
+import (
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/bugsnag/osext"
+	"os"
+	"os/exec"
+)
+
+func monitor(c *WrapConfig) (int, error) {
+
+	// If we're the child process, absorb panics.
+	if Wrapped(c) {
+		panicCh := make(chan string)
+
+		go trackPanic(os.Stdin, os.Stderr, c.DetectDuration, panicCh)
+
+		// Wait on the panic data
+		panicTxt := <-panicCh
+		if panicTxt != "" {
+			if !c.HidePanic {
+				os.Stderr.Write([]byte(panicTxt))
+			}
+
+			c.Handler(panicTxt)
+		}
+
+		os.Exit(0)
+	}
+
+	exePath, err := osext.Executable()
+	if err != nil {
+		return -1, err
+	}
+	cmd := exec.Command(exePath, os.Args[1:]...)
+
+	read, write, err := os.Pipe()
+	if err != nil {
+		return -1, err
+	}
+
+	cmd.Stdin = read
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), c.CookieKey+"="+c.CookieValue)
+
+	if err != nil {
+		return -1, err
+	}
+	err = cmd.Start()
+	if err != nil {
+		return -1, err
+	}
+
+	err = dup2(int(write.Fd()), int(os.Stderr.Fd()))
+	if err != nil {
+		return -1, err
+	}
+
+	return -1, nil
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/panicwrap/monitor_windows.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/panicwrap/monitor_windows.go
@@ -1,0 +1,7 @@
+package panicwrap
+
+import "fmt"
+
+func monitor(c *WrapConfig) (int, error) {
+	return -1, fmt.Errorf("Monitor is not supported on windows")
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/panicwrap/panicwrap.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/panicwrap/panicwrap.go
@@ -1,0 +1,340 @@
+// The panicwrap package provides functions for capturing and handling
+// panics in your application. It does this by re-executing the running
+// application and monitoring stderr for any panics. At the same time,
+// stdout/stderr/etc. are set to the same values so that data is shuttled
+// through properly, making the existence of panicwrap mostly transparent.
+//
+// Panics are only detected when the subprocess exits with a non-zero
+// exit status, since this is the only time panics are real. Otherwise,
+// "panic-like" output is ignored.
+package panicwrap
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+	"syscall"
+	"time"
+
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/bugsnag/osext"
+)
+
+const (
+	DEFAULT_COOKIE_KEY = "cccf35992f8f3cd8d1d28f0109dd953e26664531"
+	DEFAULT_COOKIE_VAL = "7c28215aca87789f95b406b8dd91aa5198406750"
+)
+
+// HandlerFunc is the type called when a panic is detected.
+type HandlerFunc func(string)
+
+// WrapConfig is the configuration for panicwrap when wrapping an existing
+// binary. To get started, in general, you only need the BasicWrap function
+// that will set this up for you. However, for more customizability,
+// WrapConfig and Wrap can be used.
+type WrapConfig struct {
+	// Handler is the function called when a panic occurs.
+	Handler HandlerFunc
+
+	// The cookie key and value are used within environmental variables
+	// to tell the child process that it is already executing so that
+	// wrap doesn't re-wrap itself.
+	CookieKey   string
+	CookieValue string
+
+	// If true, the panic will not be mirrored to the configured writer
+	// and will instead ONLY go to the handler. This lets you effectively
+	// hide panics from the end user. This is not recommended because if
+	// your handler fails, the panic is effectively lost.
+	HidePanic bool
+
+	// If true, panicwrap will boot a monitor sub-process and let the parent
+	// run the app. This mode is useful for processes run under supervisors
+	// like runit as signals get sent to the correct codebase. This is not
+	// supported when GOOS=windows, and ignores c.Stderr and c.Stdout.
+	Monitor bool
+
+	// The amount of time that a process must exit within after detecting
+	// a panic header for panicwrap to assume it is a panic. Defaults to
+	// 300 milliseconds.
+	DetectDuration time.Duration
+
+	// The writer to send the stderr to. If this is nil, then it defaults
+	// to os.Stderr.
+	Writer io.Writer
+
+	// The writer to send stdout to. If this is nil, then it defaults to
+	// os.Stdout.
+	Stdout io.Writer
+}
+
+// BasicWrap calls Wrap with the given handler function, using defaults
+// for everything else. See Wrap and WrapConfig for more information on
+// functionality and return values.
+func BasicWrap(f HandlerFunc) (int, error) {
+	return Wrap(&WrapConfig{
+		Handler: f,
+	})
+}
+
+// BasicMonitor calls Wrap with Monitor set to true on supported platforms.
+// It forks your program and runs it again form the start. In one process
+// BasicMonitor never returns, it just listens on stderr of the other process,
+// and calls your handler when a panic is seen. In the other it either returns
+// nil to indicate that the panic monitoring is enabled, or an error to indicate
+// that something else went wrong.
+func BasicMonitor(f HandlerFunc) error {
+	exitStatus, err := Wrap(&WrapConfig{
+		Handler: f,
+		Monitor: runtime.GOOS != "windows",
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if exitStatus >= 0 {
+		os.Exit(exitStatus)
+	}
+
+	return nil
+}
+
+// Wrap wraps the current executable in a handler to catch panics. It
+// returns an error if there was an error during the wrapping process.
+// If the error is nil, then the int result indicates the exit status of the
+// child process. If the exit status is -1, then this is the child process,
+// and execution should continue as normal. Otherwise, this is the parent
+// process and the child successfully ran already, and you should exit the
+// process with the returned exit status.
+//
+// This function should be called very very early in your program's execution.
+// Ideally, this runs as the first line of code of main.
+//
+// Once this is called, the given WrapConfig shouldn't be modified or used
+// any further.
+func Wrap(c *WrapConfig) (int, error) {
+	if c.Handler == nil {
+		return -1, errors.New("Handler must be set")
+	}
+
+	if c.DetectDuration == 0 {
+		c.DetectDuration = 300 * time.Millisecond
+	}
+
+	if c.Writer == nil {
+		c.Writer = os.Stderr
+	}
+
+	if c.Monitor {
+		return monitor(c)
+	} else {
+		return wrap(c)
+	}
+}
+
+func wrap(c *WrapConfig) (int, error) {
+
+	// If we're already wrapped, exit out.
+	if Wrapped(c) {
+		return -1, nil
+	}
+
+	// Get the path to our current executable
+	exePath, err := osext.Executable()
+	if err != nil {
+		return -1, err
+	}
+
+	// Pipe the stderr so we can read all the data as we look for panics
+	stderr_r, stderr_w := io.Pipe()
+
+	// doneCh is closed when we're done, signaling any other goroutines
+	// to end immediately.
+	doneCh := make(chan struct{})
+
+	// panicCh is the channel on which the panic text will actually be
+	// sent.
+	panicCh := make(chan string)
+
+	// On close, make sure to finish off the copying of data to stderr
+	defer func() {
+		defer close(doneCh)
+		stderr_w.Close()
+		<-panicCh
+	}()
+
+	// Start the goroutine that will watch stderr for any panics
+	go trackPanic(stderr_r, c.Writer, c.DetectDuration, panicCh)
+
+	// Create the writer for stdout that we're going to use
+	var stdout_w io.Writer = os.Stdout
+	if c.Stdout != nil {
+		stdout_w = c.Stdout
+	}
+
+	// Build a subcommand to re-execute ourselves. We make sure to
+	// set the environmental variable to include our cookie. We also
+	// set stdin/stdout to match the config. Finally, we pipe stderr
+	// through ourselves in order to watch for panics.
+	cmd := exec.Command(exePath, os.Args[1:]...)
+	cmd.Env = append(os.Environ(), c.CookieKey+"="+c.CookieValue)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = stdout_w
+	cmd.Stderr = stderr_w
+	if err := cmd.Start(); err != nil {
+		return 1, err
+	}
+
+	// Listen to signals and capture them forever. We allow the child
+	// process to handle them in some way.
+	sigCh := make(chan os.Signal)
+	signal.Notify(sigCh, os.Interrupt)
+	go func() {
+		defer signal.Stop(sigCh)
+		for {
+			select {
+			case <-doneCh:
+				return
+			case <-sigCh:
+			}
+		}
+	}()
+
+	if err := cmd.Wait(); err != nil {
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			// This is some other kind of subprocessing error.
+			return 1, err
+		}
+
+		exitStatus := 1
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+			exitStatus = status.ExitStatus()
+		}
+
+		// Close the writer end so that the tracker goroutine ends at some point
+		stderr_w.Close()
+
+		// Wait on the panic data
+		panicTxt := <-panicCh
+		if panicTxt != "" {
+			if !c.HidePanic {
+				c.Writer.Write([]byte(panicTxt))
+			}
+
+			c.Handler(panicTxt)
+		}
+
+		return exitStatus, nil
+	}
+
+	return 0, nil
+}
+
+// Wrapped checks if we're already wrapped according to the configuration
+// given.
+//
+// Wrapped is very cheap and can be used early to short-circuit some pre-wrap
+// logic your application may have.
+func Wrapped(c *WrapConfig) bool {
+	if c.CookieKey == "" {
+		c.CookieKey = DEFAULT_COOKIE_KEY
+	}
+
+	if c.CookieValue == "" {
+		c.CookieValue = DEFAULT_COOKIE_VAL
+	}
+
+	// If the cookie key/value match our environment, then we are the
+	// child, so just exit now and tell the caller that we're the child
+	return os.Getenv(c.CookieKey) == c.CookieValue
+}
+
+// trackPanic monitors the given reader for a panic. If a panic is detected,
+// it is outputted on the result channel. This will close the channel once
+// it is complete.
+func trackPanic(r io.Reader, w io.Writer, dur time.Duration, result chan<- string) {
+	defer close(result)
+
+	var panicTimer <-chan time.Time
+	panicBuf := new(bytes.Buffer)
+	panicHeader := []byte("panic:")
+
+	tempBuf := make([]byte, 2048)
+	for {
+		var buf []byte
+		var n int
+
+		if panicTimer == nil && panicBuf.Len() > 0 {
+			// We're not tracking a panic but the buffer length is
+			// greater than 0. We need to clear out that buffer, but
+			// look for another panic along the way.
+
+			// First, remove the previous panic header so we don't loop
+			w.Write(panicBuf.Next(len(panicHeader)))
+
+			// Next, assume that this is our new buffer to inspect
+			n = panicBuf.Len()
+			buf = make([]byte, n)
+			copy(buf, panicBuf.Bytes())
+			panicBuf.Reset()
+		} else {
+			var err error
+			buf = tempBuf
+			n, err = r.Read(buf)
+			if n <= 0 && err == io.EOF {
+				if panicBuf.Len() > 0 {
+					// We were tracking a panic, assume it was a panic
+					// and return that as the result.
+					result <- panicBuf.String()
+				}
+
+				return
+			}
+		}
+
+		if panicTimer != nil {
+			// We're tracking what we think is a panic right now.
+			// If the timer ended, then it is not a panic.
+			isPanic := true
+			select {
+			case <-panicTimer:
+				isPanic = false
+			default:
+			}
+
+			// No matter what, buffer the text some more.
+			panicBuf.Write(buf[0:n])
+
+			if !isPanic {
+				// It isn't a panic, stop tracking. Clean-up will happen
+				// on the next iteration.
+				panicTimer = nil
+			}
+
+			continue
+		}
+
+		flushIdx := n
+		idx := bytes.Index(buf[0:n], panicHeader)
+		if idx >= 0 {
+			flushIdx = idx
+		}
+
+		// Flush to stderr what isn't a panic
+		w.Write(buf[0:flushIdx])
+
+		if idx < 0 {
+			// Not a panic so just continue along
+			continue
+		}
+
+		// We have a panic header. Write we assume is a panic os far.
+		panicBuf.Write(buf[idx:n])
+		panicTimer = time.After(dur)
+	}
+}

--- a/Godeps/_workspace/src/github.com/bugsnag/panicwrap/panicwrap_test.go
+++ b/Godeps/_workspace/src/github.com/bugsnag/panicwrap/panicwrap_test.go
@@ -1,0 +1,360 @@
+package panicwrap
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func helperProcess(s ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--"}
+	cs = append(cs, s...)
+	env := []string{
+		"GO_WANT_HELPER_PROCESS=1",
+	}
+
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = append(env, os.Environ()...)
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	return cmd
+}
+
+// This is executed by `helperProcess` in a separate process in order to
+// provider a proper sub-process environment to test some of our functionality.
+func TestHelperProcess(*testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	// Find the arguments to our helper, which are the arguments past
+	// the "--" in the command line.
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+
+		args = args[1:]
+	}
+
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "No command\n")
+		os.Exit(2)
+	}
+
+	panicHandler := func(s string) {
+		fmt.Fprintf(os.Stdout, "wrapped: %d", len(s))
+		os.Exit(0)
+	}
+
+	cmd, args := args[0], args[1:]
+	switch cmd {
+	case "no-panic-ordered-output":
+		exitStatus, err := BasicWrap(panicHandler)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
+			os.Exit(1)
+		}
+
+		if exitStatus < 0 {
+			for i := 0; i < 1000; i++ {
+				os.Stdout.Write([]byte("a"))
+				os.Stderr.Write([]byte("b"))
+			}
+			os.Exit(0)
+		}
+
+		os.Exit(exitStatus)
+	case "no-panic-output":
+		fmt.Fprint(os.Stdout, "i am output")
+		fmt.Fprint(os.Stderr, "stderr out")
+		os.Exit(0)
+	case "panic-boundary":
+		exitStatus, err := BasicWrap(panicHandler)
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
+			os.Exit(1)
+		}
+
+		if exitStatus < 0 {
+			// Simulate a panic but on two boundaries...
+			fmt.Fprint(os.Stderr, "pan")
+			os.Stderr.Sync()
+			time.Sleep(100 * time.Millisecond)
+			fmt.Fprint(os.Stderr, "ic: oh crap")
+			os.Exit(2)
+		}
+
+		os.Exit(exitStatus)
+	case "panic-long":
+		exitStatus, err := BasicWrap(panicHandler)
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
+			os.Exit(1)
+		}
+
+		if exitStatus < 0 {
+			// Make a fake panic by faking the header and adding a
+			// bunch of garbage.
+			fmt.Fprint(os.Stderr, "panic: foo\n\n")
+			for i := 0; i < 1024; i++ {
+				fmt.Fprint(os.Stderr, "foobarbaz")
+			}
+
+			// Sleep so that it dumps the previous data
+			//time.Sleep(1 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
+
+			// Make a real panic
+			panic("I AM REAL!")
+		}
+
+		os.Exit(exitStatus)
+	case "panic":
+		hidePanic := false
+		if args[0] == "hide" {
+			hidePanic = true
+		}
+
+		config := &WrapConfig{
+			Handler:   panicHandler,
+			HidePanic: hidePanic,
+		}
+
+		exitStatus, err := Wrap(config)
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
+			os.Exit(1)
+		}
+
+		if exitStatus < 0 {
+			panic("uh oh")
+		}
+
+		os.Exit(exitStatus)
+	case "wrapped":
+		child := false
+		if len(args) > 0 && args[0] == "child" {
+			child = true
+		}
+		config := &WrapConfig{
+			Handler: panicHandler,
+		}
+
+		exitStatus, err := Wrap(config)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
+			os.Exit(1)
+		}
+
+		if exitStatus < 0 {
+			if child {
+				fmt.Printf("%v", Wrapped(config))
+			}
+			os.Exit(0)
+		}
+
+		if !child {
+			fmt.Printf("%v", Wrapped(config))
+		}
+		os.Exit(exitStatus)
+	case "panic-monitor":
+
+		config := &WrapConfig{
+			Handler: panicHandler,
+			HidePanic: true,
+			Monitor: true,
+		}
+
+		exitStatus, err := Wrap(config)
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
+			os.Exit(1)
+		}
+
+		if exitStatus != -1 {
+			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
+			os.Exit(1)
+		}
+
+		panic("uh oh")
+
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown command: %q\n", cmd)
+		os.Exit(2)
+	}
+}
+
+func TestPanicWrap_Output(t *testing.T) {
+	stderr := new(bytes.Buffer)
+	stdout := new(bytes.Buffer)
+
+	p := helperProcess("no-panic-output")
+	p.Stdout = stdout
+	p.Stderr = stderr
+	if err := p.Run(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(stdout.String(), "i am output") {
+		t.Fatalf("didn't forward: %#v", stdout.String())
+	}
+
+	if !strings.Contains(stderr.String(), "stderr out") {
+		t.Fatalf("didn't forward: %#v", stderr.String())
+	}
+}
+
+/*
+TODO(mitchellh): This property would be nice to gain.
+func TestPanicWrap_Output_Order(t *testing.T) {
+	output := new(bytes.Buffer)
+
+	p := helperProcess("no-panic-ordered-output")
+	p.Stdout = output
+	p.Stderr = output
+	if err := p.Run(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expectedBuf := new(bytes.Buffer)
+	for i := 0; i < 1000; i++ {
+		expectedBuf.WriteString("ab")
+	}
+
+	actual := strings.TrimSpace(output.String())
+	expected := strings.TrimSpace(expectedBuf.String())
+
+	if actual != expected {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+*/
+
+func TestPanicWrap_panicHide(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	p := helperProcess("panic", "hide")
+	p.Stdout = stdout
+	p.Stderr = stderr
+	if err := p.Run(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(stdout.String(), "wrapped:") {
+		t.Fatalf("didn't wrap: %#v", stdout.String())
+	}
+
+	if strings.Contains(stderr.String(), "panic:") {
+		t.Fatalf("shouldn't have panic: %#v", stderr.String())
+	}
+}
+
+func TestPanicWrap_panicShow(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	p := helperProcess("panic", "show")
+	p.Stdout = stdout
+	p.Stderr = stderr
+	if err := p.Run(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(stdout.String(), "wrapped:") {
+		t.Fatalf("didn't wrap: %#v", stdout.String())
+	}
+
+	if !strings.Contains(stderr.String(), "panic:") {
+		t.Fatalf("should have panic: %#v", stderr.String())
+	}
+}
+
+func TestPanicWrap_panicLong(t *testing.T) {
+	stdout := new(bytes.Buffer)
+
+	p := helperProcess("panic-long")
+	p.Stdout = stdout
+	p.Stderr = new(bytes.Buffer)
+	if err := p.Run(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(stdout.String(), "wrapped:") {
+		t.Fatalf("didn't wrap: %#v", stdout.String())
+	}
+}
+
+func TestPanicWrap_panicBoundary(t *testing.T) {
+	// TODO(mitchellh): panics are currently lost on boundaries
+	t.SkipNow()
+
+	stdout := new(bytes.Buffer)
+
+	p := helperProcess("panic-boundary")
+	p.Stdout = stdout
+	//p.Stderr = new(bytes.Buffer)
+	if err := p.Run(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(stdout.String(), "wrapped: 1015") {
+		t.Fatalf("didn't wrap: %#v", stdout.String())
+	}
+}
+
+func TestPanicWrap_monitor(t *testing.T) {
+
+	stdout := new(bytes.Buffer)
+
+	p := helperProcess("panic-monitor")
+	p.Stdout = stdout
+	//p.Stderr = new(bytes.Buffer)
+	if err := p.Run(); err == nil || err.Error() != "exit status 2" {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(stdout.String(), "wrapped:") {
+		t.Fatalf("didn't wrap: %#v", stdout.String())
+	}
+}
+
+func TestWrapped(t *testing.T) {
+	stdout := new(bytes.Buffer)
+
+	p := helperProcess("wrapped", "child")
+	p.Stdout = stdout
+	if err := p.Run(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(stdout.String(), "true") {
+		t.Fatalf("bad: %#v", stdout.String())
+	}
+}
+
+func TestWrapped_parent(t *testing.T) {
+	stdout := new(bytes.Buffer)
+
+	p := helperProcess("wrapped")
+	p.Stdout = stdout
+	if err := p.Run(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(stdout.String(), "false") {
+		t.Fatalf("bad: %#v", stdout.String())
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/chtimes.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/chtimes.go
@@ -1,0 +1,52 @@
+package system
+
+import (
+	"os"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+var (
+	maxTime time.Time
+)
+
+func init() {
+	if unsafe.Sizeof(syscall.Timespec{}.Nsec) == 8 {
+		// This is a 64 bit timespec
+		// os.Chtimes limits time to the following
+		maxTime = time.Unix(0, 1<<63-1)
+	} else {
+		// This is a 32 bit timespec
+		maxTime = time.Unix(1<<31-1, 0)
+	}
+}
+
+// Chtimes changes the access time and modified time of a file at the given path
+func Chtimes(name string, atime time.Time, mtime time.Time) error {
+	unixMinTime := time.Unix(0, 0)
+	unixMaxTime := maxTime
+
+	// If the modified time is prior to the Unix Epoch, or after the
+	// end of Unix Time, os.Chtimes has undefined behavior
+	// default to Unix Epoch in this case, just in case
+
+	if atime.Before(unixMinTime) || atime.After(unixMaxTime) {
+		atime = unixMinTime
+	}
+
+	if mtime.Before(unixMinTime) || mtime.After(unixMaxTime) {
+		mtime = unixMinTime
+	}
+
+	if err := os.Chtimes(name, atime, mtime); err != nil {
+		return err
+	}
+
+	// Take platform specific action for setting create time.
+	if err := setCTime(name, mtime); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/chtimes_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/chtimes_test.go
@@ -1,0 +1,94 @@
+package system
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// prepareTempFile creates a temporary file in a temporary directory.
+func prepareTempFile(t *testing.T) (string, string) {
+	dir, err := ioutil.TempDir("", "docker-system-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file := filepath.Join(dir, "exist")
+	if err := ioutil.WriteFile(file, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return file, dir
+}
+
+// TestChtimes tests Chtimes on a tempfile. Test only mTime, because aTime is OS dependent
+func TestChtimes(t *testing.T) {
+	file, dir := prepareTempFile(t)
+	defer os.RemoveAll(dir)
+
+	beforeUnixEpochTime := time.Unix(0, 0).Add(-100 * time.Second)
+	unixEpochTime := time.Unix(0, 0)
+	afterUnixEpochTime := time.Unix(100, 0)
+	unixMaxTime := maxTime
+
+	// Test both aTime and mTime set to Unix Epoch
+	Chtimes(file, unixEpochTime, unixEpochTime)
+
+	f, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f.ModTime() != unixEpochTime {
+		t.Fatalf("Expected: %s, got: %s", unixEpochTime, f.ModTime())
+	}
+
+	// Test aTime before Unix Epoch and mTime set to Unix Epoch
+	Chtimes(file, beforeUnixEpochTime, unixEpochTime)
+
+	f, err = os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f.ModTime() != unixEpochTime {
+		t.Fatalf("Expected: %s, got: %s", unixEpochTime, f.ModTime())
+	}
+
+	// Test aTime set to Unix Epoch and mTime before Unix Epoch
+	Chtimes(file, unixEpochTime, beforeUnixEpochTime)
+
+	f, err = os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f.ModTime() != unixEpochTime {
+		t.Fatalf("Expected: %s, got: %s", unixEpochTime, f.ModTime())
+	}
+
+	// Test both aTime and mTime set to after Unix Epoch (valid time)
+	Chtimes(file, afterUnixEpochTime, afterUnixEpochTime)
+
+	f, err = os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f.ModTime() != afterUnixEpochTime {
+		t.Fatalf("Expected: %s, got: %s", afterUnixEpochTime, f.ModTime())
+	}
+
+	// Test both aTime and mTime set to Unix max time
+	Chtimes(file, unixMaxTime, unixMaxTime)
+
+	f, err = os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f.ModTime().Truncate(time.Second) != unixMaxTime.Truncate(time.Second) {
+		t.Fatalf("Expected: %s, got: %s", unixMaxTime.Truncate(time.Second), f.ModTime().Truncate(time.Second))
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/chtimes_unix.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/chtimes_unix.go
@@ -1,0 +1,14 @@
+// +build !windows
+
+package system
+
+import (
+	"time"
+)
+
+//setCTime will set the create time on a file. On Unix, the create
+//time is updated as a side effect of setting the modified time, so
+//no action is required.
+func setCTime(path string, ctime time.Time) error {
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/chtimes_unix_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/chtimes_unix_test.go
@@ -1,0 +1,91 @@
+// +build !windows
+
+package system
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestChtimes tests Chtimes access time on a tempfile on Linux
+func TestChtimesLinux(t *testing.T) {
+	file, dir := prepareTempFile(t)
+	defer os.RemoveAll(dir)
+
+	beforeUnixEpochTime := time.Unix(0, 0).Add(-100 * time.Second)
+	unixEpochTime := time.Unix(0, 0)
+	afterUnixEpochTime := time.Unix(100, 0)
+	unixMaxTime := maxTime
+
+	// Test both aTime and mTime set to Unix Epoch
+	Chtimes(file, unixEpochTime, unixEpochTime)
+
+	f, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stat := f.Sys().(*syscall.Stat_t)
+	aTime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+	if aTime != unixEpochTime {
+		t.Fatalf("Expected: %s, got: %s", unixEpochTime, aTime)
+	}
+
+	// Test aTime before Unix Epoch and mTime set to Unix Epoch
+	Chtimes(file, beforeUnixEpochTime, unixEpochTime)
+
+	f, err = os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stat = f.Sys().(*syscall.Stat_t)
+	aTime = time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+	if aTime != unixEpochTime {
+		t.Fatalf("Expected: %s, got: %s", unixEpochTime, aTime)
+	}
+
+	// Test aTime set to Unix Epoch and mTime before Unix Epoch
+	Chtimes(file, unixEpochTime, beforeUnixEpochTime)
+
+	f, err = os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stat = f.Sys().(*syscall.Stat_t)
+	aTime = time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+	if aTime != unixEpochTime {
+		t.Fatalf("Expected: %s, got: %s", unixEpochTime, aTime)
+	}
+
+	// Test both aTime and mTime set to after Unix Epoch (valid time)
+	Chtimes(file, afterUnixEpochTime, afterUnixEpochTime)
+
+	f, err = os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stat = f.Sys().(*syscall.Stat_t)
+	aTime = time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+	if aTime != afterUnixEpochTime {
+		t.Fatalf("Expected: %s, got: %s", afterUnixEpochTime, aTime)
+	}
+
+	// Test both aTime and mTime set to Unix max time
+	Chtimes(file, unixMaxTime, unixMaxTime)
+
+	f, err = os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stat = f.Sys().(*syscall.Stat_t)
+	aTime = time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+	if aTime.Truncate(time.Second) != unixMaxTime.Truncate(time.Second) {
+		t.Fatalf("Expected: %s, got: %s", unixMaxTime.Truncate(time.Second), aTime.Truncate(time.Second))
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/chtimes_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/chtimes_windows.go
@@ -1,0 +1,27 @@
+// +build windows
+
+package system
+
+import (
+	"syscall"
+	"time"
+)
+
+//setCTime will set the create time on a file. On Windows, this requires
+//calling SetFileTime and explicitly including the create time.
+func setCTime(path string, ctime time.Time) error {
+	ctimespec := syscall.NsecToTimespec(ctime.UnixNano())
+	pathp, e := syscall.UTF16PtrFromString(path)
+	if e != nil {
+		return e
+	}
+	h, e := syscall.CreateFile(pathp,
+		syscall.FILE_WRITE_ATTRIBUTES, syscall.FILE_SHARE_WRITE, nil,
+		syscall.OPEN_EXISTING, syscall.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	if e != nil {
+		return e
+	}
+	defer syscall.Close(h)
+	c := syscall.NsecToFiletime(syscall.TimespecToNsec(ctimespec))
+	return syscall.SetFileTime(h, &c, nil, nil)
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/chtimes_windows_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/chtimes_windows_test.go
@@ -1,0 +1,86 @@
+// +build windows
+
+package system
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestChtimes tests Chtimes access time on a tempfile on Windows
+func TestChtimesWindows(t *testing.T) {
+	file, dir := prepareTempFile(t)
+	defer os.RemoveAll(dir)
+
+	beforeUnixEpochTime := time.Unix(0, 0).Add(-100 * time.Second)
+	unixEpochTime := time.Unix(0, 0)
+	afterUnixEpochTime := time.Unix(100, 0)
+	unixMaxTime := maxTime
+
+	// Test both aTime and mTime set to Unix Epoch
+	Chtimes(file, unixEpochTime, unixEpochTime)
+
+	f, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aTime := time.Unix(0, f.Sys().(*syscall.Win32FileAttributeData).LastAccessTime.Nanoseconds())
+	if aTime != unixEpochTime {
+		t.Fatalf("Expected: %s, got: %s", unixEpochTime, aTime)
+	}
+
+	// Test aTime before Unix Epoch and mTime set to Unix Epoch
+	Chtimes(file, beforeUnixEpochTime, unixEpochTime)
+
+	f, err = os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aTime = time.Unix(0, f.Sys().(*syscall.Win32FileAttributeData).LastAccessTime.Nanoseconds())
+	if aTime != unixEpochTime {
+		t.Fatalf("Expected: %s, got: %s", unixEpochTime, aTime)
+	}
+
+	// Test aTime set to Unix Epoch and mTime before Unix Epoch
+	Chtimes(file, unixEpochTime, beforeUnixEpochTime)
+
+	f, err = os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aTime = time.Unix(0, f.Sys().(*syscall.Win32FileAttributeData).LastAccessTime.Nanoseconds())
+	if aTime != unixEpochTime {
+		t.Fatalf("Expected: %s, got: %s", unixEpochTime, aTime)
+	}
+
+	// Test both aTime and mTime set to after Unix Epoch (valid time)
+	Chtimes(file, afterUnixEpochTime, afterUnixEpochTime)
+
+	f, err = os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aTime = time.Unix(0, f.Sys().(*syscall.Win32FileAttributeData).LastAccessTime.Nanoseconds())
+	if aTime != afterUnixEpochTime {
+		t.Fatalf("Expected: %s, got: %s", afterUnixEpochTime, aTime)
+	}
+
+	// Test both aTime and mTime set to Unix max time
+	Chtimes(file, unixMaxTime, unixMaxTime)
+
+	f, err = os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aTime = time.Unix(0, f.Sys().(*syscall.Win32FileAttributeData).LastAccessTime.Nanoseconds())
+	if aTime.Truncate(time.Second) != unixMaxTime.Truncate(time.Second) {
+		t.Fatalf("Expected: %s, got: %s", unixMaxTime.Truncate(time.Second), aTime.Truncate(time.Second))
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/errors.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/errors.go
@@ -1,0 +1,10 @@
+package system
+
+import (
+	"errors"
+)
+
+var (
+	// ErrNotSupportedPlatform means the platform is not supported.
+	ErrNotSupportedPlatform = errors.New("platform and architecture is not supported")
+)

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/events_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/events_windows.go
@@ -1,0 +1,83 @@
+package system
+
+// This file implements syscalls for Win32 events which are not implemented
+// in golang.
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	procCreateEvent = modkernel32.NewProc("CreateEventW")
+	procOpenEvent   = modkernel32.NewProc("OpenEventW")
+	procSetEvent    = modkernel32.NewProc("SetEvent")
+	procResetEvent  = modkernel32.NewProc("ResetEvent")
+	procPulseEvent  = modkernel32.NewProc("PulseEvent")
+)
+
+// CreateEvent implements win32 CreateEventW func in golang. It will create an event object.
+func CreateEvent(eventAttributes *syscall.SecurityAttributes, manualReset bool, initialState bool, name string) (handle syscall.Handle, err error) {
+	namep, _ := syscall.UTF16PtrFromString(name)
+	var _p1 uint32
+	if manualReset {
+		_p1 = 1
+	}
+	var _p2 uint32
+	if initialState {
+		_p2 = 1
+	}
+	r0, _, e1 := procCreateEvent.Call(uintptr(unsafe.Pointer(eventAttributes)), uintptr(_p1), uintptr(_p2), uintptr(unsafe.Pointer(namep)))
+	use(unsafe.Pointer(namep))
+	handle = syscall.Handle(r0)
+	if handle == syscall.InvalidHandle {
+		err = e1
+	}
+	return
+}
+
+// OpenEvent implements win32 OpenEventW func in golang. It opens an event object.
+func OpenEvent(desiredAccess uint32, inheritHandle bool, name string) (handle syscall.Handle, err error) {
+	namep, _ := syscall.UTF16PtrFromString(name)
+	var _p1 uint32
+	if inheritHandle {
+		_p1 = 1
+	}
+	r0, _, e1 := procOpenEvent.Call(uintptr(desiredAccess), uintptr(_p1), uintptr(unsafe.Pointer(namep)))
+	use(unsafe.Pointer(namep))
+	handle = syscall.Handle(r0)
+	if handle == syscall.InvalidHandle {
+		err = e1
+	}
+	return
+}
+
+// SetEvent implements win32 SetEvent func in golang.
+func SetEvent(handle syscall.Handle) (err error) {
+	return setResetPulse(handle, procSetEvent)
+}
+
+// ResetEvent implements win32 ResetEvent func in golang.
+func ResetEvent(handle syscall.Handle) (err error) {
+	return setResetPulse(handle, procResetEvent)
+}
+
+// PulseEvent implements win32 PulseEvent func in golang.
+func PulseEvent(handle syscall.Handle) (err error) {
+	return setResetPulse(handle, procPulseEvent)
+}
+
+func setResetPulse(handle syscall.Handle, proc *syscall.LazyProc) (err error) {
+	r0, _, _ := proc.Call(uintptr(handle))
+	if r0 != 0 {
+		err = syscall.Errno(r0)
+	}
+	return
+}
+
+var temp unsafe.Pointer
+
+// use ensures a variable is kept alive without the GC freeing while still needed
+func use(p unsafe.Pointer) {
+	temp = p
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/filesys.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/filesys.go
@@ -1,0 +1,19 @@
+// +build !windows
+
+package system
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// MkdirAll creates a directory named path along with any necessary parents,
+// with permission specified by attribute perm for all dir created.
+func MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+// IsAbs is a platform-specific wrapper for filepath.IsAbs.
+func IsAbs(path string) bool {
+	return filepath.IsAbs(path)
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/filesys_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/filesys_windows.go
@@ -1,0 +1,82 @@
+// +build windows
+
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"syscall"
+)
+
+// MkdirAll implementation that is volume path aware for Windows.
+func MkdirAll(path string, perm os.FileMode) error {
+	if re := regexp.MustCompile(`^\\\\\?\\Volume{[a-z0-9-]+}$`); re.MatchString(path) {
+		return nil
+	}
+
+	// The rest of this method is copied from os.MkdirAll and should be kept
+	// as-is to ensure compatibility.
+
+	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
+	dir, err := os.Stat(path)
+	if err == nil {
+		if dir.IsDir() {
+			return nil
+		}
+		return &os.PathError{
+			Op:   "mkdir",
+			Path: path,
+			Err:  syscall.ENOTDIR,
+		}
+	}
+
+	// Slow path: make sure parent exists and then call Mkdir for path.
+	i := len(path)
+	for i > 0 && os.IsPathSeparator(path[i-1]) { // Skip trailing path separator.
+		i--
+	}
+
+	j := i
+	for j > 0 && !os.IsPathSeparator(path[j-1]) { // Scan backward over element.
+		j--
+	}
+
+	if j > 1 {
+		// Create parent
+		err = MkdirAll(path[0:j-1], perm)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Parent now exists; invoke Mkdir and use its result.
+	err = os.Mkdir(path, perm)
+	if err != nil {
+		// Handle arguments like "foo/." by
+		// double-checking that directory doesn't exist.
+		dir, err1 := os.Lstat(path)
+		if err1 == nil && dir.IsDir() {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// IsAbs is a platform-specific wrapper for filepath.IsAbs. On Windows,
+// golang filepath.IsAbs does not consider a path \windows\system32 as absolute
+// as it doesn't start with a drive-letter/colon combination. However, in
+// docker we need to verify things such as WORKDIR /windows/system32 in
+// a Dockerfile (which gets translated to \windows\system32 when being processed
+// by the daemon. This SHOULD be treated as absolute from a docker processing
+// perspective.
+func IsAbs(path string) bool {
+	if !filepath.IsAbs(path) {
+		if !strings.HasPrefix(path, string(os.PathSeparator)) {
+			return false
+		}
+	}
+	return true
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat.go
@@ -1,0 +1,19 @@
+// +build !windows
+
+package system
+
+import (
+	"syscall"
+)
+
+// Lstat takes a path to a file and returns
+// a system.StatT type pertaining to that file.
+//
+// Throws an error if the file does not exist
+func Lstat(path string) (*StatT, error) {
+	s := &syscall.Stat_t{}
+	if err := syscall.Lstat(path, s); err != nil {
+		return nil, err
+	}
+	return fromStatT(s)
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat_unix_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat_unix_test.go
@@ -1,0 +1,30 @@
+// +build linux freebsd
+
+package system
+
+import (
+	"os"
+	"testing"
+)
+
+// TestLstat tests Lstat for existing and non existing files
+func TestLstat(t *testing.T) {
+	file, invalid, _, dir := prepareFiles(t)
+	defer os.RemoveAll(dir)
+
+	statFile, err := Lstat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statFile == nil {
+		t.Fatal("returned empty stat for existing file")
+	}
+
+	statInvalid, err := Lstat(invalid)
+	if err == nil {
+		t.Fatal("did not return error for non-existing file")
+	}
+	if statInvalid != nil {
+		t.Fatal("returned non-nil stat for non-existing file")
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat_windows.go
@@ -1,0 +1,25 @@
+// +build windows
+
+package system
+
+import (
+	"os"
+)
+
+// Lstat calls os.Lstat to get a fileinfo interface back.
+// This is then copied into our own locally defined structure.
+// Note the Linux version uses fromStatT to do the copy back,
+// but that not strictly necessary when already in an OS specific module.
+func Lstat(path string) (*StatT, error) {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &StatT{
+		name:    fi.Name(),
+		size:    fi.Size(),
+		mode:    fi.Mode(),
+		modTime: fi.ModTime(),
+		isDir:   fi.IsDir()}, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/meminfo.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/meminfo.go
@@ -1,0 +1,17 @@
+package system
+
+// MemInfo contains memory statistics of the host system.
+type MemInfo struct {
+	// Total usable RAM (i.e. physical RAM minus a few reserved bits and the
+	// kernel binary code).
+	MemTotal int64
+
+	// Amount of free memory.
+	MemFree int64
+
+	// Total amount of swap space available.
+	SwapTotal int64
+
+	// Amount of swap space that is currently unused.
+	SwapFree int64
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/meminfo_linux.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/meminfo_linux.go
@@ -1,0 +1,66 @@
+package system
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/docker/go-units"
+)
+
+// ReadMemInfo retrieves memory statistics of the host system and returns a
+//  MemInfo type.
+func ReadMemInfo() (*MemInfo, error) {
+	file, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return parseMemInfo(file)
+}
+
+// parseMemInfo parses the /proc/meminfo file into
+// a MemInfo object given a io.Reader to the file.
+//
+// Throws error if there are problems reading from the file
+func parseMemInfo(reader io.Reader) (*MemInfo, error) {
+	meminfo := &MemInfo{}
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		// Expected format: ["MemTotal:", "1234", "kB"]
+		parts := strings.Fields(scanner.Text())
+
+		// Sanity checks: Skip malformed entries.
+		if len(parts) < 3 || parts[2] != "kB" {
+			continue
+		}
+
+		// Convert to bytes.
+		size, err := strconv.Atoi(parts[1])
+		if err != nil {
+			continue
+		}
+		bytes := int64(size) * units.KiB
+
+		switch parts[0] {
+		case "MemTotal:":
+			meminfo.MemTotal = bytes
+		case "MemFree:":
+			meminfo.MemFree = bytes
+		case "SwapTotal:":
+			meminfo.SwapTotal = bytes
+		case "SwapFree:":
+			meminfo.SwapFree = bytes
+		}
+
+	}
+
+	// Handle errors that may have occurred during the reading of the file.
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return meminfo, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/meminfo_unix_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/meminfo_unix_test.go
@@ -1,0 +1,40 @@
+// +build linux freebsd
+
+package system
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docker/go-units"
+)
+
+// TestMemInfo tests parseMemInfo with a static meminfo string
+func TestMemInfo(t *testing.T) {
+	const input = `
+	MemTotal:      1 kB
+	MemFree:       2 kB
+	SwapTotal:     3 kB
+	SwapFree:      4 kB
+	Malformed1:
+	Malformed2:    1
+	Malformed3:    2 MB
+	Malformed4:    X kB
+	`
+	meminfo, err := parseMemInfo(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meminfo.MemTotal != 1*units.KiB {
+		t.Fatalf("Unexpected MemTotal: %d", meminfo.MemTotal)
+	}
+	if meminfo.MemFree != 2*units.KiB {
+		t.Fatalf("Unexpected MemFree: %d", meminfo.MemFree)
+	}
+	if meminfo.SwapTotal != 3*units.KiB {
+		t.Fatalf("Unexpected SwapTotal: %d", meminfo.SwapTotal)
+	}
+	if meminfo.SwapFree != 4*units.KiB {
+		t.Fatalf("Unexpected SwapFree: %d", meminfo.SwapFree)
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/meminfo_unsupported.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/meminfo_unsupported.go
@@ -1,0 +1,8 @@
+// +build !linux,!windows
+
+package system
+
+// ReadMemInfo is not supported on platforms other than linux and windows.
+func ReadMemInfo() (*MemInfo, error) {
+	return nil, ErrNotSupportedPlatform
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/meminfo_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/meminfo_windows.go
@@ -1,0 +1,44 @@
+package system
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+	procGlobalMemoryStatusEx = modkernel32.NewProc("GlobalMemoryStatusEx")
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa366589(v=vs.85).aspx
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa366770(v=vs.85).aspx
+type memorystatusex struct {
+	dwLength                uint32
+	dwMemoryLoad            uint32
+	ullTotalPhys            uint64
+	ullAvailPhys            uint64
+	ullTotalPageFile        uint64
+	ullAvailPageFile        uint64
+	ullTotalVirtual         uint64
+	ullAvailVirtual         uint64
+	ullAvailExtendedVirtual uint64
+}
+
+// ReadMemInfo retrieves memory statistics of the host system and returns a
+//  MemInfo type.
+func ReadMemInfo() (*MemInfo, error) {
+	msi := &memorystatusex{
+		dwLength: 64,
+	}
+	r1, _, _ := procGlobalMemoryStatusEx.Call(uintptr(unsafe.Pointer(msi)))
+	if r1 == 0 {
+		return &MemInfo{}, nil
+	}
+	return &MemInfo{
+		MemTotal:  int64(msi.ullTotalPhys),
+		MemFree:   int64(msi.ullAvailPhys),
+		SwapTotal: int64(msi.ullTotalPageFile),
+		SwapFree:  int64(msi.ullAvailPageFile),
+	}, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/mknod.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/mknod.go
@@ -1,0 +1,22 @@
+// +build !windows
+
+package system
+
+import (
+	"syscall"
+)
+
+// Mknod creates a filesystem node (file, device special file or named pipe) named path
+// with attributes specified by mode and dev.
+func Mknod(path string, mode uint32, dev int) error {
+	return syscall.Mknod(path, mode, dev)
+}
+
+// Mkdev is used to build the value of linux devices (in /dev/) which specifies major
+// and minor number of the newly created device special file.
+// Linux device nodes are a bit weird due to backwards compat with 16 bit device nodes.
+// They are, from low to high: the lower 8 bits of the minor, then 12 bits of the major,
+// then the top 12 bits of the minor.
+func Mkdev(major int64, minor int64) uint32 {
+	return uint32(((minor & 0xfff00) << 12) | ((major & 0xfff) << 8) | (minor & 0xff))
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/mknod_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/mknod_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package system
+
+// Mknod is not implemented on Windows.
+func Mknod(path string, mode uint32, dev int) error {
+	return ErrNotSupportedPlatform
+}
+
+// Mkdev is not implemented on Windows.
+func Mkdev(major int64, minor int64) uint32 {
+	panic("Mkdev not implemented on Windows.")
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/path_unix.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/path_unix.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package system
+
+// DefaultPathEnv is unix style list of directories to search for
+// executables. Each directory is separated from the next by a colon
+// ':' character .
+const DefaultPathEnv = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/path_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/path_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package system
+
+// DefaultPathEnv is deliberately empty on Windows as the default path will be set by
+// the container. Docker has no context of what the default path should be.
+const DefaultPathEnv = ""

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat.go
@@ -1,0 +1,53 @@
+// +build !windows
+
+package system
+
+import (
+	"syscall"
+)
+
+// StatT type contains status of a file. It contains metadata
+// like permission, owner, group, size, etc about a file.
+type StatT struct {
+	mode uint32
+	uid  uint32
+	gid  uint32
+	rdev uint64
+	size int64
+	mtim syscall.Timespec
+}
+
+// Mode returns file's permission mode.
+func (s StatT) Mode() uint32 {
+	return s.mode
+}
+
+// UID returns file's user id of owner.
+func (s StatT) UID() uint32 {
+	return s.uid
+}
+
+// GID returns file's group id of owner.
+func (s StatT) GID() uint32 {
+	return s.gid
+}
+
+// Rdev returns file's device ID (if it's special file).
+func (s StatT) Rdev() uint64 {
+	return s.rdev
+}
+
+// Size returns file's size.
+func (s StatT) Size() int64 {
+	return s.size
+}
+
+// Mtim returns file's last modification time.
+func (s StatT) Mtim() syscall.Timespec {
+	return s.mtim
+}
+
+// GetLastModification returns file's last modification time.
+func (s StatT) GetLastModification() syscall.Timespec {
+	return s.Mtim()
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_freebsd.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_freebsd.go
@@ -1,0 +1,27 @@
+package system
+
+import (
+	"syscall"
+)
+
+// fromStatT converts a syscall.Stat_t type to a system.Stat_t type
+func fromStatT(s *syscall.Stat_t) (*StatT, error) {
+	return &StatT{size: s.Size,
+		mode: uint32(s.Mode),
+		uid:  s.Uid,
+		gid:  s.Gid,
+		rdev: uint64(s.Rdev),
+		mtim: s.Mtimespec}, nil
+}
+
+// Stat takes a path to a file and returns
+// a system.Stat_t type pertaining to that file.
+//
+// Throws an error if the file does not exist
+func Stat(path string) (*StatT, error) {
+	s := &syscall.Stat_t{}
+	if err := syscall.Stat(path, s); err != nil {
+		return nil, err
+	}
+	return fromStatT(s)
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_linux.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_linux.go
@@ -1,0 +1,33 @@
+package system
+
+import (
+	"syscall"
+)
+
+// fromStatT converts a syscall.Stat_t type to a system.Stat_t type
+func fromStatT(s *syscall.Stat_t) (*StatT, error) {
+	return &StatT{size: s.Size,
+		mode: s.Mode,
+		uid:  s.Uid,
+		gid:  s.Gid,
+		rdev: s.Rdev,
+		mtim: s.Mtim}, nil
+}
+
+// FromStatT exists only on linux, and loads a system.StatT from a
+// syscal.Stat_t.
+func FromStatT(s *syscall.Stat_t) (*StatT, error) {
+	return fromStatT(s)
+}
+
+// Stat takes a path to a file and returns
+// a system.StatT type pertaining to that file.
+//
+// Throws an error if the file does not exist
+func Stat(path string) (*StatT, error) {
+	s := &syscall.Stat_t{}
+	if err := syscall.Stat(path, s); err != nil {
+		return nil, err
+	}
+	return fromStatT(s)
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_solaris.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_solaris.go
@@ -1,0 +1,17 @@
+// +build solaris
+
+package system
+
+import (
+	"syscall"
+)
+
+// fromStatT creates a system.StatT type from a syscall.Stat_t type
+func fromStatT(s *syscall.Stat_t) (*StatT, error) {
+	return &StatT{size: s.Size,
+		mode: uint32(s.Mode),
+		uid:  s.Uid,
+		gid:  s.Gid,
+		rdev: uint64(s.Rdev),
+		mtim: s.Mtim}, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_unix_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_unix_test.go
@@ -1,0 +1,39 @@
+// +build linux freebsd
+
+package system
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// TestFromStatT tests fromStatT for a tempfile
+func TestFromStatT(t *testing.T) {
+	file, _, _, dir := prepareFiles(t)
+	defer os.RemoveAll(dir)
+
+	stat := &syscall.Stat_t{}
+	err := syscall.Lstat(file, stat)
+
+	s, err := fromStatT(stat)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if stat.Mode != s.Mode() {
+		t.Fatal("got invalid mode")
+	}
+	if stat.Uid != s.UID() {
+		t.Fatal("got invalid uid")
+	}
+	if stat.Gid != s.GID() {
+		t.Fatal("got invalid gid")
+	}
+	if stat.Rdev != s.Rdev() {
+		t.Fatal("got invalid rdev")
+	}
+	if stat.Mtim != s.Mtim() {
+		t.Fatal("got invalid mtim")
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_unsupported.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_unsupported.go
@@ -1,0 +1,17 @@
+// +build !linux,!windows,!freebsd,!solaris
+
+package system
+
+import (
+	"syscall"
+)
+
+// fromStatT creates a system.StatT type from a syscall.Stat_t type
+func fromStatT(s *syscall.Stat_t) (*StatT, error) {
+	return &StatT{size: s.Size,
+		mode: uint32(s.Mode),
+		uid:  s.Uid,
+		gid:  s.Gid,
+		rdev: uint64(s.Rdev),
+		mtim: s.Mtimespec}, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_windows.go
@@ -1,0 +1,43 @@
+// +build windows
+
+package system
+
+import (
+	"os"
+	"time"
+)
+
+// StatT type contains status of a file. It contains metadata
+// like name, permission, size, etc about a file.
+type StatT struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	isDir   bool
+}
+
+// Name returns file's name.
+func (s StatT) Name() string {
+	return s.name
+}
+
+// Size returns file's size.
+func (s StatT) Size() int64 {
+	return s.size
+}
+
+// Mode returns file's permission mode.
+func (s StatT) Mode() os.FileMode {
+	return s.mode
+}
+
+// ModTime returns file's last modification time.
+func (s StatT) ModTime() time.Time {
+	return s.modTime
+}
+
+// IsDir returns whether file is actually a directory.
+func (s StatT) IsDir() bool {
+	return s.isDir
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/syscall_unix.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/syscall_unix.go
@@ -1,0 +1,11 @@
+// +build linux freebsd
+
+package system
+
+import "syscall"
+
+// Unmount is a platform-specific helper function to call
+// the unmount syscall.
+func Unmount(dest string) error {
+	return syscall.Unmount(dest, 0)
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/syscall_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/syscall_windows.go
@@ -1,0 +1,36 @@
+package system
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// OSVersion is a wrapper for Windows version information
+// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724439(v=vs.85).aspx
+type OSVersion struct {
+	Version      uint32
+	MajorVersion uint8
+	MinorVersion uint8
+	Build        uint16
+}
+
+// GetOSVersion gets the operating system version on Windows. Note that
+// docker.exe must be manifested to get the correct version information.
+func GetOSVersion() (OSVersion, error) {
+	var err error
+	osv := OSVersion{}
+	osv.Version, err = syscall.GetVersion()
+	if err != nil {
+		return osv, fmt.Errorf("Failed to call GetVersion()")
+	}
+	osv.MajorVersion = uint8(osv.Version & 0xFF)
+	osv.MinorVersion = uint8(osv.Version >> 8 & 0xFF)
+	osv.Build = uint16(osv.Version >> 16)
+	return osv, nil
+}
+
+// Unmount is a platform-specific helper function to call
+// the unmount syscall. Not supported on Windows
+func Unmount(dest string) error {
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/umask.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/umask.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+package system
+
+import (
+	"syscall"
+)
+
+// Umask sets current process's file mode creation mask to newmask
+// and return oldmask.
+func Umask(newmask int) (oldmask int, err error) {
+	return syscall.Umask(newmask), nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/umask_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/umask_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package system
+
+// Umask is not supported on the windows platform.
+func Umask(newmask int) (oldmask int, err error) {
+	// should not be called on cli code path
+	return 0, ErrNotSupportedPlatform
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/utimes_darwin.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/utimes_darwin.go
@@ -1,0 +1,8 @@
+package system
+
+import "syscall"
+
+// LUtimesNano is not supported by darwin platform.
+func LUtimesNano(path string, ts []syscall.Timespec) error {
+	return ErrNotSupportedPlatform
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/utimes_freebsd.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/utimes_freebsd.go
@@ -1,0 +1,22 @@
+package system
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// LUtimesNano is used to change access and modification time of the specified path.
+// It's used for symbol link file because syscall.UtimesNano doesn't support a NOFOLLOW flag atm.
+func LUtimesNano(path string, ts []syscall.Timespec) error {
+	var _path *byte
+	_path, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+
+	if _, _, err := syscall.Syscall(syscall.SYS_LUTIMES, uintptr(unsafe.Pointer(_path)), uintptr(unsafe.Pointer(&ts[0])), 0); err != 0 && err != syscall.ENOSYS {
+		return err
+	}
+
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/utimes_linux.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/utimes_linux.go
@@ -1,0 +1,26 @@
+package system
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// LUtimesNano is used to change access and modification time of the specified path.
+// It's used for symbol link file because syscall.UtimesNano doesn't support a NOFOLLOW flag atm.
+func LUtimesNano(path string, ts []syscall.Timespec) error {
+	// These are not currently available in syscall
+	atFdCwd := -100
+	atSymLinkNoFollow := 0x100
+
+	var _path *byte
+	_path, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+
+	if _, _, err := syscall.Syscall6(syscall.SYS_UTIMENSAT, uintptr(atFdCwd), uintptr(unsafe.Pointer(_path)), uintptr(unsafe.Pointer(&ts[0])), uintptr(atSymLinkNoFollow), 0, 0); err != 0 && err != syscall.ENOSYS {
+		return err
+	}
+
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/utimes_unix_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/utimes_unix_test.go
@@ -1,0 +1,68 @@
+// +build linux freebsd
+
+package system
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// prepareFiles creates files for testing in the temp directory
+func prepareFiles(t *testing.T) (string, string, string, string) {
+	dir, err := ioutil.TempDir("", "docker-system-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file := filepath.Join(dir, "exist")
+	if err := ioutil.WriteFile(file, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	invalid := filepath.Join(dir, "doesnt-exist")
+
+	symlink := filepath.Join(dir, "symlink")
+	if err := os.Symlink(file, symlink); err != nil {
+		t.Fatal(err)
+	}
+
+	return file, invalid, symlink, dir
+}
+
+func TestLUtimesNano(t *testing.T) {
+	file, invalid, symlink, dir := prepareFiles(t)
+	defer os.RemoveAll(dir)
+
+	before, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts := []syscall.Timespec{{0, 0}, {0, 0}}
+	if err := LUtimesNano(symlink, ts); err != nil {
+		t.Fatal(err)
+	}
+
+	symlinkInfo, err := os.Lstat(symlink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.ModTime().Unix() == symlinkInfo.ModTime().Unix() {
+		t.Fatal("The modification time of the symlink should be different")
+	}
+
+	fileInfo, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.ModTime().Unix() != fileInfo.ModTime().Unix() {
+		t.Fatal("The modification time of the file should be same")
+	}
+
+	if err := LUtimesNano(invalid, ts); err == nil {
+		t.Fatal("Doesn't return an error on a non-existing file")
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/utimes_unsupported.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/utimes_unsupported.go
@@ -1,0 +1,10 @@
+// +build !linux,!freebsd,!darwin
+
+package system
+
+import "syscall"
+
+// LUtimesNano is not supported on platforms other than linux, freebsd and darwin.
+func LUtimesNano(path string, ts []syscall.Timespec) error {
+	return ErrNotSupportedPlatform
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/xattrs_linux.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/xattrs_linux.go
@@ -1,0 +1,63 @@
+package system
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// Lgetxattr retrieves the value of the extended attribute identified by attr
+// and associated with the given path in the file system.
+// It will returns a nil slice and nil error if the xattr is not set.
+func Lgetxattr(path string, attr string) ([]byte, error) {
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	attrBytes, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return nil, err
+	}
+
+	dest := make([]byte, 128)
+	destBytes := unsafe.Pointer(&dest[0])
+	sz, _, errno := syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+	if errno == syscall.ENODATA {
+		return nil, nil
+	}
+	if errno == syscall.ERANGE {
+		dest = make([]byte, sz)
+		destBytes := unsafe.Pointer(&dest[0])
+		sz, _, errno = syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+	}
+	if errno != 0 {
+		return nil, errno
+	}
+
+	return dest[:sz], nil
+}
+
+var _zero uintptr
+
+// Lsetxattr sets the value of the extended attribute identified by attr
+// and associated with the given path in the file system.
+func Lsetxattr(path string, attr string, data []byte, flags int) error {
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+	attrBytes, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return err
+	}
+	var dataBytes unsafe.Pointer
+	if len(data) > 0 {
+		dataBytes = unsafe.Pointer(&data[0])
+	} else {
+		dataBytes = unsafe.Pointer(&_zero)
+	}
+	_, _, errno := syscall.Syscall6(syscall.SYS_LSETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(dataBytes), uintptr(len(data)), uintptr(flags), 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/xattrs_unsupported.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/xattrs_unsupported.go
@@ -1,0 +1,13 @@
+// +build !linux
+
+package system
+
+// Lgetxattr is not supported on platforms other than linux.
+func Lgetxattr(path string, attr string) ([]byte, error) {
+	return nil, ErrNotSupportedPlatform
+}
+
+// Lsetxattr is not supported on platforms other than linux.
+func Lsetxattr(path string, attr string, data []byte, flags int) error {
+	return ErrNotSupportedPlatform
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/term_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/term_windows.go
@@ -8,8 +8,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/Azure/go-ansiterm/winterm"
-	"github.com/docker/docker/pkg/system"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/docker/docker/pkg/system"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/docker/docker/pkg/term/windows"
 )
 

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/windows/ansi_reader.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/windows/ansi_reader.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"unsafe"
 
-	ansiterm "github.com/Azure/go-ansiterm"
-	"github.com/Azure/go-ansiterm/winterm"
+	ansiterm "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Azure/go-ansiterm"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm"
 )
 
 const (

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/windows/ansi_writer.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/windows/ansi_writer.go
@@ -6,8 +6,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	ansiterm "github.com/Azure/go-ansiterm"
-	"github.com/Azure/go-ansiterm/winterm"
+	ansiterm "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Azure/go-ansiterm"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/windows/console.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/windows/console.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/Azure/go-ansiterm/winterm"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Azure/go-ansiterm/winterm"
 
-	ansiterm "github.com/Azure/go-ansiterm"
+	ansiterm "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Azure/go-ansiterm"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"io/ioutil"
 )

--- a/Godeps/_workspace/src/github.com/eris-ltd/common/go/log/logger_bugsnag.go
+++ b/Godeps/_workspace/src/github.com/eris-ltd/common/go/log/logger_bugsnag.go
@@ -1,0 +1,103 @@
+package log
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"runtime/debug"
+
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	bugsnag "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/bugsnag/bugsnag-go"
+)
+
+// Default API Key. Can be overridden with the ERIS_BUGSNAG_TOKEN
+// environment variable.
+var APIKey = "1b9565bb7a4f8fd6dc446f2efd238fa3"
+
+// Bugsnag implements the CrashReporter and the logrus.Hook interfaces.
+type Bugsnag struct {
+	config map[string]string
+
+	remoteLogger *log.Logger
+}
+
+// NewBugsnagReporter configures the Bugsnag library and sets up a logger
+// for collecting logging messages.
+func NewBugsnagReporter(config map[string]string) Bugsnag {
+	if os.Getenv("ERIS_BUGSNAG_TOKEN") != "" {
+		APIKey = os.Getenv("ERIS_BUGSNAG_TOKEN")
+	}
+
+	bugsnag.Configure(bugsnag.Configuration{
+		APIKey:       APIKey,
+		Synchronous:  true,
+		AppVersion:   config["version"],
+		ReleaseStage: config["branch"],
+		// Bugsnag tries to say something itself occasionally.
+		Logger: &log.Logger{
+			Out:       os.Stdout,
+			Formatter: ConsoleFormatter(log.DebugLevel),
+			Level:     log.DebugLevel,
+		},
+		// Using our own panic recover.
+		PanicHandler: func() {},
+	})
+
+	return Bugsnag{
+		// Logger for silently collecting logging messages on all levels.
+		remoteLogger: &log.Logger{
+			Out:       new(bytes.Buffer),
+			Formatter: RemoteFormatter(log.DebugLevel),
+			Level:     log.DebugLevel,
+		},
+		config: config,
+	}
+}
+
+func (b Bugsnag) Hook() log.Hook {
+	return b
+}
+
+func (b Bugsnag) Levels() []log.Level {
+	// Collecting messages on all levels.
+	return []log.Level{
+		log.PanicLevel,
+		log.FatalLevel,
+		log.ErrorLevel,
+		log.WarnLevel,
+		log.InfoLevel,
+		log.DebugLevel,
+	}
+}
+
+func (b Bugsnag) Fire(e *log.Entry) error {
+	out, err := b.remoteLogger.Formatter.Format(e)
+	if err != nil {
+		// Not important.
+		return nil
+	}
+
+	b.remoteLogger.Out.Write(out)
+
+	return nil
+}
+
+func (b Bugsnag) SendReport(message interface{}) error {
+	debug.PrintStack()
+
+	// Sending out a panic along with some useful bits of information.
+	return bugsnag.Notify(
+		fmt.Errorf("%v", message),
+		bugsnag.ErrorClass{"panic"},
+		bugsnag.SeverityError,
+		bugsnag.User{Id: b.config["user"], Email: b.config["email"]},
+		bugsnag.MetaData{
+			"Log": {
+				"Debug Output": b.remoteLogger.Out.(*bytes.Buffer).String(),
+			},
+			"Docker": {
+				"Client": b.config["docker client"],
+			},
+		},
+	)
+}

--- a/Godeps/_workspace/src/github.com/eris-ltd/common/go/log/logger_new.go
+++ b/Godeps/_workspace/src/github.com/eris-ltd/common/go/log/logger_new.go
@@ -2,14 +2,23 @@ package log
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
-	"runtime"
 	"sort"
+
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/docker/docker/pkg/term"
 
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
-type ErisFormatter struct{}
+type ErisFormatter struct {
+	// Override the logging level to be able to collect logger messages
+	// at a level lower (more verbose) than the one is used for the console.
+	Level log.Level
+
+	// Provide color formatting for log messages.
+	Color bool
+}
 
 const (
 	arrowTag = "=>"
@@ -29,48 +38,26 @@ var (
 	escTag = tput("setaf", 241)
 )
 
-// Tput asks the terminfo database for a particular escape sequence.
-func tput(command string, params ...interface{}) []byte {
-	args := []string{command}
-
-	// Don't do anything on Windows.
-	if runtime.GOOS == "windows" {
-		return []byte{}
-	}
-
-	for _, param := range params {
-		switch param.(type) {
-		case string:
-			args = append(args, param.(string))
-		case int:
-			args = append(args, fmt.Sprintf("%d", param))
-		}
-	}
-
-	out, err := exec.Command("tput", args...).Output()
-	if err != nil {
-		return []byte{}
-	}
-
-	return out
+// RemoteFormatter returns the ErisFormatter with settings
+// suitable for the remote logging.
+func RemoteFormatter(level log.Level) ErisFormatter {
+	return ErisFormatter{Level: level}
 }
 
-// highlight emphasizes a tag and a comment. It returns the highlighted
-// text along with an offset where to place it on screen.
-func highlight(tag, comment string) (adjustedOffset int, text string) {
-	tagDecorated := fmt.Sprintf("%s%s%s", escTag, tag, escReset)
-	commentDecorated := fmt.Sprintf("%s%s%s", escBold, comment, escReset)
-
-	if tag == arrowTag {
-		return offset + 2, fmt.Sprintf("%s", commentDecorated)
-	} else {
-		return offset - len(tag) + 1, fmt.Sprintf("%s=%s", tagDecorated, commentDecorated)
-	}
+// ConsoleFormatter returns the ErisFormatter with settings
+// suitable for the console media.
+func ConsoleFormatter(level log.Level) ErisFormatter {
+	return ErisFormatter{Level: level, Color: true}
 }
 
 // Format implements the logrus.Formatter interface. It returns a formatted
 // log line as a slice of bytes.
 func (f ErisFormatter) Format(entry *log.Entry) (out []byte, err error) {
+	// Check if output is necessary.
+	if entry.Level > f.Level {
+		return []byte{}, nil
+	}
+
 	// Sort tag names in alphabetical order.
 	var keys []string
 	for key, _ := range entry.Data {
@@ -83,7 +70,7 @@ func (f ErisFormatter) Format(entry *log.Entry) (out []byte, err error) {
 		tag, comment := keys[0], fmt.Sprintf("%v", entry.Data[keys[0]])
 
 		// Highlight the tag.
-		adjustedOffset, text := highlight(tag, comment)
+		adjustedOffset, text := f.Highlight(tag, comment)
 
 		if len(entry.Message) < adjustedOffset-spacing {
 			// Message with the tag inline.
@@ -103,10 +90,50 @@ func (f ErisFormatter) Format(entry *log.Entry) (out []byte, err error) {
 	// Display every other tag on a separate line.
 	for _, key := range keys {
 		// Highlight the tag.
-		adjustedOffset, text := highlight(key, fmt.Sprintf("%v", entry.Data[key]))
+		adjustedOffset, text := f.Highlight(key, fmt.Sprintf("%v", entry.Data[key]))
 
 		out = append(out, fmt.Sprintf("%-*s%s\n", adjustedOffset, "", text)...)
 	}
 
 	return out, nil
+}
+
+// Highlight emphasizes a tag and a comment. It returns the highlighted
+// text along with an offset where to place it on screen.
+func (f ErisFormatter) Highlight(tag, comment string) (adjustedOffset int, text string) {
+	tagDecorated := tag
+	commentDecorated := comment
+
+	// Use color formatting if specified and if connected to the terminal.
+	if f.Color && term.IsTerminal(os.Stdout.Fd()) && term.IsTerminal(os.Stderr.Fd()) {
+		tagDecorated = fmt.Sprintf("%s%s%s", escTag, tag, escReset)
+		commentDecorated = fmt.Sprintf("%s%s%s", escBold, comment, escReset)
+	}
+
+	if tag == arrowTag {
+		return offset + 2, fmt.Sprintf("%s", commentDecorated)
+	} else {
+		return offset - len(tag) + 1, fmt.Sprintf("%s=%s", tagDecorated, commentDecorated)
+	}
+}
+
+// tput asks the terminfo database for a particular escape sequence.
+func tput(command string, params ...interface{}) []byte {
+	args := []string{command}
+
+	for _, param := range params {
+		switch param.(type) {
+		case string:
+			args = append(args, param.(string))
+		case int:
+			args = append(args, fmt.Sprintf("%d", param))
+		}
+	}
+
+	out, err := exec.Command("tput", args...).Output()
+	if err != nil {
+		return []byte{}
+	}
+
+	return out
 }

--- a/Godeps/_workspace/src/github.com/eris-ltd/common/go/log/logger_stub.go
+++ b/Godeps/_workspace/src/github.com/eris-ltd/common/go/log/logger_stub.go
@@ -1,0 +1,32 @@
+package log
+
+import (
+	"runtime/debug"
+
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+)
+
+// Stub is a void implementation of the CrashReporter and logrus Hook interfaces.
+type Stub struct{}
+
+func NewStubReporter(c map[string]string) Stub {
+	return Stub{}
+}
+
+func (s Stub) Levels() []log.Level {
+	return []log.Level{}
+}
+
+func (s Stub) Fire(e *log.Entry) error {
+	return nil
+}
+
+func (s Stub) Hook() log.Hook {
+	return s
+}
+
+func (s Stub) SendReport(message interface{}) error {
+	debug.PrintStack()
+
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus/doc.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus/doc.go
@@ -7,7 +7,7 @@ The simplest way to use Logrus is simply the package-level exported logger:
   package main
 
   import (
-    log "github.com/Sirupsen/logrus"
+    log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
   )
 
   func main() {
@@ -21,6 +21,6 @@ The simplest way to use Logrus is simply the package-level exported logger:
 Output:
   time="2015-09-07T08:48:33Z" level=info msg="A walrus appears" animal=walrus number=1 size=10
 
-For a full guide visit https://github.com/Sirupsen/logrus
+For a full guide visit https://github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus
 */
 package logrus

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus/json_formatter.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus/json_formatter.go
@@ -16,7 +16,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		switch v := v.(type) {
 		case error:
 			// Otherwise errors are ignored by `encoding/json`
-			// https://github.com/Sirupsen/logrus/issues/137
+			// https://github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus/issues/137
 			data[k] = v.Error()
 		default:
 			data[k] = v

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/example_changes.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/example_changes.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive"
 )
 

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/fileutils/fileutils_unix.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/fileutils/fileutils_unix.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 // GetTotalUsedFds Returns the number of used File Descriptors by

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/fileutils/fileutils_unix.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/fileutils/fileutils_unix.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/external/github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
 // GetTotalUsedFds Returns the number of used File Descriptors by

--- a/cmd/crash_report.go
+++ b/cmd/crash_report.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	logger "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
+	"github.com/eris-ltd/eris-cli/config"
+
+	"github.com/eris-ltd/eris-cli/util"
+	"github.com/eris-ltd/eris-cli/version"
+)
+
+var crashReport CrashReport
+
+// CrashReport interface represents operations for sending out panics
+// remotely and hooking to a logging library to collect debug messages.
+type CrashReport interface {
+	SendReport(interface{}) error
+	Hook() log.Hook
+}
+
+// CrashReportHook sets up a remote logging implementation (depending on
+// the 'CrashReport' value in the `eris.toml` configuration file) and returns
+// a hook for the logrus logging library.
+func CrashReportHook() log.Hook {
+	switch config.GlobalConfig.Config.CrashReport {
+	case "bugsnag":
+		crashReport = logger.NewBugsnagReporter(ConfigureCrashReport())
+	default:
+		crashReport = logger.NewStubReporter(ConfigureCrashReport())
+	}
+
+	return crashReport.Hook()
+}
+
+// SendReport executes the actual transmission.
+func SendReport(message interface{}) error {
+	return crashReport.SendReport(message)
+}
+
+// ConfigureCrashReport collects variables from various places
+// to send them along with a crash report.
+func ConfigureCrashReport() map[string]string {
+	user, email, err := config.GitConfigUser()
+	if err != nil {
+		user, email = "n/a", "n/a"
+	}
+
+	dockerClient, err := util.DockerClientVersion()
+	if err != nil {
+		dockerClient = "n/a"
+	}
+
+	return map[string]string{
+		"version":       version.VERSION,
+		"branch":        "*",
+		"user":          user,
+		"email":         email,
+		"docker client": dockerClient,
+	}
+}

--- a/cmd/eris.go
+++ b/cmd/eris.go
@@ -34,18 +34,26 @@ Made with <3 by Eris Industries.
 Complete documentation is available at https://docs.erisindustries.com
 ` + "\nVersion:\n  " + VERSION,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		log.SetFormatter(logger.ErisFormatter{})
+		// Using stdout for less fuss with redirecting the log messages
+		// into a file (`eris > out`) or a viewer (`eris|more`).
+		log.SetOutput(os.Stdout)
 
-		log.SetLevel(log.WarnLevel)
+		// The baseline logging level (to record debug logging
+		// messages for remote logging, not for console).
+		log.SetLevel(log.DebugLevel)
+
+		log.SetFormatter(logger.ConsoleFormatter(log.WarnLevel))
 		if do.Verbose {
-			log.SetLevel(log.InfoLevel)
+			log.SetFormatter(logger.ConsoleFormatter(log.InfoLevel))
 		} else if do.Debug {
-			log.SetLevel(log.DebugLevel)
+			log.SetFormatter(logger.ConsoleFormatter(log.DebugLevel))
 		}
 
-		ipfs.IpfsHost = config.GlobalConfig.Config.IpfsHost
-
 		util.DockerConnect(do.Verbose, do.MachineName)
+
+		log.AddHook(CrashReportHook())
+
+		ipfs.IpfsHost = config.GlobalConfig.Config.IpfsHost
 
 		dockerVersion, err := util.DockerClientVersion()
 		if err != nil {
@@ -65,6 +73,13 @@ Complete documentation is available at https://docs.erisindustries.com
 }
 
 func Execute() {
+	// Handle panics within Execute().
+	defer func() {
+		if err := recover(); err != nil {
+			SendReport(err)
+		}
+	}()
+
 	InitializeConfig()
 	AddGlobalFlags()
 	AddCommands()
@@ -113,6 +128,7 @@ func AddCommands() {
 		buildManCommand()
 		ErisCmd.AddCommand(ManPage)
 	}
+
 	ErisCmd.SetHelpCommand(Help)
 	ErisCmd.SetHelpTemplate(helpTemplate)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type ErisConfig struct {
 	CompilersHost  string `json:"CompilersHost,omitempty" yaml:"CompilersHost,omitempty" toml:"CompilersHost,omitempty"`
 	DockerHost     string `json:"DockerHost,omitempty" yaml:"DockerHost,omitempty" toml:"DockerHost,omitempty"`
 	DockerCertPath string `json:"DockerCertPath,omitempty" yaml:"DockerCertPath,omitempty" toml:"DockerCertPath,omitempty"`
+	CrashReport    string `json:"CrashReport,omitempty" yaml:"CrashReport,omitempty" toml:"CrashReport,omitempty"`
 
 	Verbose bool
 }
@@ -89,6 +90,7 @@ func SetDefaults() (*viper.Viper, error) {
 	var globalConfig = viper.New()
 	globalConfig.SetDefault("IpfsHost", "http://0.0.0.0")
 	globalConfig.SetDefault("CompilersHost", "https://compilers.eris.industries")
+	globalConfig.SetDefault("CrashReport", "bugsnag")
 	return globalConfig, nil
 }
 
@@ -123,6 +125,8 @@ func GetConfigValue(key string) string {
 		return GlobalConfig.Config.DockerHost
 	case "DockerCertPath":
 		return GlobalConfig.Config.DockerCertPath
+	case "CrashReport":
+		return GlobalConfig.Config.CrashReport
 	default:
 		return ""
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -105,6 +105,7 @@ func TestSetGlobalObjectDefaultConfig(t *testing.T) {
 		"compilers host": cli.Config.CompilersHost,
 		"host":           cli.Config.DockerHost,
 		"cert path":      cli.Config.DockerCertPath,
+		"crash report":   cli.Config.CrashReport,
 		"verbose":        cli.Config.Verbose,
 	}).Info("Checking defaults")
 }
@@ -115,6 +116,7 @@ IpfsHost = "foo"
 CompilersHost = "bar"
 DockerHost = "baz"
 DockerCertPath = "qux"
+CrashReport = "quux"
 Verbose = true
 `)
 	defer removeErisDir()
@@ -140,8 +142,11 @@ Verbose = true
 	if custom, returned := "qux", cli.Config.DockerCertPath; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := true, cli.Config.Verbose; custom != returned {
+	if custom, returned := "quux", cli.Config.CrashReport; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
+	}
+	if custom, returned := true, cli.Config.Verbose; custom != returned {
+		t.Fatalf("expected %v, got %v", custom, returned)
 	}
 }
 
@@ -166,12 +171,13 @@ func TestSetGlobalObjectCustomEmptyConfig(t *testing.T) {
 		"compilers host": cli.Config.CompilersHost,
 		"host":           cli.Config.DockerHost,
 		"cert path":      cli.Config.DockerCertPath,
+		"crash report":   cli.Config.CrashReport,
 		"verbose":        cli.Config.Verbose,
 	}).Info("Checking empty values")
 
 	// With an empty config, the values are used are defaults.
 	if def, returned := defaults.Get("IpfsHost"), cli.Config.IpfsHost; reflect.DeepEqual(returned, def) != true {
-		t.Fatalf("expected default %q, got %q", returned, def)
+		t.Fatalf("expected default %v, got %v", returned, def)
 	}
 
 	if def, returned := defaults.Get("CompilersHost"), cli.Config.CompilersHost; reflect.DeepEqual(returned, def) != true {
@@ -184,8 +190,11 @@ func TestSetGlobalObjectCustomEmptyConfig(t *testing.T) {
 	if custom, returned := "", cli.Config.DockerCertPath; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := false, cli.Config.Verbose; custom != returned {
+	if custom, returned := "bugsnag", cli.Config.CrashReport; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
+	}
+	if custom, returned := false, cli.Config.Verbose; custom != returned {
+		t.Fatalf("expected %v, got %v", custom, returned)
 	}
 }
 
@@ -205,6 +214,7 @@ func TestSetGlobalObjectCustomBadConfig(t *testing.T) {
 		"compilers host": cli.Config.CompilersHost,
 		"host":           cli.Config.DockerHost,
 		"cert path":      cli.Config.DockerCertPath,
+		"crash report":   cli.Config.CrashReport,
 		"verbose":        cli.Config.Verbose,
 	}).Info("Checking empty values")
 
@@ -228,8 +238,11 @@ func TestSetGlobalObjectCustomBadConfig(t *testing.T) {
 	if custom, returned := "", cli.Config.DockerCertPath; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := false, cli.Config.Verbose; custom != returned {
+	if custom, returned := "bugsnag", cli.Config.CrashReport; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
+	}
+	if custom, returned := false, cli.Config.Verbose; custom != returned {
+		t.Fatalf("expected %v, got %v", custom, returned)
 	}
 }
 
@@ -254,6 +267,7 @@ IpfsHost = "foo"
 CompilersHost = "bar"
 DockerHost = "baz"
 DockerCertPath = "qux"
+CrashReport = "quux"
 Verbose = true
 `)
 	defer removeErisDir()
@@ -275,8 +289,11 @@ Verbose = true
 	if expected, returned := "qux", config.Get("DockerCertPath"); reflect.DeepEqual(expected, returned) != true {
 		t.Fatalf("expected %q, got %q", expected, returned)
 	}
-	if expected, returned := true, config.Get("Verbose"); reflect.DeepEqual(expected, returned) != true {
+	if expected, returned := "quux", config.Get("CrashReport"); reflect.DeepEqual(expected, returned) != true {
 		t.Fatalf("expected %q, got %q", expected, returned)
+	}
+	if expected, returned := true, config.Get("Verbose"); reflect.DeepEqual(expected, returned) != true {
+		t.Fatalf("expected %v, got %v", expected, returned)
 	}
 }
 
@@ -305,6 +322,9 @@ func TestLoadGlobalConfigEmpty(t *testing.T) {
 	}
 	if returned := config.Get("DockerCertPath"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
+	}
+	if def, returned := config.Get("CrashReport"), config.Get("CrashReport"); reflect.DeepEqual(returned, def) != true {
+		t.Fatalf("expected default %q, got %q", returned, def)
 	}
 	if returned := config.Get("Verbose"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
@@ -338,6 +358,9 @@ func TestLoadGlobalConfigBad(t *testing.T) {
 	if returned := config.Get("DockerCertPath"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
 	}
+	if def, returned := config.Get("CrashReport"), config.Get("CrashReport"); reflect.DeepEqual(returned, def) != true {
+		t.Fatalf("expected default %q, got %q", returned, def)
+	}
 	if returned := config.Get("Verbose"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
 	}
@@ -349,6 +372,7 @@ IpfsHost = "foo"
 CompilersHost = "bar"
 DockerHost = "baz"
 DockerCertPath = "qux"
+CrashReport = "quux"
 Verbose = true
 `)
 	defer removeErisDir()
@@ -370,8 +394,11 @@ Verbose = true
 	if expected, returned := "qux", config.Get("DockerCertPath"); reflect.DeepEqual(expected, returned) != true {
 		t.Fatalf("expected %q, got %q", expected, returned)
 	}
-	if expected, returned := true, config.Get("Verbose"); reflect.DeepEqual(expected, returned) != true {
+	if expected, returned := "quux", config.Get("CrashReport"); reflect.DeepEqual(expected, returned) != true {
 		t.Fatalf("expected %q, got %q", expected, returned)
+	}
+	if expected, returned := true, config.Get("Verbose"); reflect.DeepEqual(expected, returned) != true {
+		t.Fatalf("expected %v, got %v", expected, returned)
 	}
 }
 
@@ -396,6 +423,9 @@ func TestLoadViperConfigEmpty(t *testing.T) {
 	if returned := config.Get("DockerCertPath"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
 	}
+	if returned := config.Get("CrashReport"); returned != nil {
+		t.Fatalf("expected nil, got %q", returned)
+	}
 	if returned := config.Get("Verbose"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
 	}
@@ -407,21 +437,21 @@ func TestLoadViperConfigBad(t *testing.T) {
 
 	_, err := LoadViperConfig(configErisDir, "eris", "test")
 	if err == nil {
-		t.Fatalf("expected failure, got nil", err)
+		t.Fatalf("expected failure, got nil")
 	}
 }
 
 func TestLoadViperConfigNonExistent1(t *testing.T) {
 	_, err := LoadViperConfig(configErisDir, "eris", "test")
 	if err == nil {
-		t.Fatalf("expected failure, got nil", err)
+		t.Fatalf("expected failure, got nil")
 	}
 }
 
 func TestLoadViperConfigNonExistent2(t *testing.T) {
 	_, err := LoadViperConfig(configErisDir, "12345", "test")
 	if err == nil {
-		t.Fatalf("expected failure, got nil", err)
+		t.Fatalf("expected failure, got nil")
 	}
 }
 

--- a/files/handle.go
+++ b/files/handle.go
@@ -388,7 +388,7 @@ func writeCsv(hashArray, fileNames []string) error {
 
 	csvfile, err := os.Create("ipfs_hashes.csv")
 	if err != nil {
-		return fmt.Errorf("error creating csv file:", err)
+		return fmt.Errorf("error creating csv file: %v", err)
 	}
 	defer csvfile.Close()
 
@@ -396,7 +396,7 @@ func writeCsv(hashArray, fileNames []string) error {
 	w.WriteAll(strToWrite)
 
 	if err := w.Error(); err != nil {
-		return fmt.Errorf("error writing csv: \n", err)
+		return fmt.Errorf("error writing csv: %v", err)
 	}
 	return nil
 }

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -154,6 +154,9 @@ func pullDefaultImages() error {
 		if err, ok := <-ch; ok {
 			return err
 		}
+
+		// Spacer.
+		log.Warn()
 	}
 	return nil
 }

--- a/perform/perform.go
+++ b/perform/perform.go
@@ -706,7 +706,7 @@ func pullImage(name string, writer io.Writer) error {
 	}
 
 	if os.Getenv("ERIS_PULL_APPROVE") == "true" {
-		opts.OutputStream = nil
+		opts.OutputStream = ioutil.Discard
 	}
 
 	auth := docker.AuthConfiguration{}

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -1024,7 +1024,7 @@ func TestRemoveWithoutData(t *testing.T) {
 	}
 
 	if err := DockerStop(srv.Service, srv.Operations, 5); err != nil {
-		t.Fatal("expected service container stopped, got %v", err)
+		t.Fatalf("expected service container stopped, got %v", err)
 	}
 
 	if n := util.HowManyContainersExisting(name, def.TypeService); n != 1 {
@@ -1032,7 +1032,7 @@ func TestRemoveWithoutData(t *testing.T) {
 	}
 
 	if err := DockerRemove(srv.Service, srv.Operations, false, true, false); err != nil {
-		t.Fatal("expected service container removed, got %v", err)
+		t.Fatalf("expected service container removed, got %v", err)
 	}
 
 	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
@@ -1045,7 +1045,7 @@ func TestRemoveWithoutData(t *testing.T) {
 	}
 
 	if err := DockerRemove(srv.Service, srv.Operations, false, true, false); err != nil {
-		t.Fatal("expected service container removed, got %v", err)
+		t.Fatalf("expected service container removed, got %v", err)
 	}
 
 	if n := util.HowManyContainersExisting(name, def.TypeData); n != 0 {
@@ -1074,7 +1074,7 @@ func TestRemoveWithData(t *testing.T) {
 	}
 
 	if err := DockerStop(srv.Service, srv.Operations, 5); err != nil {
-		t.Fatal("expected service container stopped, got %v", err)
+		t.Fatalf("expected service container stopped, got %v", err)
 	}
 
 	if n := util.HowManyContainersExisting(name, def.TypeService); n != 1 {
@@ -1086,7 +1086,7 @@ func TestRemoveWithData(t *testing.T) {
 	}
 
 	if err := DockerRemove(srv.Service, srv.Operations, true, true, false); err != nil {
-		t.Fatal("expected service container removed, got %v", err)
+		t.Fatalf("expected service container removed, got %v", err)
 	}
 
 	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
@@ -1327,7 +1327,7 @@ func TestRebuildNotRunning(t *testing.T) {
 	}
 
 	if err := DockerStop(srv.Service, srv.Operations, timeout); err != nil {
-		t.Fatal("expected service container stopped, got %v", err)
+		t.Fatalf("expected service container stopped, got %v", err)
 	}
 
 	if n := util.HowManyContainersRunning(name, def.TypeService); n != 0 {

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -229,7 +229,7 @@ func TestKillService(t *testing.T) {
 	do.RmD = false
 	do.Operations.Args = []string{servName}
 	if err := KillService(do); err != nil {
-		t.Fatalf("expected service to be stopped, got %v")
+		t.Fatalf("expected service to be stopped, got %v", err)
 	}
 	if n := util.HowManyContainersRunning(servName, def.TypeService); n != 0 {
 		t.Fatalf("expecting 0 running service container, got %v", n)

--- a/util/clean.go
+++ b/util/clean.go
@@ -205,8 +205,6 @@ func canWeRemove(removing []string, what string) bool {
 	if input == "Y" || input == "y" || input == "YES" || input == "Yes" || input == "yes" {
 		log.WithField("=>", what).Warn("Authorization given, removing")
 		return true
-	} else {
-		return false
 	}
 	return false
 }

--- a/util/container_stats.go
+++ b/util/container_stats.go
@@ -202,10 +202,6 @@ func FormulatePortsOutput(container *docker.Container) string {
 
 func camelize(field string) string {
 	return snaker.SnakeToCamel(field)
-	if !startsUp(field) {
-		return snaker.SnakeToCamel(field)
-	}
-	return field
 }
 
 func writeTemplate(container interface{}, toParse string) error {

--- a/util/docker_client.go
+++ b/util/docker_client.go
@@ -396,11 +396,9 @@ func mustInstallError() error {
 		return fmt.Errorf("%s%s\n", errBase, (dInst + "mac/"))
 	case "windows":
 		return fmt.Errorf("%s%s\n", errBase, (dInst + "windows/"))
-	default:
-		return fmt.Errorf("%s%s\n", errBase, dInst)
 	}
 
-	return nil
+	return fmt.Errorf("%s%s\n", errBase, dInst)
 }
 
 // need to add ssh.exe to PATH, it resides in GIT dir.

--- a/util/migrate_dirs.go
+++ b/util/migrate_dirs.go
@@ -23,11 +23,9 @@ func MigrateDeprecatedDirs(dirsToMigrate map[string]string, prompt bool) error {
 		return Migrate(dirsMap)
 	} else if canWeMigrate() {
 		return Migrate(dirsMap)
-	} else {
-		return fmt.Errorf("permission to migrate not given")
 	}
 
-	return nil
+	return fmt.Errorf("permission to migrate not given")
 }
 
 //check that migration is actually needed

--- a/util/update_tool.go
+++ b/util/update_tool.go
@@ -172,7 +172,7 @@ func ChangeDirectory(to string) {
 		err := os.Chdir(dir)
 
 		if err != nil {
-			log.Fatalf("Error changing directory: %v")
+			log.Fatalf("Error changing directory: %v", err)
 		}
 		log.WithField("dir", dir).Debug("Directory changed to")
 	}

--- a/util/update_tool_test.go
+++ b/util/update_tool_test.go
@@ -20,7 +20,7 @@ func TestCheckGitAndGo(t *testing.T) {
 	for _, g := range tests {
 		resultGit, resultGo := CheckGitAndGo(g.hasGit, g.hasGo)
 		if g.hasGit != resultGit && g.hasGo != resultGo {
-			t.Fatalf("Expected git = %b and go = %b.\nResult: git = %b, go = %b", g.hasGit, g.hasGo, resultGit, resultGo)
+			t.Fatalf("Expected git = %v and go = %v.\nResult: git = %v, go = %v", g.hasGit, g.hasGo, resultGit, resultGo)
 		}
 	}
 }


### PR DESCRIPTION
### Bugsnag

This PR implements a remote logger to be used to send `panic()` events along with debug logging output for further analysis.

Bugsnag is selected as a remote logger because:  1) Unlike Papertrail it has more convenient and stable Go client library  and allows for more structured view of the sent events. 2) Unlike Sentry it is less expensive and, again, allows for more structured view of information. 

View of a panic stack trace:

![crash report](http://i.imgur.com/vl16AGZ.png)


`eris -d` output (irrespective of the console logging level, remote logging is always at the debug level):

![debug output](http://i.imgur.com/L42IF0F.png)

Additional bits of information in separate tabs and on separate rows:

![docker client](http://i.imgur.com/VQacWUT.png)

This PR also adds the `CrashReport` variable to the `eris.toml` definition file which defaults to "bugsnag" to control the remote logger behavior. Setting it to anything else but "bugsnag" will turn the remote logging off.

Notifying the users in `eris init` to allow them to opt out from remote logging like this:

```
Eris sends crash reports to a remote server in case something goes completely 
wrong. You may disable this feature by adding the CrashReport = "don't send" 
line to the /Users/peter/.eris/eris.toml definition file.
```
This is opinionated: can be changed to opt in easily, but assuming users are lazy and we don't send anything yet but panics, this is not a huge privacy intervention.

Currently the logging library uses an `APIKey` authentication key of a personal Bugsnag account. If Bugsnag is okay for remote logging, we'd need to create a team/team account there (or share a password). Before merging a temporary token can be set like this for testing: 

```
$ export ERIS_BUGSNAG_TOKEN=...
```

Closes #403.

### Other fixes

* Setting default logging output stream to stdout instead of stderr for more convenient redirecting and viewing of logging information.

* Turning off the color formatting when redirecting output to a file `eris > out` or a viewer `eris|more`. Fixes #506.

* Cleaning up ungodepped dependencies on Windows. Fixes #523.

* small editing of the `eris init` screen to fit the 80-column console width.

* small fixes satisfying `go vet ./...`.