### PR TITLE
chains new; overwrite scratch dir by default

### DIFF
--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -285,7 +285,9 @@ func TestCatChainContainerGenesis(t *testing.T) {
 	}
 }
 
-func TestChainsNewDirGenCustomFile(t *testing.T) {
+// XXX this functionality has been abolished
+// see commented out flags in cmd/chains.go
+func _TestChainsNewDirGenCustomFile(t *testing.T) {
 	defer tests.RemoveAllContainers()
 
 	const (

--- a/chains/operate.go
+++ b/chains/operate.go
@@ -25,17 +25,12 @@ import (
 )
 
 func NewChain(do *definitions.Do) error {
-	//overwrites directory if --force
 	dir := filepath.Join(DataContainersPath, do.Name)
-	if _, err := os.Stat(dir); err == nil {
+	if util.DoesDirExist(dir) {
 		log.WithField("dir", dir).Debug("Chain data already exists in")
-		if do.Force {
-			log.Debug("Overwriting with new data")
-			if os.RemoveAll(dir); err != nil {
-				return err
-			}
-		} else {
-			log.Debug("Using existing data; `--force` flag not given")
+		log.Debug("Overwriting with new data")
+		if err := os.RemoveAll(dir); err != nil {
+			return err
 		}
 	}
 

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -415,7 +415,6 @@ func addChainsFlags() {
 	buildFlag(chainsNew, do, "publish", "chain")
 	buildFlag(chainsNew, do, "links", "chain")
 	buildFlag(chainsNew, do, "api", "chain")
-	chainsNew.PersistentFlags().BoolVarP(&do.Force, "force", "f", true, "overwrite data in  ~/.eris/data/chainName")
 	chainsNew.PersistentFlags().BoolVarP(&do.Logsrotate, "logsrotate", "z", false, "turn on logsrotate as a dependency to handle long output")
 
 	// buildFlag(chainsRegister, do, "links", "chain")


### PR DESCRIPTION
- prevents bad things from happening when new-ing (then removing) chains of the same name
- closes #540 