### PR TITLE
proposed compilers url strategy

### DIFF
--- a/cmd/pkgs.go
+++ b/cmd/pkgs.go
@@ -1,9 +1,13 @@
 package commands
 
 import (
+	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/eris-ltd/eris-cli/pkgs"
+	"github.com/eris-ltd/eris-cli/version"
 
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
@@ -73,7 +77,7 @@ func addPackagesFlags() {
 	packagesDo.Flags().StringVarP(&do.PackagePath, "contracts-path", "p", "./contracts", "path to the contracts EPM should use")
 	packagesDo.Flags().StringVarP(&do.ABIPath, "abi-path", "b", "./abi", "path to the abi directory EPM should use when saving ABIs after the compile process")
 	packagesDo.Flags().StringVarP(&do.DefaultGas, "gas", "g", "1111111111", "default gas to use; can be overridden for any single job")
-	packagesDo.Flags().StringVarP(&do.Compiler, "compiler", "l", "https://compilers.eris.industries:9090", "<ip:port> of compiler which EPM should use")
+	packagesDo.Flags().StringVarP(&do.Compiler, "compiler", "l", formCompilers(), "<ip:port> of compiler which EPM should use")
 	packagesDo.Flags().StringVarP(&do.DefaultAddr, "address", "a", "", "default address to use; operates the same way as the [account] job, only before the epm file is ran")
 	packagesDo.Flags().StringVarP(&do.DefaultFee, "fee", "w", "1234", "default fee to use")
 	packagesDo.Flags().StringVarP(&do.DefaultAmount, "amount", "y", "9999", "default amount to use")
@@ -103,4 +107,12 @@ func PackagesDo(cmd *cobra.Command, args []string) {
 		IfExit(err)
 	}
 	IfExit(pkgs.RunPackage(do))
+}
+
+func formCompilers() string {
+	verSplit := strings.Split(version.VERSION, ".")
+	maj, _ := strconv.Atoi(verSplit[0])
+	min, _ := strconv.Atoi(verSplit[1])
+	pat, _ := strconv.Atoi(verSplit[2])
+	return fmt.Sprintf("https://compilers-new.eris.industries:1%01d%02d%01d", maj, min, pat)
 }

--- a/cmd/pkgs.go
+++ b/cmd/pkgs.go
@@ -114,5 +114,5 @@ func formCompilers() string {
 	maj, _ := strconv.Atoi(verSplit[0])
 	min, _ := strconv.Atoi(verSplit[1])
 	pat, _ := strconv.Atoi(verSplit[2])
-	return fmt.Sprintf("https://compilers-new.eris.industries:1%01d%02d%01d", maj, min, pat)
+	return fmt.Sprintf("https://compilers.eris.industries:1%01d%02d%01d", maj, min, pat)
 }


### PR DESCRIPTION
**Problem** -- currently we have no way to version the information which comes and goes to the compilers service. which means we have no way to migrate changes to how epm talks to the compilers. 

normally this is fine cause we run nightly builds of the image which pulls in the latest from eth's ppas and leaves our go wrapper code fine. that go wrapper code is due for a refresh ( https://github.com/eris-ltd/eris-compilers/issues/51 ). in turn this will affect how epm talks to the compilers. 

as contract bundles and engines get more complex we will need to ensure that the epm and compilers interface is somewhat coupled. 

**Solution** -- better version the connection between epm and compilers wrapper

**Strategy** -- for discussion

(option a) Use a ports strategy as outlined here. Just run a bunch of compilers in parallel.
(option b) (better option if we have manpower) Improve the handshake between eris-pm and the compilers.
(option c) ..?

cc @eris-ltd/team-platform 