### PR TITLE
remove container numbering functionality

### DIFF
--- a/actions/manage.go
+++ b/actions/manage.go
@@ -44,8 +44,7 @@ func ImportAction(do *definitions.Do) error {
 	if s[0] == "ipfs" {
 
 		var err error
-		//unset 1 as default ContainerNumber, let it take flag?
-		ipfsService, err := loaders.LoadServiceDefinition("ipfs", false, 1)
+		ipfsService, err := loaders.LoadServiceDefinition("ipfs", false)
 		if err != nil {
 			return err
 		}
@@ -83,8 +82,7 @@ func ExportAction(do *definitions.Do) error {
 		return err
 	}
 
-	//unset 1 as default ContainerNumber, let it take flag?
-	ipfsService, err := loaders.LoadServiceDefinition("ipfs", false, 1)
+	ipfsService, err := loaders.LoadServiceDefinition("ipfs", false)
 	if err != nil {
 		return err
 	}

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -91,7 +91,7 @@ func TestChainGraduate(t *testing.T) {
 		t.Fatalf("expected chain to graduate, got %v", err)
 	}
 
-	srvDef, err := loaders.LoadServiceDefinition(chainName, false, 1)
+	srvDef, err := loaders.LoadServiceDefinition(chainName, false)
 	if err != nil {
 		t.Fatalf("expected service definition to be loaded")
 	}
@@ -116,7 +116,7 @@ func TestChainGraduate(t *testing.T) {
 func TestLoadChainDefinition(t *testing.T) {
 	// [pv]: this test belongs to the loaders package.
 	var err error
-	chain, err := loaders.LoadChainDefinition(chainName, false, 1)
+	chain, err := loaders.LoadChainDefinition(chainName, false)
 	if err != nil {
 		t.Fatalf("expected chain definition to be loaded, got %v", err)
 	}
@@ -246,7 +246,6 @@ func TestCatChainContainerConfig(t *testing.T) {
 	do := def.NowDo()
 	do.ConfigFile = filepath.Join(common.ChainsPath, "default", "config.toml")
 	do.Name = chainName
-	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
 	if err := NewChain(do); err != nil {
 		t.Fatalf("expected a new chain to be created, got %v", err)
@@ -271,7 +270,6 @@ func TestCatChainContainerGenesis(t *testing.T) {
 	do := def.NowDo()
 	do.ConfigFile = filepath.Join(common.ChainsPath, "default", "config.toml")
 	do.Name = chainName
-	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
 	if err := NewChain(do); err != nil {
 		t.Fatalf("expected a new chain to be created, got %v", err)
@@ -308,7 +306,6 @@ func TestChainsNewDirGenCustomFile(t *testing.T) {
 	do.GenesisFile = filepath.Join(common.ChainsPath, "default", "genesis.json")
 	do.Name = chain
 	do.Path = dir
-	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
 	if err := NewChain(do); err != nil {
 		t.Fatalf("expected a new chain to be created, got %v", err)
@@ -329,7 +326,6 @@ func TestChainsNewDirGenesis(t *testing.T) {
 
 	do := def.NowDo()
 	do.Name = chain
-	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
 	if err := NewChain(do); err != nil {
 		t.Fatalf("expected a new chain to be created, got %v", err)
@@ -351,7 +347,6 @@ func TestChainsNewConfig(t *testing.T) {
 	do.Name = chain
 	do.ConfigFile = filepath.Join(common.ChainsPath, "default", "config.toml")
 	do.CSV = filepath.Join(common.ChainsPath, "default", "genesis.csv")
-	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
 	if err := NewChain(do); err != nil {
 		t.Fatalf("expected to create a new chain, got %v", err)
@@ -372,7 +367,6 @@ func TestChainsNewCSV(t *testing.T) {
 	do := def.NowDo()
 	do.Name = chain
 	do.CSV = filepath.Join(common.ChainsPath, "default", "genesis.csv")
-	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
 	if err := NewChain(do); err != nil {
 		t.Fatalf("expected to create a new chain, got %v", err)
@@ -394,7 +388,6 @@ func TestChainsNewConfigOpts(t *testing.T) {
 	do := def.NowDo()
 	do.Name = chain
 	do.ConfigOpts = []string{"moniker=satoshi", "p2p=1.1.1.1:42", "fast-sync=true"}
-	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
 	if err := NewChain(do); err != nil {
 		t.Fatalf("expected to create a new chain, got %v", err)
@@ -450,7 +443,6 @@ func TestInspectChain(t *testing.T) {
 	do := def.NowDo()
 	do.Name = chainName
 	do.Operations.Args = []string{"name"}
-	do.Operations.ContainerNumber = 1
 	if err := InspectChain(do); err != nil {
 		t.Fatalf("expected chain to be inspected, got %v", err)
 	}
@@ -466,7 +458,6 @@ func TestRenameChain(t *testing.T) {
 
 	do := def.NowDo()
 	do.Name = chain
-	do.Operations.ContainerNumber = 1
 	if err := NewChain(do); err != nil {
 		t.Fatalf("expected a new chain to be created, got %v", err)
 	}
@@ -570,7 +561,6 @@ data_container = true
 
 	do := def.NowDo()
 	do.Operations.Args = []string{"fake"}
-	do.Operations.ContainerNumber = 1
 	if err := services.StartService(do); err == nil {
 		t.Fatalf("expect start service to fail, got nil")
 	}
@@ -591,7 +581,6 @@ image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
 
 	do := def.NowDo()
 	do.Operations.Args = []string{"fake"}
-	do.Operations.ContainerNumber = 1
 	do.ChainName = "non-existent-chain"
 	if err := services.StartService(do); err == nil {
 		t.Fatalf("expect start service to fail, got nil")
@@ -613,7 +602,6 @@ image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
 
 	do := def.NowDo()
 	do.Operations.Args = []string{"fake"}
-	do.Operations.ContainerNumber = 1
 	do.ChainName = "non-existent-chain"
 
 	// [pv]: is this a bug? the service which doesn't have a
@@ -638,7 +626,6 @@ func TestServiceLink(t *testing.T) {
 
 	do := def.NowDo()
 	do.Name = chain
-	do.Operations.ContainerNumber = 1
 	if err := NewChain(do); err != nil {
 		t.Fatalf("could not start a new chain, got %v", err)
 	}
@@ -667,7 +654,6 @@ data_container = false
 
 	do = def.NowDo()
 	do.Operations.Args = []string{"fake"}
-	do.Operations.ContainerNumber = 1
 	do.ChainName = chain
 	if err := services.StartService(do); err != nil {
 		t.Fatalf("expecting service to start, got %v", err)
@@ -680,7 +666,7 @@ data_container = false
 		t.Fatalf("expecting 0 fake data containers, got %v", n)
 	}
 
-	links := tests.Links("fake", def.TypeService, 1)
+	links := tests.Links("fake", def.TypeService)
 	if len(links) != 1 || !strings.Contains(links[0], chain) {
 		t.Fatalf("expected service be linked to a test chain, got %v", links)
 	}
@@ -694,7 +680,6 @@ func TestServiceLinkWithDataContainer(t *testing.T) {
 
 	do := def.NowDo()
 	do.Name = chain
-	do.Operations.ContainerNumber = 1
 	if err := NewChain(do); err != nil {
 		t.Fatalf("could not start a new chain, got %v", err)
 	}
@@ -723,7 +708,6 @@ data_container = true
 
 	do = def.NowDo()
 	do.Operations.Args = []string{"fake"}
-	do.Operations.ContainerNumber = 1
 	do.ChainName = chain
 	if err := services.StartService(do); err != nil {
 		t.Fatalf("expecting service to start, got %v", err)
@@ -736,7 +720,7 @@ data_container = true
 		t.Fatalf("expecting 1 data containers, got %v", n)
 	}
 
-	links := tests.Links("fake", def.TypeService, 1)
+	links := tests.Links("fake", def.TypeService)
 	if len(links) != 1 || !strings.Contains(links[0], chain) {
 		t.Fatalf("expected service be linked to a test chain, got %v", links)
 	}
@@ -750,7 +734,6 @@ func TestServiceLinkLiteral(t *testing.T) {
 
 	do := def.NowDo()
 	do.Name = chain
-	do.Operations.ContainerNumber = 1
 	if err := NewChain(do); err != nil {
 		t.Fatalf("could not start a new chain, got %v", err)
 	}
@@ -778,7 +761,6 @@ image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)+`"
 
 	do = def.NowDo()
 	do.Operations.Args = []string{"fake"}
-	do.Operations.ContainerNumber = 1
 	do.ChainName = chain
 	if err := services.StartService(do); err != nil {
 		t.Fatalf("expecting service to start, got %v", err)
@@ -791,7 +773,7 @@ image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)+`"
 		t.Fatalf("expecting 0 fake data containers, got %v", n)
 	}
 
-	links := tests.Links("fake", def.TypeService, 1)
+	links := tests.Links("fake", def.TypeService)
 	if len(links) != 1 || !strings.Contains(links[0], chain) {
 		t.Fatalf("expected service be linked to a test chain, got %v", links)
 	}
@@ -805,7 +787,6 @@ func TestServiceLinkBadLiteral(t *testing.T) {
 
 	do := def.NowDo()
 	do.Name = chain
-	do.Operations.ContainerNumber = 1
 	if err := NewChain(do); err != nil {
 		t.Fatalf("could not start a new chain, got %v", err)
 	}
@@ -826,7 +807,6 @@ image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
 
 	do = def.NowDo()
 	do.Operations.Args = []string{"fake"}
-	do.Operations.ContainerNumber = 1
 	do.ChainName = chain
 	// [pv]: probably a bug. Bad literal chain link in a definition
 	// file doesn't affect the service start. Links is not nil.
@@ -834,7 +814,7 @@ image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
 		t.Fatalf("expecting service to start, got %v", err)
 	}
 
-	links := tests.Links("fake", def.TypeService, 1)
+	links := tests.Links("fake", def.TypeService)
 	if len(links) != 1 || !strings.Contains(links[0], chain) {
 		t.Fatalf("expected service be linked to a test chain, got %v", links)
 	}
@@ -848,7 +828,6 @@ func TestServiceLinkKeys(t *testing.T) {
 
 	do := def.NowDo()
 	do.Name = chain
-	do.Operations.ContainerNumber = 1
 	if err := NewChain(do); err != nil {
 		t.Fatalf("could not start a new chain, got %v", err)
 	}
@@ -859,7 +838,6 @@ func TestServiceLinkKeys(t *testing.T) {
 
 	do = def.NowDo()
 	do.Operations.Args = []string{"keys"}
-	do.Operations.ContainerNumber = 1
 	do.ChainName = chain
 	if err := services.StartService(do); err != nil {
 		t.Fatalf("expecting service to start, got %v", err)
@@ -869,7 +847,7 @@ func TestServiceLinkKeys(t *testing.T) {
 		t.Fatalf("expecting 1 test chain containers, got %v", n)
 	}
 
-	links := tests.Links("keys", def.TypeService, 1)
+	links := tests.Links("keys", def.TypeService)
 	if len(links) != 0 {
 		t.Fatalf("expected service links be empty, got %v", links)
 	}
@@ -886,7 +864,6 @@ func TestServiceLinkChainedService(t *testing.T) {
 
 	do := def.NowDo()
 	do.Name = chain
-	do.Operations.ContainerNumber = 1
 	if err := NewChain(do); err != nil {
 		t.Fatalf("could not start a new chain, got %v", err)
 	}
@@ -921,7 +898,6 @@ data_container = true
 
 	do = def.NowDo()
 	do.Operations.Args = []string{"fake"}
-	do.Operations.ContainerNumber = 1
 	do.ChainName = chain
 	if err := services.StartService(do); err != nil {
 		t.Fatalf("expecting service to start, got %v", err)
@@ -941,7 +917,7 @@ data_container = true
 	}
 
 	// [pv]: second service doesn't reference the chain.
-	links := tests.Links("fake", def.TypeService, 1)
+	links := tests.Links("fake", def.TypeService)
 	if len(links) != 2 || (!strings.Contains(links[1], chain) && !strings.Contains(links[0], chain)) {
 		t.Fatalf("expected service be linked to a test chain, got %v", links)
 	}
@@ -951,7 +927,6 @@ func create(t *testing.T, chain string) {
 	do := def.NowDo()
 	do.ConfigFile = filepath.Join(common.ChainsPath, "default", "config.toml")
 	do.Name = chain
-	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
 	if err := NewChain(do); err != nil {
 		t.Fatalf("expected a new chain to be created, got %v", err)
@@ -961,7 +936,6 @@ func create(t *testing.T, chain string) {
 func start(t *testing.T, chain string) {
 	do := def.NowDo()
 	do.Name = chain
-	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = true
 	if err := StartChain(do); err != nil {
 		t.Fatalf("starting chain %v failed: %v", chain, err)
@@ -995,7 +969,7 @@ func exec(t *testing.T, chain string, args []string) string {
 }
 
 func mockChainDefinitionFile(name string) error {
-	definition := loaders.MockChainDefinition(name, name, false, 1)
+	definition := loaders.MockChainDefinition(name, name, false)
 
 	return WriteChainDefinitionFile(definition, filepath.Join(erisDir, "chains", name))
 }

--- a/chains/load.go
+++ b/chains/load.go
@@ -1,8 +1,6 @@
 package chains
 
 import (
-	"fmt"
-
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
 
@@ -10,8 +8,8 @@ import (
 )
 
 func IsChainExisting(chain *definitions.Chain) bool {
-	log.WithField("=>", fmt.Sprintf("%s:%d", chain.Name, chain.Operations.ContainerNumber)).Debug("Checking chain existing")
-	cName := util.FindChainContainer(chain.Name, chain.Operations.ContainerNumber, true)
+	log.WithField("=>", chain.Name).Debug("Checking chain existing")
+	cName := util.FindChainContainer(chain.Name, true)
 	if cName == nil {
 		return false
 	}
@@ -20,8 +18,8 @@ func IsChainExisting(chain *definitions.Chain) bool {
 }
 
 func IsChainRunning(chain *definitions.Chain) bool {
-	log.WithField("=>", fmt.Sprintf("%s:%d", chain.Name, chain.Operations.ContainerNumber)).Debug("Checking chain running")
-	cName := util.FindChainContainer(chain.Name, chain.Operations.ContainerNumber, false)
+	log.WithField("=>", chain.Name).Debug("Checking chain running")
+	cName := util.FindChainContainer(chain.Name, false)
 	if cName == nil {
 		return false
 	}

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -45,7 +45,7 @@ func MakeChain(do *definitions.Do) error {
 	do.Service.Image = path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_CM)
 	do.Service.User = "eris"
 	do.Service.AutoData = true
-	do.Service.Links = []string{fmt.Sprintf("%s:%s", util.ServiceContainersName("keys", do.Operations.ContainerNumber), "keys")}
+	do.Service.Links = []string{fmt.Sprintf("%s:%s", util.ServiceContainersName("keys"), "keys")}
 	do.Service.Environment = []string{
 		fmt.Sprintf("ERIS_KEYS_PATH=http://keys:%d", 4767), // note, needs to be made aware of keys port...
 		fmt.Sprintf("ERIS_CHAINMANAGER_ACCOUNTTYPES=%s", strings.Join(do.AccountTypes, ",")),
@@ -58,8 +58,8 @@ func MakeChain(do *definitions.Do) error {
 	}
 
 	do.Operations.ContainerType = "service"
-	do.Operations.SrvContainerName = util.ServiceContainersName(do.Name, do.Operations.ContainerNumber)
-	do.Operations.DataContainerName = util.DataContainersName(do.Name, do.Operations.ContainerNumber)
+	do.Operations.SrvContainerName = util.ServiceContainersName(do.Name)
+	do.Operations.DataContainerName = util.DataContainersName(do.Name)
 	if do.RmD {
 		do.Operations.Remove = true
 	}
@@ -85,11 +85,8 @@ func MakeChain(do *definitions.Do) error {
 
 	doData := definitions.NowDo()
 	doData.Name = do.Name
-	doData.Operations.ContainerNumber = do.Operations.ContainerNumber
-	if doData.Operations.ContainerNumber == 0 {
-		doData.Operations.ContainerNumber = 1
-	}
-	doData.Operations.DataContainerName = util.DataContainersName(do.Name, do.Operations.ContainerNumber)
+
+	doData.Operations.DataContainerName = util.DataContainersName(do.Name)
 	doData.Operations.ContainerType = "service"
 
 	doData.Source = AccountsTypePath
@@ -178,7 +175,7 @@ func ImportChain(do *definitions.Do) error {
 //  do.Operations.Args - fields to inspect in the form Major.Minor or "all" (required)
 //
 func InspectChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)
+	chain, err := loaders.LoadChainDefinition(do.Name, false)
 	if err != nil {
 		return err
 	}
@@ -202,7 +199,7 @@ func InspectChain(do *definitions.Do) error {
 //  do.Tail    - number of lines to display (can be "all") (optional)
 //
 func LogsChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)
+	chain, err := loaders.LoadChainDefinition(do.Name, false)
 	if err != nil {
 		return err
 	}
@@ -221,7 +218,7 @@ func LogsChain(do *definitions.Do) error {
 //  do.Name - name of the chain (required)
 //
 func ExportChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)
+	chain, err := loaders.LoadChainDefinition(do.Name, false)
 	if err != nil {
 		return err
 	}
@@ -328,7 +325,7 @@ func CatChain(do *definitions.Do) error {
 //  do.Name - name of the chain to display port mappings for (required)
 //
 func PortsChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)
+	chain, err := loaders.LoadChainDefinition(do.Name, false)
 	if err != nil {
 		return err
 	}
@@ -371,7 +368,7 @@ func RenameChain(do *definitions.Do) error {
 		}).Info("Renaming chain")
 
 		log.WithField("=>", do.Name).Debug("Loading chain definition file")
-		chainDef, err := loaders.LoadChainDefinition(do.Name, false, 1) // TODO:CNUM
+		chainDef, err := loaders.LoadChainDefinition(do.Name, false)
 		if err != nil {
 			return err
 		}
@@ -415,10 +412,9 @@ func RenameChain(do *definitions.Do) error {
 
 		if !transformOnly {
 			log.WithFields(log.Fields{
-				"from": fmt.Sprintf("%s:%d", do.Name, chainDef.Operations.ContainerNumber),
-				"to":   fmt.Sprintf("%s:%d", do.NewName, chainDef.Operations.ContainerNumber),
+				"from": do.Name,
+				"to":   do.NewName,
 			}).Info("Renaming chain data container")
-			do.Operations.ContainerNumber = chainDef.Operations.ContainerNumber
 			err = data.RenameData(do)
 			if err != nil {
 				return err
@@ -433,7 +429,7 @@ func RenameChain(do *definitions.Do) error {
 }
 
 func UpdateChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)
+	chain, err := loaders.LoadChainDefinition(do.Name, false)
 	if err != nil {
 		return err
 	}
@@ -454,7 +450,7 @@ func UpdateChain(do *definitions.Do) error {
 }
 
 func RmChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)
+	chain, err := loaders.LoadChainDefinition(do.Name, false)
 	if err != nil {
 		return err
 	}
@@ -481,7 +477,7 @@ func RmChain(do *definitions.Do) error {
 }
 
 func GraduateChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false, 1)
+	chain, err := loaders.LoadChainDefinition(do.Name, false)
 	if err != nil {
 		return err
 	}
@@ -521,11 +517,11 @@ func RegisterChain(do *definitions.Do) error {
 	do.ChainID = do.Name
 
 	// NOTE: registration expects you to have the data container
-	if !util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
+	if !util.IsDataContainer(do.Name) {
 		return fmt.Errorf("Registration requires you to have a data container for the chain. Could not find data for %s", do.Name)
 	}
 
-	chain, err := loaders.LoadChainDefinition(do.Name, false, do.Operations.ContainerNumber)
+	chain, err := loaders.LoadChainDefinition(do.Name, false)
 	if err != nil {
 		return err
 	}
@@ -556,7 +552,7 @@ func RegisterChain(do *definitions.Do) error {
 		"=>":    chain.Service.Name,
 		"image": chain.Service.Image,
 	}).Debug("Performing chain container start")
-	chain.Operations = loaders.LoadDataDefinition(chain.Service.Name, do.Operations.ContainerNumber)
+	chain.Operations = loaders.LoadDataDefinition(chain.Service.Name)
 	chain.Operations.Args = []string{loaders.ErisChainRegister}
 
 	_, err = perform.DockerRunData(chain.Operations, chain.Service)

--- a/chains/writers.go
+++ b/chains/writers.go
@@ -72,7 +72,6 @@ func MakeGenesisFile(do *def.Do) error {
 	doThr.Chain.ChainType = "throwaway" //for teardown
 	doThr.Name = "default"
 	doThr.Chain.Name = "default" //for teardown
-	doThr.Operations.ContainerNumber = 1
 	doThr.Operations.PublishAllPorts = true
 
 	log.WithField("=>", doThr.Name).Info("Making genesis.json file. Starting chain")

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -137,9 +137,8 @@ func TestClean(t *testing.T) {
 func testStartService(t *testing.T, serviceName string, publishAll bool) {
 	do := def.NowDo()
 	do.Operations.Args = []string{serviceName}
-	do.Operations.ContainerNumber = 1 //util.AutoMagic(0, "service", true)
 	do.Operations.PublishAllPorts = publishAll
-	log.WithField("=>", fmt.Sprintf("%s:%d", serviceName, do.Operations.ContainerNumber)).Debug("Starting service (from tests)")
+	log.WithField("=>", fmt.Sprintf("%s:%d", serviceName, 1)).Debug("Starting service (from tests)")
 	e := srv.StartService(do)
 	if e != nil {
 		log.Infof("Error starting service: %v", e)

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -432,7 +432,6 @@ func addChainsFlags() {
 	// buildFlag(chainsInstall, do, "dir", "chain")
 	// chainsInstall.PersistentFlags().StringVarP(&do.ChainID, "id", "", "", "id of the chain to fetch")
 	// chainsInstall.PersistentFlags().StringVarP(&do.Gateway, "etcb-host", "", "interblock.io:46657", "set the address of the etcb chain")
-	// chainsInstall.PersistentFlags().IntVarP(&do.Operations.ContainerNumber, "N", "N", 1, "container number")
 
 	buildFlag(chainsStart, do, "publish", "chain")
 	buildFlag(chainsStart, do, "env", "chain")

--- a/cmd/eris.go
+++ b/cmd/eris.go
@@ -125,7 +125,6 @@ var do *definitions.Do
 func AddGlobalFlags() {
 	ErisCmd.PersistentFlags().BoolVarP(&do.Verbose, "verbose", "v", false, "verbose output")
 	ErisCmd.PersistentFlags().BoolVarP(&do.Debug, "debug", "d", false, "debug level output")
-	ErisCmd.PersistentFlags().IntVarP(&do.Operations.ContainerNumber, "num", "n", 1, "container number")
 	ErisCmd.PersistentFlags().StringVarP(&do.MachineName, "machine", "m", "eris", "machine name for docker-machine that is running VM")
 }
 

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -48,7 +48,6 @@ func TestExportData(t *testing.T) {
 	do.Name = dataName
 	do.Source = common.ErisContainerRoot
 	do.Destination = filepath.Join(common.DataContainersPath, do.Name)
-	do.Operations.ContainerNumber = 1
 	if err := ExportData(do); err != nil {
 		log.Error(err)
 		t.FailNow()
@@ -109,7 +108,6 @@ func TestExecData(t *testing.T) {
 	do.Name = dataName
 	do.Operations.Args = []string{"mv", "/home/eris/.eris/test", "/home/eris/.eris/tset"}
 	do.Operations.Interactive = false
-	do.Operations.ContainerNumber = 1
 
 	log.WithFields(log.Fields{
 		"data container": do.Name,
@@ -133,7 +131,6 @@ func TestRenameData(t *testing.T) {
 	do := definitions.NowDo()
 	do.Name = dataName
 	do.NewName = newName
-	do.Operations.ContainerNumber = 1
 	log.WithFields(log.Fields{
 		"from": do.Name,
 		"to":   do.NewName,
@@ -149,7 +146,6 @@ func TestRenameData(t *testing.T) {
 	do = definitions.NowDo()
 	do.Name = newName
 	do.NewName = dataName
-	do.Operations.ContainerNumber = 1
 	log.WithFields(log.Fields{
 		"from": do.Name,
 		"to":   do.NewName,
@@ -170,7 +166,6 @@ func TestInspectData(t *testing.T) {
 	do := definitions.NowDo()
 	do.Name = dataName
 	do.Operations.Args = []string{"name"}
-	do.Operations.ContainerNumber = 1
 	log.WithFields(log.Fields{
 		"data container": do.Name,
 		"args":           do.Operations.Args,
@@ -183,7 +178,6 @@ func TestInspectData(t *testing.T) {
 	do = definitions.NowDo()
 	do.Name = dataName
 	do.Operations.Args = []string{"config.network_disabled"}
-	do.Operations.ContainerNumber = 1
 	log.WithFields(log.Fields{
 		"data container": do.Name,
 		"args":           do.Operations.Args,
@@ -225,7 +219,6 @@ func testCreateDataByImport(t *testing.T, name string) {
 	do.Name = name
 	do.Source = filepath.Join(common.DataContainersPath, do.Name)
 	do.Destination = common.ErisContainerRoot
-	do.Operations.ContainerNumber = 1
 	log.WithField("=>", do.Name).Info("Importing data (from tests)")
 	if err := ImportData(do); err != nil {
 		log.Error(err)
@@ -241,7 +234,6 @@ func testKillDataCont(t *testing.T, name string) {
 
 	do := definitions.NowDo()
 	do.Name = name
-	do.Operations.ContainerNumber = 1
 	if err := RmData(do); err != nil {
 		log.Error(err)
 		t.Fail()

--- a/data/load.go
+++ b/data/load.go
@@ -9,23 +9,9 @@ import (
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
-func PretendToBeAService(serviceYourPretendingToBe string, cNum ...int) *def.ServiceDefinition {
+func PretendToBeAService(serviceYourPretendingToBe string) *def.ServiceDefinition {
 	srv := def.BlankServiceDefinition()
 	srv.Name = serviceYourPretendingToBe
-
-	if len(cNum) == 0 || cNum[0] == 0 {
-		log.WithField("=>", fmt.Sprintf("%s:1", serviceYourPretendingToBe)).Debug("Loading service definition (autoassigned)")
-		// TODO: findNextContainerIndex => util/container_operations.go
-		if len(cNum) == 0 {
-			cNum = append(cNum, 1)
-		} else {
-			cNum[0] = 1
-		}
-	} else {
-		log.WithField("=>", fmt.Sprintf("%s:%d", serviceYourPretendingToBe, cNum[0])).Debug("Loading service definition")
-	}
-
-	srv.Operations.ContainerNumber = cNum[0]
 
 	giveMeAllTheNames(serviceYourPretendingToBe, srv)
 	return srv
@@ -35,8 +21,8 @@ func giveMeAllTheNames(name string, srv *def.ServiceDefinition) {
 	log.WithField("=>", name).Debug("Giving myself all the names")
 	srv.Name = name
 	srv.Service.Name = name
-	srv.Operations.SrvContainerName = util.DataContainersName(srv.Name, srv.Operations.ContainerNumber)
-	srv.Operations.DataContainerName = util.DataContainersName(srv.Name, srv.Operations.ContainerNumber)
+	srv.Operations.SrvContainerName = util.DataContainersName(srv.Name)
+	srv.Operations.DataContainerName = util.DataContainersName(srv.Name)
 	log.WithFields(log.Fields{
 		"data container":    srv.Operations.DataContainerName,
 		"service container": srv.Operations.SrvContainerName,

--- a/data/manage.go
+++ b/data/manage.go
@@ -16,12 +16,12 @@ import (
 
 func RenameData(do *definitions.Do) error {
 	log.WithFields(log.Fields{
-		"from": fmt.Sprintf("%s:%d", do.Name, do.Operations.ContainerNumber),
-		"to":   fmt.Sprintf("%s:%d", do.NewName, do.Operations.ContainerNumber),
+		"from": do.Name,
+		"to":   do.NewName,
 	}).Info("Renaming data container")
 
-	if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
-		ops := loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
+	if util.IsDataContainer(do.Name) {
+		ops := loaders.LoadDataDefinition(do.Name)
 		util.Merge(ops, do.Operations)
 
 		err := perform.DockerRename(ops, do.NewName)
@@ -36,11 +36,11 @@ func RenameData(do *definitions.Do) error {
 }
 
 func InspectData(do *definitions.Do) error {
-	if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
+	if util.IsDataContainer(do.Name) {
 		log.WithField("=>", do.Name).Info("Inspecting data container")
 
 		srv := definitions.BlankServiceDefinition()
-		srv.Operations.SrvContainerName = util.ContainersName(definitions.TypeData, do.Name, do.Operations.ContainerNumber)
+		srv.Operations.SrvContainerName = util.ContainersName(definitions.TypeData, do.Name)
 
 		err := perform.DockerInspect(srv.Service, srv.Operations, do.Operations.Args[0])
 		if err != nil {
@@ -60,11 +60,11 @@ func RmData(do *definitions.Do) (err error) {
 	}
 	for _, name := range do.Operations.Args {
 		do.Name = name
-		if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
+		if util.IsDataContainer(do.Name) {
 			log.WithField("=>", do.Name).Info("Removing data container")
 
 			srv := definitions.BlankServiceDefinition()
-			srv.Operations.SrvContainerName = util.ContainersName("data", do.Name, do.Operations.ContainerNumber)
+			srv.Operations.SrvContainerName = util.ContainersName("data", do.Name)
 
 			if err = perform.DockerRemove(srv.Service, srv.Operations, false, do.Volumes, false); err != nil {
 				log.Errorf("Error removing %s: %v", do.Name, err)

--- a/data/operate.go
+++ b/data/operate.go
@@ -25,7 +25,6 @@ import (
 // in a data container. It returns an error.
 //
 //  do.Name                       - name of the data container to use (required)
-//  do.Operations.ContainerNumber - container number (optional)
 //  do.Source                     - directory which should be imported (required)
 //  do.Destination                - directory to _unload_ the payload into (required)
 //
@@ -34,9 +33,9 @@ func ImportData(do *definitions.Do) error {
 		"from": do.Source,
 		"to":   do.Destination,
 	}).Debug("Importing")
-	if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
+	if util.IsDataContainer(do.Name) {
 
-		srv := PretendToBeAService(do.Name, do.Operations.ContainerNumber)
+		srv := PretendToBeAService(do.Name)
 		service, exists := perform.ContainerExists(srv.Operations)
 
 		if !exists {
@@ -46,7 +45,7 @@ func ImportData(do *definitions.Do) error {
 			return err
 		}
 
-		containerName := util.DataContainersName(do.Name, do.Operations.ContainerNumber)
+		containerName := util.DataContainersName(do.Name)
 		// os.Chdir(do.Source)
 
 		reader, err := util.Tar(do.Source, 0)
@@ -70,7 +69,6 @@ func ImportData(do *definitions.Do) error {
 		doChown := definitions.NowDo()
 		doChown.Operations.DataContainerName = containerName
 		doChown.Operations.ContainerType = "data"
-		doChown.Operations.ContainerNumber = do.Operations.ContainerNumber
 		//required b/c `docker cp` (UploadToContainer) goes in as root
 		doChown.Operations.Args = []string{"chown", "--recursive", "eris", do.Destination}
 		_, err = perform.DockerRunData(doChown.Operations, nil)
@@ -79,7 +77,7 @@ func ImportData(do *definitions.Do) error {
 		}
 	} else {
 		log.WithField("name", do.Name).Info("Data container does not exist.")
-		ops := loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
+		ops := loaders.LoadDataDefinition(do.Name)
 		if err := perform.DockerCreateData(ops); err != nil {
 			return fmt.Errorf("Error creating data container %v.", err)
 		}
@@ -90,10 +88,10 @@ func ImportData(do *definitions.Do) error {
 }
 
 func ExecData(do *definitions.Do) (buf *bytes.Buffer, err error) {
-	if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
+	if util.IsDataContainer(do.Name) {
 		log.WithField("=>", do.Operations.DataContainerName).Info("Executing data container")
 
-		ops := loaders.LoadDataDefinition(do.Name, do.Operations.ContainerNumber)
+		ops := loaders.LoadDataDefinition(do.Name)
 		util.Merge(ops, do.Operations)
 		buf, err = perform.DockerExecData(ops, nil)
 		if err != nil {
@@ -108,18 +106,18 @@ func ExecData(do *definitions.Do) (buf *bytes.Buffer, err error) {
 
 //export from: do.Source(in container), to: do.Destination(on host)
 func ExportData(do *definitions.Do) error {
-	if util.IsDataContainer(do.Name, do.Operations.ContainerNumber) {
+	if util.IsDataContainer(do.Name) {
 		log.WithField("=>", do.Name).Info("Exporting data container")
 
 		// we want to export to a temp directory.
-		exportPath, err := ioutil.TempDir(os.TempDir(), do.Name) // TODO: do.Operations.ContainerNumber ?
+		exportPath, err := ioutil.TempDir(os.TempDir(), do.Name)
 		defer os.Remove(exportPath)
 		if err != nil {
 			return err
 		}
 
-		containerName := util.DataContainersName(do.Name, do.Operations.ContainerNumber)
-		srv := PretendToBeAService(do.Name, do.Operations.ContainerNumber)
+		containerName := util.DataContainersName(do.Name)
+		srv := PretendToBeAService(do.Name)
 		service, exists := perform.ContainerExists(srv.Operations)
 
 		if !exists {

--- a/definitions/operation.go
+++ b/definitions/operation.go
@@ -7,7 +7,6 @@ type Operation struct {
 	DataContainerName string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	DataContainerID   string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	ContainerType     string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
-	ContainerNumber   int               `json:",omitempty,omitzero" yaml:",omitempty" toml:",omitempty,omitzero"`
 	Remove            bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	Privileged        bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	Interactive       bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -103,7 +103,6 @@ func TestExportKeySingle(t *testing.T) {
 	do := def.NowDo()
 	do.Name = "keys"
 	do.Operations.Interactive = false
-	do.Operations.ContainerNumber = 1
 	keyPath := path.Join(ErisContainerRoot, "keys", "data", address, address)
 
 	//cat container contents of new key
@@ -162,7 +161,6 @@ func TestImportKeySingle(t *testing.T) {
 	doRm := def.NowDo()
 	doRm.Name = "keys"
 	doRm.Operations.Interactive = false
-	doRm.Operations.ContainerNumber = 1
 	keyPath := path.Join(ErisContainerRoot, "keys", "data", address)
 
 	doRm.Operations.Args = []string{"rm", "-rf", keyPath}
@@ -182,7 +180,6 @@ func TestImportKeySingle(t *testing.T) {
 	doCat := def.NowDo()
 	doCat.Name = "keys"
 	doCat.Operations.Interactive = false
-	doCat.Operations.ContainerNumber = 1
 	keyPathCat := path.Join(ErisContainerRoot, "keys", "data", address, address)
 
 	//cat container contents of new key
@@ -301,8 +298,7 @@ func testStartKeys(t *testing.T) {
 	serviceName := "keys"
 	do := def.NowDo()
 	do.Operations.Args = []string{serviceName}
-	do.Operations.ContainerNumber = 1
-	log.WithField("=>", fmt.Sprintf("%s:%d", serviceName, do.Operations.ContainerNumber)).Debug("Starting service (via tests)")
+	log.WithField("=>", serviceName).Debug("Starting service (via tests)")
 	e := srv.StartService(do)
 	if e != nil {
 		log.Infof("Error starting service: %v", e)

--- a/keys/readers.go
+++ b/keys/readers.go
@@ -38,7 +38,6 @@ func ListKeys(do *definitions.Do) error {
 
 	if do.Container {
 		do.Name = "keys"
-		do.Operations.ContainerNumber = 1
 		if err := srv.EnsureRunning(do); err != nil {
 			return err
 		}

--- a/keys/writers.go
+++ b/keys/writers.go
@@ -15,7 +15,6 @@ import (
 
 func GenerateKey(do *definitions.Do) error {
 	do.Name = "keys"
-	do.Operations.ContainerNumber = 1
 
 	if err := srv.EnsureRunning(do); err != nil {
 		return err
@@ -36,7 +35,6 @@ func GenerateKey(do *definitions.Do) error {
 func GetPubKey(do *definitions.Do) error {
 
 	do.Name = "keys"
-	do.Operations.ContainerNumber = 1
 	if err := srv.EnsureRunning(do); err != nil {
 		return err
 	}
@@ -57,7 +55,6 @@ func GetPubKey(do *definitions.Do) error {
 func ExportKey(do *definitions.Do) error {
 
 	do.Name = "keys"
-	do.Operations.ContainerNumber = 1
 	if err := srv.EnsureRunning(do); err != nil {
 		return err
 	}
@@ -77,7 +74,6 @@ func ExportKey(do *definitions.Do) error {
 func ImportKey(do *definitions.Do) error {
 
 	do.Name = "keys"
-	do.Operations.ContainerNumber = 1
 	if err := srv.EnsureRunning(do); err != nil {
 		return err
 	}

--- a/loaders/data.go
+++ b/loaders/data.go
@@ -1,8 +1,6 @@
 package loaders
 
 import (
-	"fmt"
-
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
 
@@ -10,19 +8,15 @@ import (
 )
 
 // LoadDataDefinition returns an Operation structure for a blank data container
-// specified by a name dataName and a cNum number.
-func LoadDataDefinition(dataName string, cNum int) *definitions.Operation {
-	if cNum == 0 {
-		cNum = 1
-	}
+// specified by a name dataName
+func LoadDataDefinition(dataName string) *definitions.Operation {
 
-	log.WithField("=>", fmt.Sprintf("%s:%d", dataName, cNum)).Debug("Loading data definition")
+	log.WithField("=>", dataName).Debug("Loading data definition")
 
 	ops := definitions.BlankOperation()
-	ops.ContainerNumber = cNum
 	ops.ContainerType = definitions.TypeData
-	ops.SrvContainerName = util.DataContainersName(dataName, cNum)
-	ops.DataContainerName = util.DataContainersName(dataName, cNum)
+	ops.SrvContainerName = util.DataContainersName(dataName)
+	ops.DataContainerName = util.DataContainersName(dataName)
 	ops.Labels = util.Labels(dataName, ops)
 
 	return ops

--- a/perform/perform.go
+++ b/perform/perform.go
@@ -34,7 +34,6 @@ var (
 //
 //  ops.DataContainerName  - data container name to be created
 //  ops.ContainerType      - container type
-//  ops.ContainerNumber    - container number
 //  ops.Labels             - container creation time labels (use LoadDataDefinition)
 //
 func DockerCreateData(ops *def.Operation) error {
@@ -67,7 +66,6 @@ func DockerCreateData(ops *def.Operation) error {
 //
 //  ops.DataContainerName - container name to be mount with `--volumes-from=[]` option.
 //  ops.ContainerType     - container type
-//  ops.ContainerNumber   - container number
 //  ops.Labels            - container creation time labels (use LoadDataDefinition)
 //  ops.Args              - if specified, run these args in a container
 //
@@ -182,7 +180,6 @@ func DockerExecData(ops *def.Operation, service *def.Service) (buf *bytes.Buffer
 //
 //  ops.SrvContainerName  - service or a chain container name
 //  ops.DataContainerName - dependent data container name
-//  ops.ContainerNumber   - container number
 //  ops.ContainerType     - container type
 //  ops.Labels            - container creation time labels
 //                          (use LoadServiceDefinition or LoadChainDefinition)
@@ -359,7 +356,6 @@ func DockerExecService(srv *def.Service, ops *def.Operation) (buf *bytes.Buffer,
 // container process ungracefully.
 //
 //  ops.SrvContainerName  - service or a chain container name to rebuild
-//  ops.ContainerNumber   - container number
 //  ops.ContainerType     - container type
 //  ops.Labels            - container creation time labels
 //
@@ -427,7 +423,6 @@ func DockerRebuild(srv *def.Service, ops *def.Operation, pullImage bool, timeout
 // DockerPull returns Docker errors on exit if not successful.
 //
 //  ops.SrvContainerName  - service or a chain container name
-//  ops.ContainerNumber   - container number
 //  ops.ContainerType     - container type
 //  ops.Labels            - container creation time labels
 //
@@ -549,12 +544,11 @@ func DockerStop(srv *def.Service, ops *def.Operation, timeout uint) error {
 // if the container with the new (long) name exists.
 //
 //  ops.SrvContainerName  - container name
-//  ops.ContainerNumber   - container number
 //  ops.ContainerType     - container type
 //  ops.Labels            - container creation time labels
 //
 func DockerRename(ops *def.Operation, newName string) error {
-	longNewName := util.ContainersName(ops.ContainerType, newName, ops.ContainerNumber)
+	longNewName := util.ContainersName(ops.ContainerType, newName)
 
 	log.WithFields(log.Fields{
 		"from": ops.SrvContainerName,
@@ -977,9 +971,6 @@ func configureInteractiveContainer(srv *def.Service, ops *def.Operation) docker.
 }
 
 func configureServiceContainer(srv *def.Service, ops *def.Operation) docker.CreateContainerOptions {
-	if ops.ContainerNumber == 0 {
-		ops.ContainerNumber = 1
-	}
 
 	opts := docker.CreateContainerOptions{
 		Name: ops.SrvContainerName,

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -36,8 +36,7 @@ func TestMain(m *testing.M) {
 
 func TestCreateDataSimple(t *testing.T) {
 	const (
-		name   = "testdata"
-		number = 199
+		name = "testdata"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -46,7 +45,7 @@ func TestCreateDataSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	ops := loaders.LoadDataDefinition(name, number)
+	ops := loaders.LoadDataDefinition(name)
 	if err := DockerCreateData(ops); err != nil {
 		t.Fatalf("expected data container created, got %v", err)
 	}
@@ -63,8 +62,7 @@ func TestCreateDataSimple(t *testing.T) {
 
 func TestRunDataSimple(t *testing.T) {
 	const (
-		name   = "testdata"
-		number = 199
+		name = "testdata"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -73,7 +71,7 @@ func TestRunDataSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	ops := loaders.LoadDataDefinition(name, number)
+	ops := loaders.LoadDataDefinition(name)
 	if err := DockerCreateData(ops); err != nil {
 		t.Fatalf("expected data container created, got %v", err)
 	}
@@ -86,8 +84,7 @@ func TestRunDataSimple(t *testing.T) {
 
 func TestRunDataBadCommandLine(t *testing.T) {
 	const (
-		name   = "testdata"
-		number = 199
+		name = "testdata"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -96,7 +93,7 @@ func TestRunDataBadCommandLine(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	ops := loaders.LoadDataDefinition(name, number)
+	ops := loaders.LoadDataDefinition(name)
 	if err := DockerCreateData(ops); err != nil {
 		t.Fatalf("expected data container created, got %v", err)
 	}
@@ -111,8 +108,7 @@ func TestRunDataBadCommandLine(t *testing.T) {
 
 func TestExecDataSimple(t *testing.T) {
 	const (
-		name   = "testdata"
-		number = 199
+		name = "testdata"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -121,7 +117,7 @@ func TestExecDataSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	ops := loaders.LoadDataDefinition(name, number)
+	ops := loaders.LoadDataDefinition(name)
 	if err := DockerCreateData(ops); err != nil {
 		t.Fatalf("expected data container created, got %v", err)
 	}
@@ -138,8 +134,7 @@ func TestExecDataSimple(t *testing.T) {
 
 func TestExecDataBadCommandLine(t *testing.T) {
 	const (
-		name   = "testdata"
-		number = 199
+		name = "testdata"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -148,7 +143,7 @@ func TestExecDataBadCommandLine(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	ops := loaders.LoadDataDefinition(name, number)
+	ops := loaders.LoadDataDefinition(name)
 	if err := DockerCreateData(ops); err != nil {
 		t.Fatalf("expected data container created, got %v", err)
 	}
@@ -161,8 +156,7 @@ func TestExecDataBadCommandLine(t *testing.T) {
 
 func TestExecDataBufferNotOverwritten(t *testing.T) {
 	const (
-		name   = "testdata"
-		number = 199
+		name = "testdata"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -171,7 +165,7 @@ func TestExecDataBufferNotOverwritten(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	ops := loaders.LoadDataDefinition(name, number)
+	ops := loaders.LoadDataDefinition(name)
 	if err := DockerCreateData(ops); err != nil {
 		t.Fatalf("expected data container created, got %v", err)
 	}
@@ -195,8 +189,7 @@ func TestExecDataBufferNotOverwritten(t *testing.T) {
 
 func TestRunServiceSimple(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -205,7 +198,7 @@ func TestRunServiceSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -224,8 +217,7 @@ func TestRunServiceSimple(t *testing.T) {
 
 func TestRunServiceNoDataContainer(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -234,7 +226,7 @@ func TestRunServiceNoDataContainer(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -252,87 +244,9 @@ func TestRunServiceNoDataContainer(t *testing.T) {
 	}
 }
 
-func TestRunServiceTwoServices(t *testing.T) {
-	const (
-		name   = "ipfs"
-		number = 99
-	)
-
-	defer tests.RemoveAllContainers()
-
-	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
-		t.Fatalf("expecting 0 containers, got %v", n)
-	}
-
-	srv1, err := loaders.LoadServiceDefinition(name, true, number)
-	if err != nil {
-		t.Fatalf("1. could not load service definition %v", err)
-	}
-
-	if err := DockerRunService(srv1.Service, srv1.Operations); err != nil {
-		t.Fatalf("1. expected service container created, got %v", err)
-	}
-
-	srv2, err := loaders.LoadServiceDefinition(name, true, number+1)
-	if err != nil {
-		t.Fatalf("2. could not load service definition %v", err)
-	}
-
-	if err := DockerRunService(srv2.Service, srv2.Operations); err == nil {
-		t.Fatalf("2. expected service failure due to occupied ports, got %v", err)
-	}
-
-	if n := util.HowManyContainersRunning(name, def.TypeService); n != 1 {
-		t.Fatalf("expecting 1 service running, got %v", n)
-	}
-	if n := util.HowManyContainersExisting(name, def.TypeData); n != 2 {
-		t.Fatalf("expecting 2 dependent data container, got %v", n)
-	}
-}
-
-func TestRunServiceTwoServicesPublishedPorts(t *testing.T) {
-	const (
-		name   = "ipfs"
-		number = 99
-	)
-
-	defer tests.RemoveAllContainers()
-
-	if n := util.HowManyContainersExisting(name, def.TypeService); n != 0 {
-		t.Fatalf("expecting 0 containers, got %v", n)
-	}
-
-	srv1, err := loaders.LoadServiceDefinition(name, true, number)
-	if err != nil {
-		t.Fatalf("1. could not load service definition %v", err)
-	}
-
-	if err := DockerRunService(srv1.Service, srv1.Operations); err != nil {
-		t.Fatalf("1. expected service container created, got %v", err)
-	}
-
-	srv2, err := loaders.LoadServiceDefinition(name, true, number+1)
-	if err != nil {
-		t.Fatalf("2. could not load service definition %v", err)
-	}
-
-	srv2.Operations.PublishAllPorts = true
-	if err := DockerRunService(srv2.Service, srv2.Operations); err != nil {
-		t.Fatalf("2. expected service container created, got %v", err)
-	}
-
-	if n := util.HowManyContainersRunning(name, def.TypeService); n != 2 {
-		t.Fatalf("expecting 2 services running, got %v", n)
-	}
-	if n := util.HowManyContainersExisting(name, def.TypeData); n != 2 {
-		t.Fatalf("expecting 2 dependent data container, got %v", n)
-	}
-}
-
 func TestExecServiceSimple(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -341,7 +255,7 @@ func TestExecServiceSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -362,13 +276,12 @@ func TestExecServiceSimple(t *testing.T) {
 
 func TestExecServiceBufferNotOverwritten(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -392,8 +305,7 @@ func TestExecServiceBufferNotOverwritten(t *testing.T) {
 
 func TestExecServiceAlwaysRestart(t *testing.T) {
 	const (
-		name   = "restart-keys"
-		number = 99
+		name = "restart-keys"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -415,7 +327,7 @@ restart = "always"
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -439,8 +351,7 @@ restart = "always"
 
 func TestExecServiceMaxAttemptsRestart(t *testing.T) {
 	const (
-		name   = "restart-keys"
-		number = 99
+		name = "restart-keys"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -462,7 +373,7 @@ restart = "max:99"
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -486,8 +397,7 @@ restart = "max:99"
 
 func TestExecServiceNeverRestart(t *testing.T) {
 	const (
-		name   = "restart-keys"
-		number = 99
+		name = "restart-keys"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -508,7 +418,7 @@ exec_host = "ERIS_KEYS_HOST"
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -532,8 +442,7 @@ exec_host = "ERIS_KEYS_HOST"
 
 func TestExecServiceLogOutput(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -542,7 +451,7 @@ func TestExecServiceLogOutput(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -560,8 +469,7 @@ func TestExecServiceLogOutput(t *testing.T) {
 
 func TestExecServiceLogOutputLongRunning(t *testing.T) {
 	const (
-		name   = "keys"
-		number = 99
+		name = "keys"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -570,7 +478,7 @@ func TestExecServiceLogOutputLongRunning(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -588,8 +496,7 @@ func TestExecServiceLogOutputLongRunning(t *testing.T) {
 
 func TestExecServiceLogOutputInteractive(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -598,7 +505,7 @@ func TestExecServiceLogOutputInteractive(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -617,8 +524,7 @@ func TestExecServiceLogOutputInteractive(t *testing.T) {
 
 func TestExecServiceTwice(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -627,7 +533,7 @@ func TestExecServiceTwice(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -653,8 +559,7 @@ func TestExecServiceTwice(t *testing.T) {
 
 func TestExecServiceTwiceWithoutData(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -663,7 +568,7 @@ func TestExecServiceTwiceWithoutData(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -689,8 +594,7 @@ func TestExecServiceTwiceWithoutData(t *testing.T) {
 
 func TestExecServiceBadCommandLine(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -699,7 +603,7 @@ func TestExecServiceBadCommandLine(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -720,8 +624,7 @@ func TestExecServiceBadCommandLine(t *testing.T) {
 
 func TestExecServiceNonInteractive(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -730,7 +633,7 @@ func TestExecServiceNonInteractive(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -751,8 +654,7 @@ func TestExecServiceNonInteractive(t *testing.T) {
 
 func TestExecServiceAfterRunService(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -761,7 +663,7 @@ func TestExecServiceAfterRunService(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -779,8 +681,7 @@ func TestExecServiceAfterRunService(t *testing.T) {
 
 func TestExecServiceAfterRunServiceWithPublishedPorts1(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -789,7 +690,7 @@ func TestExecServiceAfterRunServiceWithPublishedPorts1(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -815,8 +716,7 @@ func TestExecServiceAfterRunServiceWithPublishedPorts1(t *testing.T) {
 
 func TestExecServiceAfterRunServiceWithPublishedPorts2(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -825,7 +725,7 @@ func TestExecServiceAfterRunServiceWithPublishedPorts2(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -851,8 +751,7 @@ func TestExecServiceAfterRunServiceWithPublishedPorts2(t *testing.T) {
 
 func TestContainerExistsSimple(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -861,7 +760,7 @@ func TestContainerExistsSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -882,8 +781,7 @@ func TestContainerExistsSimple(t *testing.T) {
 
 func TestContainerExistsBadName(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -892,7 +790,7 @@ func TestContainerExistsBadName(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -905,8 +803,7 @@ func TestContainerExistsBadName(t *testing.T) {
 
 func TestContainerExistsAfterRemove(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -915,7 +812,7 @@ func TestContainerExistsAfterRemove(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -928,7 +825,7 @@ func TestContainerExistsAfterRemove(t *testing.T) {
 		t.Fatalf("expecting service container exists, got false")
 	}
 
-	tests.RemoveContainer(name, def.TypeService, number)
+	tests.RemoveContainer(name, def.TypeService)
 
 	if _, exists := ContainerExists(srv.Operations); exists == true {
 		t.Fatalf("expecting service container not existing after remove, got true")
@@ -937,8 +834,7 @@ func TestContainerExistsAfterRemove(t *testing.T) {
 
 func TestContainerRunningSimple(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -947,7 +843,7 @@ func TestContainerRunningSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -968,8 +864,7 @@ func TestContainerRunningSimple(t *testing.T) {
 
 func TestContainerRunningBadName(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -978,7 +873,7 @@ func TestContainerRunningBadName(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -999,8 +894,7 @@ func TestContainerRunningBadName(t *testing.T) {
 
 func TestContainerRunningAfterRemove(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1009,7 +903,7 @@ func TestContainerRunningAfterRemove(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1022,7 +916,7 @@ func TestContainerRunningAfterRemove(t *testing.T) {
 		t.Fatalf("expecting service container exists, got false")
 	}
 
-	tests.RemoveContainer(name, def.TypeService, number)
+	tests.RemoveContainer(name, def.TypeService)
 
 	if _, running := ContainerRunning(srv.Operations); running == true {
 		t.Fatalf("expecting service container not existing after remove, got true")
@@ -1031,8 +925,7 @@ func TestContainerRunningAfterRemove(t *testing.T) {
 
 func TestDataContainerExistsSimple(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1041,7 +934,7 @@ func TestDataContainerExistsSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1058,8 +951,7 @@ func TestDataContainerExistsSimple(t *testing.T) {
 
 func TestDataContainerExistsBadName(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1068,7 +960,7 @@ func TestDataContainerExistsBadName(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1081,8 +973,7 @@ func TestDataContainerExistsBadName(t *testing.T) {
 
 func TestDataContainerExistsAfterRemove(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1091,7 +982,7 @@ func TestDataContainerExistsAfterRemove(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1105,7 +996,7 @@ func TestDataContainerExistsAfterRemove(t *testing.T) {
 		t.Fatalf("expecting service container exists, got false")
 	}
 
-	tests.RemoveContainer(name, def.TypeData, number)
+	tests.RemoveContainer(name, def.TypeData)
 
 	if _, exists := DataContainerExists(srv.Operations); exists == true {
 		t.Fatalf("expecting service container not existing after remove, got true")
@@ -1114,8 +1005,7 @@ func TestDataContainerExistsAfterRemove(t *testing.T) {
 
 func TestRemoveWithoutData(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1124,7 +1014,7 @@ func TestRemoveWithoutData(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1165,8 +1055,7 @@ func TestRemoveWithoutData(t *testing.T) {
 
 func TestRemoveWithData(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1175,7 +1064,7 @@ func TestRemoveWithData(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1211,8 +1100,7 @@ func TestRemoveWithData(t *testing.T) {
 
 func TestRemoveServiceWithoutStopping(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1221,7 +1109,7 @@ func TestRemoveServiceWithoutStopping(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1237,8 +1125,7 @@ func TestRemoveServiceWithoutStopping(t *testing.T) {
 
 func TestStopSimple(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1247,7 +1134,7 @@ func TestStopSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1279,8 +1166,7 @@ func TestStopSimple(t *testing.T) {
 
 func TestStopDataContainer(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1289,7 +1175,7 @@ func TestStopDataContainer(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1307,7 +1193,6 @@ func TestStopDataContainer(t *testing.T) {
 func TestRebuildSimple(t *testing.T) {
 	const (
 		name    = "ipfs"
-		number  = 99
 		timeout = 5
 	)
 
@@ -1317,7 +1202,7 @@ func TestRebuildSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1342,7 +1227,6 @@ func TestRebuildSimple(t *testing.T) {
 func TestRebuildBadName(t *testing.T) {
 	const (
 		name    = "ipfs"
-		number  = 99
 		timeout = 5
 	)
 
@@ -1352,7 +1236,7 @@ func TestRebuildBadName(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1367,7 +1251,6 @@ func TestRebuildBadName(t *testing.T) {
 func TestRebuildNotCreated(t *testing.T) {
 	const (
 		name    = "ipfs"
-		number  = 99
 		timeout = 5
 	)
 
@@ -1377,7 +1260,7 @@ func TestRebuildNotCreated(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1391,7 +1274,6 @@ func TestRebuildNotCreated(t *testing.T) {
 func TestRebuildTimeout0(t *testing.T) {
 	const (
 		name    = "ipfs"
-		number  = 99
 		timeout = 0
 	)
 
@@ -1401,7 +1283,7 @@ func TestRebuildTimeout0(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1426,7 +1308,6 @@ func TestRebuildTimeout0(t *testing.T) {
 func TestRebuildNotRunning(t *testing.T) {
 	const (
 		name    = "ipfs"
-		number  = 99
 		timeout = 5
 	)
 
@@ -1436,7 +1317,7 @@ func TestRebuildNotRunning(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1465,7 +1346,6 @@ func TestRebuildNotRunning(t *testing.T) {
 func TestRebuildPullDisallow(t *testing.T) {
 	const (
 		name    = "keys"
-		number  = 99
 		timeout = 5
 	)
 
@@ -1479,7 +1359,7 @@ func TestRebuildPullDisallow(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1504,7 +1384,6 @@ func TestRebuildPullDisallow(t *testing.T) {
 func TestRebuildPull(t *testing.T) {
 	const (
 		name    = "keys"
-		number  = 99
 		timeout = 5
 	)
 
@@ -1518,7 +1397,7 @@ func TestRebuildPull(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1543,7 +1422,6 @@ func TestRebuildPull(t *testing.T) {
 func TestRebuildPullRepeat(t *testing.T) {
 	const (
 		name    = "keys"
-		number  = 99
 		timeout = 5
 	)
 
@@ -1555,7 +1433,7 @@ func TestRebuildPullRepeat(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1579,8 +1457,7 @@ func TestRebuildPullRepeat(t *testing.T) {
 
 func TestPullSimple(t *testing.T) {
 	const (
-		name   = "keys"
-		number = 99
+		name = "keys"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1593,7 +1470,7 @@ func TestPullSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1617,8 +1494,7 @@ func TestPullSimple(t *testing.T) {
 
 func TestPullRepeat(t *testing.T) {
 	const (
-		name   = "keys"
-		number = 99
+		name = "keys"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1629,7 +1505,7 @@ func TestPullRepeat(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1653,13 +1529,12 @@ func TestPullRepeat(t *testing.T) {
 
 func TestPullBadName(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1673,9 +1548,8 @@ func TestPullBadName(t *testing.T) {
 
 func TestLogsSimple(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
-		tail   = "100"
+		name = "ipfs"
+		tail = "100"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1684,7 +1558,7 @@ func TestLogsSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1711,9 +1585,8 @@ func TestLogsSimple(t *testing.T) {
 
 func TestLogsFollow(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
-		tail   = "1"
+		name = "ipfs"
+		tail = "1"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1722,7 +1595,7 @@ func TestLogsFollow(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1745,9 +1618,8 @@ func TestLogsFollow(t *testing.T) {
 
 func TestLogsTail(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
-		tail   = "100"
+		name = "ipfs"
+		tail = "100"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1756,7 +1628,7 @@ func TestLogsTail(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1783,9 +1655,8 @@ func TestLogsTail(t *testing.T) {
 
 func TestLogsTail0(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
-		tail   = "0"
+		name = "ipfs"
+		tail = "0"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1794,7 +1665,7 @@ func TestLogsTail0(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1821,14 +1692,13 @@ func TestLogsTail0(t *testing.T) {
 
 func TestLogsBadName(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
-		tail   = "1"
+		name = "ipfs"
+		tail = "1"
 	)
 
 	defer tests.RemoveAllContainers()
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1842,8 +1712,7 @@ func TestLogsBadName(t *testing.T) {
 
 func TestInspectSimple(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1852,7 +1721,7 @@ func TestInspectSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1875,8 +1744,7 @@ func TestInspectSimple(t *testing.T) {
 
 func TestInspectLine(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1885,7 +1753,7 @@ func TestInspectLine(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1902,8 +1770,7 @@ func TestInspectLine(t *testing.T) {
 
 func TestInspectField(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1912,7 +1779,7 @@ func TestInspectField(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1935,13 +1802,12 @@ func TestInspectField(t *testing.T) {
 
 func TestInspectStoppedContainer(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1968,8 +1834,7 @@ func TestInspectStoppedContainer(t *testing.T) {
 
 func TestInspectBadName(t *testing.T) {
 	const (
-		name   = "ipfs"
-		number = 99
+		name = "ipfs"
 	)
 
 	defer tests.RemoveAllContainers()
@@ -1978,7 +1843,7 @@ func TestInspectBadName(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1994,7 +1859,6 @@ func TestRenameSimple(t *testing.T) {
 	const (
 		name    = "testdata"
 		newName = "newname"
-		number  = 199
 	)
 
 	defer tests.RemoveAllContainers()
@@ -2003,7 +1867,7 @@ func TestRenameSimple(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	ops := loaders.LoadDataDefinition(name, number)
+	ops := loaders.LoadDataDefinition(name)
 	if err := DockerCreateData(ops); err != nil {
 		t.Fatalf("expected data container created, got %v", err)
 	}
@@ -2024,7 +1888,6 @@ func TestRenameService(t *testing.T) {
 	const (
 		name    = "ipfs"
 		newName = "newname"
-		number  = 99
 	)
 
 	defer tests.RemoveAllContainers()
@@ -2033,7 +1896,7 @@ func TestRenameService(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -2072,7 +1935,6 @@ func TestRenameEmptyName(t *testing.T) {
 	const (
 		name    = "ipfs"
 		newName = ""
-		number  = 99
 	)
 
 	defer tests.RemoveAllContainers()
@@ -2081,7 +1943,7 @@ func TestRenameEmptyName(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -2107,7 +1969,6 @@ func TestRenameServiceStopped(t *testing.T) {
 	const (
 		name    = "ipfs"
 		newName = "newname"
-		number  = 99
 	)
 
 	defer tests.RemoveAllContainers()
@@ -2116,7 +1977,7 @@ func TestRenameServiceStopped(t *testing.T) {
 		t.Fatalf("expecting 0 containers, got %v", n)
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -2158,12 +2019,11 @@ func TestRenameBadName(t *testing.T) {
 	const (
 		name    = "ipfs"
 		newName = "newname"
-		number  = 99
 	)
 
 	defer tests.RemoveAllContainers()
 
-	srv, err := loaders.LoadServiceDefinition(name, true, number)
+	srv, err := loaders.LoadServiceDefinition(name, true)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}

--- a/pkgs/packages_test.go
+++ b/pkgs/packages_test.go
@@ -237,7 +237,6 @@ func TestKnownChainBoots(t *testing.T) {
 	doMake := definitions.NowDo()
 	doMake.Name = chainName
 	doMake.ChainType = "simplechain"
-	doMake.Operations.ContainerNumber = 1
 	doMake.Debug = true
 	if err := chains.MakeChain(doMake); err != nil {
 		log.Error(err)
@@ -246,7 +245,6 @@ func TestKnownChainBoots(t *testing.T) {
 
 	pkg := loaders.DefaultPackage(name, chainName)
 	doBoot := definitions.NowDo()
-	doBoot.Operations.ContainerNumber = 1
 	defer CleanUp(doBoot, pkg)
 
 	if err := BootServicesAndChain(doBoot, pkg); err != nil {
@@ -276,7 +274,6 @@ func TestThrowawayChainBootsAndIsRemoved(t *testing.T) {
 
 	pkg := loaders.DefaultPackage(name, chainName)
 	doBoot := definitions.NowDo()
-	doBoot.Operations.ContainerNumber = 1
 
 	if err := BootServicesAndChain(doBoot, pkg); err != nil {
 		CleanUp(doBoot, pkg)
@@ -395,7 +392,6 @@ func TestBadPathsGiven(t *testing.T) {
 	pkg := loaders.DefaultPackage(name, chainName)
 	pkg.ChainName = "temp"
 	do := definitions.NowDo()
-	do.Operations.ContainerNumber = 1
 
 	defer func() {
 		CleanUp(do, pkg)
@@ -421,7 +417,6 @@ func TestImportEPMYamlInMainDir(t *testing.T) {
 	pkg := loaders.DefaultPackage(name, chainName)
 	pkg.ChainName = "temp"
 	do := definitions.NowDo()
-	do.Operations.ContainerNumber = 1
 
 	defer func() {
 		// CleanUp(do, pkg)
@@ -465,7 +460,6 @@ func TestImportEPMYamlNotInContractDir(t *testing.T) {
 	pkg := loaders.DefaultPackage(name, chainName)
 	pkg.ChainName = "temp"
 	do := definitions.NowDo()
-	do.Operations.ContainerNumber = 1
 
 	defer func() {
 		if err := os.RemoveAll(dir); err != nil {
@@ -535,7 +529,6 @@ func TestImportMainDirRel(t *testing.T) {
 	pkg := loaders.DefaultPackage(name, chainName)
 	pkg.ChainName = "temp"
 	do := definitions.NowDo()
-	do.Operations.ContainerNumber = 1
 
 	if err := DefinePkgActionService(do, pkg); err != nil {
 		t.Fatalf("unexpected error formulating the pkg service: %v", err)
@@ -579,7 +572,6 @@ func TestImportMainDirAsFile(t *testing.T) {
 	pkg := loaders.DefaultPackage(name, chainName)
 	pkg.ChainName = "temp"
 	do := definitions.NowDo()
-	do.Operations.ContainerNumber = 1
 
 	defer func() {
 		CleanUp(do, pkg)
@@ -626,7 +618,6 @@ func TestImportContractDirRel(t *testing.T) {
 	pkg := loaders.DefaultPackage(name, chainName)
 	pkg.ChainName = "temp"
 	do := definitions.NowDo()
-	do.Operations.ContainerNumber = 1
 
 	defer func() {
 		if err := os.RemoveAll(dir); err != nil {
@@ -687,7 +678,6 @@ func TestImportContractDirAbs(t *testing.T) {
 	pkg := loaders.DefaultPackage(name, chainName)
 	pkg.ChainName = "temp"
 	do := definitions.NowDo()
-	do.Operations.ContainerNumber = 1
 
 	defer func() {
 		if err := os.RemoveAll(dir); err != nil {
@@ -746,7 +736,6 @@ func TestImportContractDirAsFile(t *testing.T) {
 	pkg := loaders.DefaultPackage(name, chainName)
 	pkg.ChainName = "temp"
 	do := definitions.NowDo()
-	do.Operations.ContainerNumber = 1
 
 	defer func() {
 		if err := os.RemoveAll(dir); err != nil {
@@ -804,7 +793,6 @@ func TestImportABIDirRel(t *testing.T) {
 	pkg := loaders.DefaultPackage(name, chainName)
 	pkg.ChainName = "temp"
 	do := definitions.NowDo()
-	do.Operations.ContainerNumber = 1
 
 	defer func() {
 		if err := os.RemoveAll(dir); err != nil {
@@ -865,7 +853,6 @@ func TestImportABIDirAbs(t *testing.T) {
 	pkg := loaders.DefaultPackage(name, chainName)
 	pkg.ChainName = "temp"
 	do := definitions.NowDo()
-	do.Operations.ContainerNumber = 1
 
 	defer func() {
 		if err := os.RemoveAll(dir); err != nil {
@@ -924,7 +911,6 @@ func TestImportABIDirAsFile(t *testing.T) {
 	pkg := loaders.DefaultPackage(name, chainName)
 	pkg.ChainName = "temp"
 	do := definitions.NowDo()
-	do.Operations.ContainerNumber = 1
 
 	defer func() {
 		if err := os.RemoveAll(dir); err != nil {
@@ -977,7 +963,6 @@ func TestExportEPMOutputsInMainDir(t *testing.T) {
 	pkg := loaders.DefaultPackage(name, chainName)
 	pkg.ChainName = "temp"
 	do := definitions.NowDo()
-	do.Operations.ContainerNumber = 1
 
 	defer func() {
 		if err := os.RemoveAll(dir); err != nil {
@@ -1033,7 +1018,6 @@ func TestExportEPMOutputsNotInMainDir(t *testing.T) {
 	pkg := loaders.DefaultPackage(name, chainName)
 	pkg.ChainName = "temp"
 	do := definitions.NowDo()
-	do.Operations.ContainerNumber = 1
 
 	defer func() {
 		if err := os.RemoveAll(dir); err != nil {
@@ -1084,7 +1068,6 @@ func TestExportEPMOutputsNotInMainDir(t *testing.T) {
 func startKeys() error {
 	doKeys := definitions.NowDo()
 	doKeys.Operations.Args = []string{"keys"}
-	doKeys.Operations.ContainerNumber = 1
 	doKeys.Rm = true
 	doKeys.RmD = true
 	if err := services.StartService(doKeys); err != nil {
@@ -1096,7 +1079,6 @@ func startKeys() error {
 func killKeys() {
 	do := definitions.NowDo()
 	do.Operations.Args = []string{"keys"}
-	do.Operations.ContainerNumber = 1
 	do.Rm = true
 	do.RmD = true
 	services.KillService(do)
@@ -1192,7 +1174,6 @@ func writeEmptyPkgJson() error {
 func exec(t *testing.T, name string, args []string) string {
 	do := definitions.NowDo()
 	do.Name = name + "_tmp_"
-	do.Operations.ContainerNumber = 1
 	do.Operations.Args = args
 	buf, err := data.ExecData(do)
 	if err != nil {

--- a/services/load.go
+++ b/services/load.go
@@ -22,7 +22,7 @@ func EnsureRunning(do *definitions.Do) error {
 		return nil
 	}
 
-	srv, err := loaders.LoadServiceDefinition(do.Name, false, do.Operations.ContainerNumber)
+	srv, err := loaders.LoadServiceDefinition(do.Name, false)
 	if err != nil {
 		return err
 	}
@@ -37,12 +37,12 @@ func EnsureRunning(do *definitions.Do) error {
 }
 
 func IsServiceExisting(service *definitions.Service, ops *definitions.Operation) bool {
-	log.WithField("=>", fmt.Sprintf("%s:%d", service.Name, ops.ContainerNumber)).Debug("Checking service existing")
+	log.WithField("=>", service.Name).Debug("Checking service existing")
 	return parseContainers(service, ops, true)
 }
 
 func IsServiceRunning(service *definitions.Service, ops *definitions.Operation) bool {
-	log.WithField("=>", fmt.Sprintf("%s:%d", service.Name, ops.ContainerNumber)).Debug("Checking service running")
+	log.WithField("=>", service.Name).Debug("Checking service running")
 	return parseContainers(service, ops, false)
 }
 
@@ -56,7 +56,7 @@ func FindServiceDefinitionFile(name string) string {
 
 func parseContainers(service *definitions.Service, ops *definitions.Operation, all bool) bool {
 	// populate service container specifics
-	cName := util.FindServiceContainer(service.Name, ops.ContainerNumber, all)
+	cName := util.FindServiceContainer(service.Name, all)
 	if cName == nil {
 		return false
 	}
@@ -65,7 +65,7 @@ func parseContainers(service *definitions.Service, ops *definitions.Operation, a
 
 	// populate data container specifics
 	if service.AutoData && ops.DataContainerID == "" {
-		dName := util.FindDataContainer(service.Name, ops.ContainerNumber)
+		dName := util.FindDataContainer(service.Name)
 		if dName != nil {
 			ops.DataContainerName = dName.FullName
 			ops.DataContainerID = dName.ContainerID

--- a/services/manage.go
+++ b/services/manage.go
@@ -38,7 +38,7 @@ func ImportService(do *definitions.Do) error {
 		return err
 	}
 
-	_, err = loaders.LoadServiceDefinition(do.Name, false, 0)
+	_, err = loaders.LoadServiceDefinition(do.Name, false)
 	//XXX add protections?
 	if err != nil {
 		return fmt.Errorf("Your service definition file looks improperly formatted and will not marshal.")
@@ -83,8 +83,8 @@ func EditService(do *definitions.Do) error {
 
 func RenameService(do *definitions.Do) error {
 	log.WithFields(log.Fields{
-		"from": fmt.Sprintf("%s:%d", do.Name, do.Operations.ContainerNumber),
-		"to":   fmt.Sprintf("%s:%d", do.NewName, do.Operations.ContainerNumber),
+		"from": do.Name,
+		"to":   do.NewName,
 	}).Info("Renaming service")
 
 	if do.Name == do.NewName {
@@ -95,17 +95,15 @@ func RenameService(do *definitions.Do) error {
 	transformOnly := newNameBase == do.Name
 
 	if parseKnown(do.Name) {
-		serviceDef, err := loaders.LoadServiceDefinition(do.Name, false, do.Operations.ContainerNumber)
+		serviceDef, err := loaders.LoadServiceDefinition(do.Name, false)
 		if err != nil {
 			return err
 		}
 
-		do.Operations.ContainerNumber = serviceDef.Operations.ContainerNumber
-
 		if !transformOnly {
 			log.WithFields(log.Fields{
-				"from": fmt.Sprintf("%s:%d", do.Name, do.Operations.ContainerNumber),
-				"to":   fmt.Sprintf("%s:%d", do.NewName, do.Operations.ContainerNumber),
+				"from": do.Name,
+				"to":   do.NewName,
 			}).Debug("Performing container rename")
 			err = perform.DockerRename(serviceDef.Operations, do.NewName)
 			if err != nil {
@@ -138,8 +136,8 @@ func RenameService(do *definitions.Do) error {
 
 		if !transformOnly {
 			log.WithFields(log.Fields{
-				"from": fmt.Sprintf("%s:%d", do.Name, do.Operations.ContainerNumber),
-				"to":   fmt.Sprintf("%s:%d", do.NewName, do.Operations.ContainerNumber),
+				"from": do.Name,
+				"to":   do.NewName,
 			}).Debug("Performing data container rename")
 			err = data.RenameData(do)
 			if err != nil {
@@ -156,7 +154,7 @@ func RenameService(do *definitions.Do) error {
 }
 
 func InspectService(do *definitions.Do) error {
-	service, err := loaders.LoadServiceDefinition(do.Name, false, do.Operations.ContainerNumber)
+	service, err := loaders.LoadServiceDefinition(do.Name, false)
 	if err != nil {
 		return err
 	}
@@ -168,7 +166,7 @@ func InspectService(do *definitions.Do) error {
 }
 
 func PortsService(do *definitions.Do) error {
-	service, err := loaders.LoadServiceDefinition(do.Name, false, do.Operations.ContainerNumber)
+	service, err := loaders.LoadServiceDefinition(do.Name, false)
 	if err != nil {
 		return err
 	}
@@ -182,7 +180,7 @@ func PortsService(do *definitions.Do) error {
 }
 
 func LogsService(do *definitions.Do) error {
-	service, err := loaders.LoadServiceDefinition(do.Name, false, do.Operations.ContainerNumber)
+	service, err := loaders.LoadServiceDefinition(do.Name, false)
 	if err != nil {
 		return err
 	}
@@ -210,7 +208,7 @@ To find known services use [eris services ls --known]`)
 }
 
 func UpdateService(do *definitions.Do) error {
-	service, err := loaders.LoadServiceDefinition(do.Name, false, do.Operations.ContainerNumber)
+	service, err := loaders.LoadServiceDefinition(do.Name, false)
 	if err != nil {
 		return err
 	}
@@ -226,7 +224,7 @@ func UpdateService(do *definitions.Do) error {
 
 func RmService(do *definitions.Do) error {
 	for _, servName := range do.Operations.Args {
-		service, err := loaders.LoadServiceDefinition(servName, false, do.Operations.ContainerNumber)
+		service, err := loaders.LoadServiceDefinition(servName, false)
 		if err != nil {
 			return err
 		}

--- a/services/operate.go
+++ b/services/operate.go
@@ -19,7 +19,7 @@ func StartService(do *definitions.Do) (err error) {
 	do.Operations.Args = append(do.Operations.Args, do.ServicesSlice...)
 	log.WithField("args", do.Operations.Args).Info("Building services group")
 	for _, srv := range do.Operations.Args {
-		s, e := BuildServicesGroup(srv, do.Operations.ContainerNumber)
+		s, e := BuildServicesGroup(srv)
 		if e != nil {
 			return e
 		}
@@ -74,7 +74,7 @@ func KillService(do *definitions.Do) (err error) {
 
 	log.WithField("args", do.Operations.Args).Info("Building services group")
 	for _, servName := range do.Operations.Args {
-		s, e := BuildServicesGroup(servName, do.Operations.ContainerNumber)
+		s, e := BuildServicesGroup(servName)
 		if e != nil {
 			return e
 		}
@@ -88,7 +88,7 @@ func KillService(do *definitions.Do) (err error) {
 
 	for _, service := range services {
 		if IsServiceRunning(service.Service, service.Operations) {
-			log.WithField("=>", fmt.Sprintf("%s:%d", service.Service.Name, service.Operations.ContainerNumber)).Debug("Stopping service")
+			log.WithField("=>", service.Service.Name).Debug("Stopping service")
 			if err := perform.DockerStop(service.Service, service.Operations, do.Timeout); err != nil {
 				return err
 			}
@@ -108,7 +108,7 @@ func KillService(do *definitions.Do) (err error) {
 }
 
 func ExecService(do *definitions.Do) (buf *bytes.Buffer, err error) {
-	service, err := loaders.LoadServiceDefinition(do.Name, false, do.Operations.ContainerNumber)
+	service, err := loaders.LoadServiceDefinition(do.Name, false)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func ExecService(do *definitions.Do) (buf *bytes.Buffer, err error) {
 	util.Merge(service.Operations, do.Operations)
 
 	// Get the main service container name, check if it's running.
-	main := util.FindServiceContainer(do.Name, do.Operations.ContainerNumber, false)
+	main := util.FindServiceContainer(do.Name, false)
 	if main != nil {
 		if service.Service.ExecHost == "" {
 			log.Info("exec_host not found in service definition file")
@@ -139,19 +139,19 @@ func ExecService(do *definitions.Do) (buf *bytes.Buffer, err error) {
 }
 
 // TODO: test this recursion and service deps generally
-func BuildServicesGroup(srvName string, cNum int, services ...*definitions.ServiceDefinition) ([]*definitions.ServiceDefinition, error) {
+func BuildServicesGroup(srvName string, services ...*definitions.ServiceDefinition) ([]*definitions.ServiceDefinition, error) {
 	log.WithFields(log.Fields{
 		"=>":        srvName,
 		"services#": len(services),
 	}).Debug("Building services group for")
-	srv, err := loaders.LoadServiceDefinition(srvName, false, cNum)
+	srv, err := loaders.LoadServiceDefinition(srvName, false)
 	if err != nil {
 		return nil, err
 	}
 	if srv.Dependencies != nil {
 		for _, sName := range srv.Dependencies.Services {
 			log.WithField("=>", sName).Debug("Found service dependency")
-			s, e := BuildServicesGroup(sName, cNum)
+			s, e := BuildServicesGroup(sName)
 			if e != nil {
 				return nil, e
 			}
@@ -210,7 +210,7 @@ func ConnectChainToService(chainFlag, chainNameAndOpts string, srv *definitions.
 			return nil, fmt.Errorf("Marmot disapproval face.\nYou tried to start a service which has a `$chain` variable but didn't give us a chain.\nPlease rerun the command either after [eris chains checkout CHAINNAME] *or* with a --chain flag.\n")
 		}
 	}
-	s, err := loaders.ChainsAsAService(chainName, false, srv.Operations.ContainerNumber)
+	s, err := loaders.ChainsAsAService(chainName, false)
 	if err != nil {
 		return nil, err
 	}

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -70,7 +70,7 @@ func TestKnownServices(t *testing.T) {
 
 func TestLoadServiceDefinition(t *testing.T) {
 	// [pv]: this test belongs to the loaders package. [csk]: agree. #496
-	srv, err := loaders.LoadServiceDefinition(servName, true, 1)
+	srv, err := loaders.LoadServiceDefinition(servName, true)
 	if err != nil {
 		t.Fatalf("expected definition to load, got %v", err)
 	}
@@ -121,7 +121,6 @@ func TestInspectService1(t *testing.T) {
 	do := def.NowDo()
 	do.Name = servName
 	do.Operations.Args = []string{"name"}
-	do.Operations.ContainerNumber = 1
 
 	if err := InspectService(do); err != nil {
 		t.Fatalf("expected service to be inspected, got %v", err)
@@ -136,7 +135,6 @@ func TestInspectService2(t *testing.T) {
 	do := def.NowDo()
 	do.Name = servName
 	do.Operations.Args = []string{"config.user"}
-	do.Operations.ContainerNumber = 1
 
 	if err := InspectService(do); err != nil {
 		t.Fatalf("expected service to be inspected, got %v", err)
@@ -490,7 +488,6 @@ func TestStartKillServiceWithDependencies(t *testing.T) {
 func start(t *testing.T, serviceName string, publishAll bool) {
 	do := def.NowDo()
 	do.Operations.Args = []string{serviceName}
-	do.Operations.ContainerNumber = 1
 	do.Operations.PublishAllPorts = publishAll
 	if err := StartService(do); err != nil {
 		t.Fatalf("expected service to start, got %v", err)

--- a/tests/testing_utils.go
+++ b/tests/testing_utils.go
@@ -67,6 +67,7 @@ func TestActionDefinitionFile(name string) bool {
 	return true
 }
 
+//TODO rm contNum
 func TestExistAndRun(name, t string, contNum int, toExist, toRun bool) error {
 	log.WithFields(log.Fields{
 		"=>":       name,
@@ -74,7 +75,7 @@ func TestExistAndRun(name, t string, contNum int, toExist, toRun bool) error {
 		"existing": toExist,
 	}).Info("Checking container")
 
-	if existing := FindContainer(name, t, contNum, false); existing != toExist {
+	if existing := FindContainer(name, t, false); existing != toExist {
 		log.WithFields(log.Fields{
 			"=>":       name,
 			"expected": toExist,
@@ -84,7 +85,7 @@ func TestExistAndRun(name, t string, contNum int, toExist, toRun bool) error {
 		return ErrContainerExistMismatch
 	}
 
-	if running := FindContainer(name, t, contNum, true); running != toRun {
+	if running := FindContainer(name, t, true); running != toRun {
 		log.WithFields(log.Fields{
 			"=>":       name,
 			"expected": toExist,
@@ -99,11 +100,11 @@ func TestExistAndRun(name, t string, contNum int, toExist, toRun bool) error {
 
 // FindContainer returns true if the container with a given
 // short name, type, number, and status exists.
-func FindContainer(name, t string, n int, running bool) bool {
+func FindContainer(name, t string, running bool) bool {
 	containers := util.ErisContainersByType(t, !running)
 
 	for _, c := range containers {
-		if c.ShortName == name && c.Number == n {
+		if c.ShortName == name {
 			return true
 		}
 	}
@@ -111,9 +112,9 @@ func FindContainer(name, t string, n int, running bool) bool {
 }
 
 // Remove a container of some name, type, and number.
-func RemoveContainer(name, t string, n int) error {
+func RemoveContainer(name, t string) error {
 	opts := docker.RemoveContainerOptions{
-		ID:            util.ContainersName(t, name, n),
+		ID:            util.ContainersName(t, name),
 		RemoveVolumes: true,
 		Force:         true,
 	}
@@ -132,8 +133,8 @@ func RemoveAllContainers() error {
 
 // Return container links. For sake of simplicity, don't expose
 // anything else.
-func Links(name, t string, n int) []string {
-	container, err := util.DockerClient.InspectContainer(util.ContainersName(t, name, n))
+func Links(name, t string) []string {
+	container, err := util.DockerClient.InspectContainer(util.ContainersName(t, name))
 	if err != nil {
 		return []string{}
 	}

--- a/util/container_info.go
+++ b/util/container_info.go
@@ -17,18 +17,18 @@ type ContainerName struct {
 	FullName    string
 	DockersName string
 	ShortName   string
-	Number      int
+	//	Number      int
 	Type        string
 	ContainerID string
 }
 
-func ContainersName(typ, name string, number int) string {
-	return ContainerAssemble(typ, name, number).FullName
+func ContainersName(typ, name string) string {
+	return ContainerAssemble(typ, name).FullName
 }
 
-func ContainersNumber(containerName string) int {
-	return ContainerDisassemble(containerName).Number
-}
+//func ContainersNumber(containerName string) int {
+//	return ContainerDisassemble(containerName).Number
+//}
 
 func ContainersType(containerName string) string {
 	return ContainerDisassemble(containerName).Type
@@ -38,15 +38,15 @@ func ContainersShortName(containerName string) string {
 	return ContainerDisassemble(containerName).ShortName
 }
 
-func ContainerAssemble(typ, name string, number int) *ContainerName {
-	full := fmt.Sprintf("eris_%s_%s_%d", typ, name, number)
+func ContainerAssemble(typ, name string) *ContainerName {
+	full := fmt.Sprintf("eris_%s_%s_1", typ, name)
 
 	return &ContainerName{
 		FullName:    full,
 		DockersName: "/" + full,
 		ShortName:   name,
 		Type:        typ,
-		Number:      number,
+		//Number:      number,
 	}
 }
 
@@ -65,7 +65,7 @@ func ContainerDisassemble(containerName string) *ContainerName {
 
 	typ := pop[1]
 	srt := strings.Join(pop[2:len(pop)-1], "_")
-	num, err := strconv.Atoi(pop[len(pop)-1])
+	_, err := strconv.Atoi(pop[len(pop)-1])
 	if err != nil {
 		log.WithField("=>", containerName).Debug("The marmots cannot disassemble container name")
 
@@ -79,21 +79,21 @@ func ContainerDisassemble(containerName string) *ContainerName {
 		FullName:    containerName,
 		DockersName: "/" + containerName,
 		Type:        typ,
-		Number:      num,
-		ShortName:   srt,
+		//Number:      num,
+		ShortName: srt,
 	}
 }
 
-func ServiceContainersName(name string, number int) string {
-	return ContainersName("service", name, number)
+func ServiceContainersName(name string) string {
+	return ContainersName("service", name)
 }
 
-func ChainContainersName(name string, number int) string {
-	return ContainersName("chain", name, number)
+func ChainContainersName(name string) string {
+	return ContainersName("chain", name)
 }
 
-func DataContainersName(name string, number int) string {
-	return ContainersName("data", name, number)
+func DataContainersName(name string) string {
+	return ContainersName("data", name)
 }
 
 func ServiceToDataContainer(serviceContainerName string) string {
@@ -235,62 +235,62 @@ func DataContainerFullNames() []string {
 	return b
 }
 
-func FindServiceContainer(srvName string, number int, running bool) *ContainerName {
+func FindServiceContainer(srvName string, running bool) *ContainerName {
 	for _, srv := range ServiceContainers(running) {
 		if srv.ShortName == srvName {
-			if srv.Number == number {
-				log.WithField("match", fmt.Sprintf("%s:%d", srv.ShortName, srv.Number)).Debug("Found service container")
-				return srv
-			}
+			//if srv.Number == number {
+			//log.WithField("match", fmt.Sprintf("%s:%d", srv.ShortName, srv.Number)).Debug("Found service container")
+			return srv
+			//}
 		}
 	}
-	log.WithField("=>", fmt.Sprintf("%s:%d", srvName, number)).Info("Could not find service container")
+	log.WithField("=>", srvName).Info("Could not find service container")
 	return nil
 }
 
 // TODO: populate the ContainerID during this portion of the general sequence
-func IsServiceContainer(name string, number int, running bool) bool {
-	if FindServiceContainer(name, number, running) == nil {
+func IsServiceContainer(name string, running bool) bool {
+	if FindServiceContainer(name, running) == nil {
 		return false
 	}
 	return true
 }
 
-func FindChainContainer(name string, number int, running bool) *ContainerName {
+func FindChainContainer(name string, running bool) *ContainerName {
 	for _, srv := range ChainContainers(running) {
 		if srv.ShortName == name {
-			if srv.Number == number {
-				log.WithField("match", fmt.Sprintf("%s:%d", srv.ShortName, srv.Number)).Debug("Found chain container")
-				return srv
-			}
+			//if srv.Number == number {
+			//log.WithField("match", fmt.Sprintf("%s:%d", srv.ShortName, srv.Number)).Debug("Found chain container")
+			return srv
+			//}
 		}
 	}
-	log.WithField("=>", fmt.Sprintf("%s:%d", name, number)).Info("Could not find chain container")
+	log.WithField("=>", name).Info("Could not find chain container")
 	return nil
 }
 
-func IsChainContainer(name string, number int, running bool) bool {
-	if FindChainContainer(name, number, running) == nil {
+func IsChainContainer(name string, running bool) bool {
+	if FindChainContainer(name, running) == nil {
 		return false
 	}
 	return true
 }
 
-func FindDataContainer(name string, number int) *ContainerName {
+func FindDataContainer(name string) *ContainerName {
 	for _, srv := range DataContainers() {
 		if srv.ShortName == name {
-			if srv.Number == number {
-				log.WithField("match", fmt.Sprintf("%s:%d", srv.ShortName, srv.Number)).Debug("Found data container")
-				return srv
-			}
+			//if srv.Number == number {
+			//log.WithField("match", fmt.Sprintf("%s:%d", srv.ShortName, srv.Number)).Debug("Found data container")
+			return srv
+			//}
 		}
 	}
-	log.WithField("=>", fmt.Sprintf("%s:%d", name, number)).Info("Could not find data container")
+	log.WithField("=>", name).Info("Could not find data container")
 	return nil
 }
 
-func IsDataContainer(name string, number int) bool {
-	if FindDataContainer(name, number) == nil {
+func IsDataContainer(name string) bool {
+	if FindDataContainer(name) == nil {
 		return false
 	}
 	return true
@@ -312,9 +312,9 @@ func erisRegExpLinks(typ string) *regexp.Regexp {
 }
 
 // here temporarily
-func NameAndNumber(name string, num int) string {
-	return fmt.Sprintf("%s_%d", name, num)
-}
+//func NameAndNumber(name string, num int) string {
+//	return fmt.Sprintf("%s_%d", name, num)
+//}
 
 func PortAndProtocol(port string) docker.Port {
 	if len(strings.Split(port, "/")) == 1 {

--- a/util/container_info_test.go
+++ b/util/container_info_test.go
@@ -8,14 +8,12 @@ var testsGood = []struct {
 	input string
 	typ   string
 	name  string
-	num   int
 }{
-	{"eris_service_mint_1", "service", "mint", 1},
-	{"eris_service_mint_10", "service", "mint", 10},
-	{"eris_service_mint_love_10", "service", "mint_love", 10},
-	{"eris_service_mint_loves_life_5", "service", "mint_loves_life", 5},
-	{"eris_data_mint_1", "data", "mint", 1},
-	{"eris_chain_mint_100", "chain", "mint", 100},
+	{"eris_service_mint_1", "service", "mint"},
+	{"eris_service_mint_love_1", "service", "mint_love"},
+	{"eris_service_mint_loves_life_1", "service", "mint_loves_life"},
+	{"eris_data_mint_1", "data", "mint"},
+	{"eris_chain_mint_1", "chain", "mint"},
 }
 
 var testsBad = []string{
@@ -37,11 +35,8 @@ func TestContainerNameGood(t *testing.T) {
 		if c.Type != rt.typ {
 			t.Fatalf("Wrong type from %s. Got %s, expected %s", rt.input, c.Type, rt.typ)
 		}
-		if c.Number != rt.num {
-			t.Fatalf("Wrong number from %s. Got %s, expected %s", rt.input, c.Number, rt.num)
-		}
 
-		d := ContainerAssemble(rt.typ, rt.name, rt.num)
+		d := ContainerAssemble(rt.typ, rt.name)
 
 		if d.FullName != rt.input {
 			t.Fatalf("Wrong full name from %s. Got %s, expected %s", rt.input, d.FullName, rt.input)

--- a/util/container_labels.go
+++ b/util/container_labels.go
@@ -1,8 +1,6 @@
 package util
 
 import (
-	"fmt"
-
 	"github.com/eris-ltd/eris-cli/config"
 	def "github.com/eris-ltd/eris-cli/definitions"
 )
@@ -11,7 +9,6 @@ import (
 // short name and ops settings.
 //
 //  ops.SrvContainerName  - container name
-//  ops.ContainerNumber   - container number
 //  ops.ContainerType     - container type
 //
 func Labels(name string, ops *def.Operation) map[string]string {
@@ -23,7 +20,7 @@ func Labels(name string, ops *def.Operation) map[string]string {
 	labels[def.Namespace+":"+def.LabelEris] = "true"
 	labels[def.Namespace+":"+def.LabelShortName] = name
 	labels[def.Namespace+":"+def.LabelType] = ops.ContainerType
-	labels[def.Namespace+":"+def.LabelNumber] = fmt.Sprintf("%v", ops.ContainerNumber)
+	labels[def.Namespace+":"+def.LabelNumber] = "1"
 
 	if user, _, err := config.GitConfigUser(); err == nil {
 		labels[def.Namespace+":"+def.LabelUser] = user

--- a/util/container_operations.go
+++ b/util/container_operations.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"strings"
 
-	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	dirs "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 )
 
@@ -82,40 +81,6 @@ func Merge(base, over interface{}) error {
 		}
 	}
 	return nil
-}
-
-// AutoMagic will return the highest container number which would represent the most recent
-// container to work on unless newCont == true in which case it would return the highest
-// container number plus one.
-func AutoMagic(cNum int, typ string, newCont bool) int {
-	log.WithField("automagic", cNum).Debug()
-	contns := ErisContainersByType(typ, true)
-
-	contnums := make([]int, len(contns))
-	for i, c := range contns {
-		contnums[i] = c.Number
-	}
-
-	// get highest container number
-	g := 0
-	for _, n := range contnums {
-		if n >= g {
-			g = n
-		}
-	}
-
-	// ensure outcomes appropriate
-	result := g
-	if newCont {
-		result = g + 1
-	}
-	if result == 0 {
-		result = 1
-	}
-
-	log.WithField("automagic", result).Debug()
-
-	return result
 }
 
 // Parse dependencies for internalName (ie. in /etc/hosts), whether to link, and whether to mount volumes-from


### PR DESCRIPTION
- cleans up a tons of un-used code
- `do.Operations.ContainerNumber` is gone
- plenty of functions that took ^ as an argument (or some variation of it), no longer do
- a couple `perform` tests removed due to obfuscation
- closes #531 
