### PR TITLE
`ExecHandler` = > wrapper for `ExecService`

### DIFF
--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -100,14 +100,10 @@ func TestExportKeySingle(t *testing.T) {
 
 	address := testsGenAKey()
 
-	do := def.NowDo()
-	do.Name = "keys"
-	do.Operations.Interactive = false
 	keyPath := path.Join(ErisContainerRoot, "keys", "data", address, address)
 
 	//cat container contents of new key
-	do.Operations.Args = []string{"cat", keyPath}
-	catOut, err := srv.ExecService(do)
+	catOut, err := srv.ExecHandler("keys", []string{"cat", keyPath})
 	if err != nil {
 		fatal(t, err)
 	}
@@ -158,13 +154,9 @@ func TestImportKeySingle(t *testing.T) {
 	keyOnHost := util.TrimString(string(key))
 
 	//rm key that was generated before import
-	doRm := def.NowDo()
-	doRm.Name = "keys"
-	doRm.Operations.Interactive = false
 	keyPath := path.Join(ErisContainerRoot, "keys", "data", address)
 
-	doRm.Operations.Args = []string{"rm", "-rf", keyPath}
-	if _, err := srv.ExecService(doRm); err != nil {
+	if _, err := srv.ExecHandler("keys", []string{"rm", "-rf", keyPath}); err != nil {
 		fatal(t, err)
 	}
 
@@ -177,14 +169,10 @@ func TestImportKeySingle(t *testing.T) {
 		fatal(t, err)
 	}
 
-	doCat := def.NowDo()
-	doCat.Name = "keys"
-	doCat.Operations.Interactive = false
 	keyPathCat := path.Join(ErisContainerRoot, "keys", "data", address, address)
 
 	//cat container contents of new key
-	doCat.Operations.Args = []string{"cat", keyPathCat}
-	catOut, err := srv.ExecService(doCat)
+	catOut, err := srv.ExecHandler("keys", []string{"cat", keyPathCat})
 	if err != nil {
 		fatal(t, err)
 	}

--- a/keys/readers.go
+++ b/keys/readers.go
@@ -42,10 +42,7 @@ func ListKeys(do *definitions.Do) error {
 			return err
 		}
 
-		do.Operations.Interactive = false
-		do.Operations.Args = []string{"ls", "/home/eris/.eris/keys/data"}
-
-		keysOut, err := srv.ExecService(do)
+		keysOut, err := srv.ExecHandler(do.Name, []string{"ls", "/home/eris/.eris/keys/data"})
 		if err != nil {
 			return err
 		}

--- a/keys/writers.go
+++ b/keys/writers.go
@@ -19,10 +19,8 @@ func GenerateKey(do *definitions.Do) error {
 	if err := srv.EnsureRunning(do); err != nil {
 		return err
 	}
-	do.Operations.Interactive = false
-	do.Operations.Args = []string{"eris-keys", "gen", "--no-pass"}
 
-	buf, err := srv.ExecService(do)
+	buf, err := srv.ExecHandler(do.Name, []string{"eris-keys", "gen", "--no-pass"})
 	if err != nil {
 		return err
 	}
@@ -33,16 +31,12 @@ func GenerateKey(do *definitions.Do) error {
 }
 
 func GetPubKey(do *definitions.Do) error {
-
 	do.Name = "keys"
 	if err := srv.EnsureRunning(do); err != nil {
 		return err
 	}
 
-	do.Operations.Interactive = false
-	do.Operations.Args = []string{"eris-keys", "pub", "--addr", do.Address}
-
-	buf, err := srv.ExecService(do)
+	buf, err := srv.ExecHandler(do.Name, []string{"eris-keys", "pub", "--addr", do.Address})
 	if err != nil {
 		return err
 	}
@@ -53,15 +47,10 @@ func GetPubKey(do *definitions.Do) error {
 }
 
 func ExportKey(do *definitions.Do) error {
-
 	do.Name = "keys"
 	if err := srv.EnsureRunning(do); err != nil {
 		return err
 	}
-	//destination on host -> given as flag default
-	//if do.Destination == "" {
-	//	do.Destination = filepath.Join(KeysPath, "data")
-	//}
 
 	//src in container
 	do.Source = path.Join(ErisContainerRoot, "keys", "data", do.Address)
@@ -72,16 +61,13 @@ func ExportKey(do *definitions.Do) error {
 }
 
 func ImportKey(do *definitions.Do) error {
-
 	do.Name = "keys"
 	if err := srv.EnsureRunning(do); err != nil {
 		return err
 	}
 
-	do.Operations.Interactive = false
 	dir := path.Join(ErisContainerRoot, "keys", "data", do.Address)
-	do.Operations.Args = []string{"mkdir", dir} //need to mkdir for import
-	buf, err := srv.ExecService(do)
+	buf, err := srv.ExecHandler(do.Name, []string{"mkdir", dir}) //need to mkdir for import TODO (#501)
 	if err != nil {
 		return err
 	}
@@ -103,14 +89,12 @@ func ImportKey(do *definitions.Do) error {
 }
 
 func ConvertKey(do *definitions.Do) error {
-
 	do.Name = "keys"
 	if err := srv.EnsureRunning(do); err != nil {
 		return err
 	}
 
-	do.Operations.Args = []string{"mintkey", "mint", do.Address}
-	buf, err := srv.ExecService(do)
+	buf, err := srv.ExecHandler(do.Name, []string{"mintkey", "mint", do.Address})
 	if err != nil {
 		return err
 	}

--- a/services/operate.go
+++ b/services/operate.go
@@ -138,6 +138,17 @@ func ExecService(do *definitions.Do) (buf *bytes.Buffer, err error) {
 	return perform.DockerExecService(service.Service, service.Operations)
 }
 
+// ExecHandler implemements ExecService for use within
+// the cli for under the hood functionality
+// (wrapping) calls to respective containers
+func ExecHandler(srvName string, args []string) (buf *bytes.Buffer, err error) {
+	do := definitions.NowDo()
+	do.Name = srvName
+	do.Operations.Interactive = false
+	do.Operations.Args = args
+	return ExecService(do)
+}
+
 // TODO: test this recursion and service deps generally
 func BuildServicesGroup(srvName string, services ...*definitions.ServiceDefinition) ([]*definitions.ServiceDefinition, error) {
 	log.WithFields(log.Fields{


### PR DESCRIPTION
- used for under the hood commands that exec upon a service (e.g., `keys` and soon `files`)
- closes #517 