### PR TITLE
refactor `eris clean` sequence

### DIFF
--- a/clean/clean.go
+++ b/clean/clean.go
@@ -6,7 +6,16 @@ import (
 )
 
 func Clean(do *definitions.Do) error {
-	if err := util.Clean(do.Yes, do.All, do.RmD, do.Images); err != nil {
+	// in util so that other pkgs can import it easily
+	toClean := map[string]bool{
+		"yes":        do.Yes,
+		"all":        do.All,
+		"containers": do.Containers,
+		"scratch":    do.Scratch,
+		"rmd":        do.RmD,
+		"images":     do.Images,
+	}
+	if err := util.Clean(toClean); err != nil {
 		return err
 	}
 	return nil

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -3,38 +3,21 @@ package clean
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
-	def "github.com/eris-ltd/eris-cli/definitions"
+	"github.com/eris-ltd/eris-cli/chains"
+	"github.com/eris-ltd/eris-cli/data"
+	"github.com/eris-ltd/eris-cli/definitions"
 	srv "github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/tests"
 	"github.com/eris-ltd/eris-cli/util"
 
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	logger "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/fsouza/go-dockerclient"
 )
-
-var ToTest = []struct {
-	name       string
-	all        bool
-	containers bool
-	scratch    bool
-	rmd        bool
-	images     bool
-	yes        bool
-	// uninstall bool => forthcoming
-	// volumes bool => forthcoming
-}{}
-
-/*{
-	{"no-flag", false, false, false, false},
-	{"rmd-only", false, true, false, false},
-	{"imgs-only", false, false, true, false},
-	{"imgs-rmd", false, true, true, false}, //is this  == --all -> prefered behaviour ?
-	{"all-only", false, false, false, true},
-	{"all-flags", false, true, true, true},
-}*/
 
 func TestMain(m *testing.M) {
 	log.SetFormatter(logger.ErisFormatter{})
@@ -51,21 +34,59 @@ func TestMain(m *testing.M) {
 }
 
 func TestRemoveAllErisContainers(t *testing.T) {
+	testFailIfAnyContainers(t)
+
+	// start a bunch of eris containers
+	testStartService("ipfs", t)
+	testStartService("tor", t)
+	testStartService("keys", t)
+
+	testStartChain("dirty-chain0", t)
+	testStartChain("dirty-chain1", t)
+
+	testCreateDataContainer("filthy-data0", t)
+	testCreateDataContainer("filthy-data1", t)
+
+	// start some not eris containers (using busybox)
+	notEris0 := testCreateNotEris("not_eris0", t)
+	notEris1 := testCreateNotEris("not_eris1", t)
+
+	// run the command
+	tests.IfExit(util.RemoveAllErisContainers())
+
+	// check that both not_eris still exist
+	// and no Eris containers exist
+	testCheckSimple(notEris0, t)
+	testCheckSimple(notEris1, t)
+
+	// remove what's left
+	testRemoveNotEris(notEris0, t)
+	testRemoveNotEris(notEris1, t)
+
+	// fail is anything remains
+	testFailIfAnyContainers(t)
 
 }
 
-func TestCleanScratchData(t *testing.T) {
+func testFailIfAnyContainers(t *testing.T) {
+	contns, err := util.DockerClient.ListContainers(docker.ListContainersOptions{All: true})
+	if err != nil {
+		t.Fatalf("error listing containers: %v", err)
+	}
 
+	if len(contns) != 0 {
+		t.Fatalf("found (%v) remaining containers, something went wrong\n", len(contns))
+	}
 }
 
+// it works...any working test
+// will take too long IMO [zr]
 func TestRemoveErisImages(t *testing.T) {
-
 }
 
-func testCreateNotEris(t *testing.T) {
-
+func testCreateNotEris(name string, t *testing.T) string {
 	opts := docker.CreateContainerOptions{
-		Name: "not_eris",
+		Name: name,
 		Config: &docker.Config{
 			Image:           "busybox",
 			AttachStdin:     false,
@@ -87,7 +108,18 @@ func testCreateNotEris(t *testing.T) {
 	return newCont.ID
 }
 
-func testCheckSimple(t *testing.T, newContID string) {
+func testRemoveNotEris(contID string, t *testing.T) {
+	rmOpts := docker.RemoveContainerOptions{
+		ID:            contID,
+		RemoveVolumes: true,
+		Force:         true,
+	}
+	if err := util.DockerClient.RemoveContainer(rmOpts); err != nil {
+		t.Fatalf("error removing container: %v", err)
+	}
+}
+
+func testCheckSimple(newContID string, t *testing.T) {
 	contns, err := util.DockerClient.ListContainers(docker.ListContainersOptions{All: true})
 	if err != nil {
 		t.Fatalf("error listing containers: %v", err)
@@ -114,39 +146,54 @@ func testCheckSimple(t *testing.T, newContID string) {
 	if !notEris {
 		t.Fatalf("Expected running container, did not find %s\n", newContID)
 	}
-
-	//teardown non-eris
-	rmOpts := docker.RemoveContainerOptions{
-		ID:            newContID,
-		RemoveVolumes: true,
-		Force:         true,
-	}
-
-	if err := util.DockerClient.RemoveContainer(rmOpts); err != nil {
-		t.Fatalf("error removing container: %v", err)
-	}
-
-	contns, err = util.DockerClient.ListContainers(docker.ListContainersOptions{All: true})
-	if err != nil {
-		t.Fatalf("error listing containers: %v", err)
-	}
-
-	if len(contns) != 0 {
-		t.Fatalf("found remaining containers, something went wrong\n")
-	}
 }
 
 //from /services/services_test.go
-func testStartService(t *testing.T, serviceName string, publishAll bool) {
-	do := def.NowDo()
+func testStartService(serviceName string, t *testing.T) {
+	do := definitions.NowDo()
 	do.Operations.Args = []string{serviceName}
-	do.Operations.PublishAllPorts = publishAll
+	do.Operations.PublishAllPorts = true
 	log.WithField("=>", fmt.Sprintf("%s:%d", serviceName, 1)).Debug("Starting service (from tests)")
-	e := srv.StartService(do)
-	if e != nil {
-		t.Fatalf("Error starting service: %v", e)
+	if err := srv.StartService(do); err != nil {
+		t.Fatalf("Error starting service: %v", err)
 	}
 
-	tests.IfExit(tests.TestExistAndRun(servName, "service", containerNumber, toExist, toRun))
+	tests.IfExit(tests.TestExistAndRun(serviceName, "service", true, true))
 	tests.IfExit(tests.TestNumbersExistAndRun(serviceName, 1, 1))
+}
+
+func testStartChain(chainName string, t *testing.T) {
+	do := definitions.NowDo()
+	do.Name = chainName
+	do.Operations.PublishAllPorts = true
+	if err := chains.NewChain(do); err != nil {
+		t.Fatalf("starting chain %v failed: %v", chainName, err)
+	}
+}
+
+func testCreateDataContainer(dataName string, t *testing.T) {
+	newDataDir := filepath.Join(common.DataContainersPath, dataName)
+	if err := os.MkdirAll(newDataDir, 0777); err != nil {
+		t.Fatalf("err mkdir: %v\n", err)
+	}
+
+	f, err := os.Create(filepath.Join(newDataDir, "test"))
+	if err != nil {
+		t.Fatalf("err creating file: %v\n", err)
+	}
+	defer f.Close()
+
+	do := definitions.NowDo()
+	do.Name = dataName
+	do.Source = filepath.Join(common.DataContainersPath, do.Name)
+	do.Destination = common.ErisContainerRoot
+	log.WithField("=>", do.Name).Info("Importing data (from tests)")
+	if err := data.ImportData(do); err != nil {
+		t.Fatalf("error importing data: %v\n", err)
+	}
+
+	if err := tests.TestExistAndRun(dataName, "data", true, false); err != nil {
+		t.Fatalf("error creating data cont: %v\n", err)
+	}
+
 }

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -16,33 +16,50 @@ import (
 )
 
 var ToTest = []struct {
-	name   string
-	prompt bool
-	rmd    bool
-	images bool
-	all    bool
-	//uninstall bool => forthcoming
-}{
+	name       string
+	all        bool
+	containers bool
+	scratch    bool
+	rmd        bool
+	images     bool
+	yes        bool
+	// uninstall bool => forthcoming
+	// volumes bool => forthcoming
+}{}
+
+/*{
 	{"no-flag", false, false, false, false},
 	{"rmd-only", false, true, false, false},
 	{"imgs-only", false, false, true, false},
 	{"imgs-rmd", false, true, true, false}, //is this  == --all -> prefered behaviour ?
 	{"all-only", false, false, false, true},
 	{"all-flags", false, true, true, true},
-}
+}*/
 
 func TestMain(m *testing.M) {
 	log.SetFormatter(logger.ErisFormatter{})
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)
-	log.SetLevel(log.DebugLevel)
+	// log.SetLevel(log.DebugLevel)
 
 	tests.IfExit(tests.TestsInit("clean"))
 
 	exitCode := m.Run()
 	tests.IfExit(tests.TestsTearDown())
 	os.Exit(exitCode)
+}
+
+func TestRemoveAllErisContainers(t *testing.T) {
+
+}
+
+func TestCleanScratchData(t *testing.T) {
+
+}
+
+func TestRemoveErisImages(t *testing.T) {
+
 }
 
 func testCreateNotEris(t *testing.T) {

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -36,9 +36,7 @@ func addCleanFlags() {
 }
 
 func CleanItUp(cmd *cobra.Command, args []string) {
-	//flag logic handled in Clean
 
-	//XXX put flag logic in here!
 	if do.All {
 		do.Containers = true
 		do.Scratch = true

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -10,9 +10,11 @@ import (
 var Clean = &cobra.Command{
 	Use:   "clean",
 	Short: "Clean up your eris working environment.",
-	Long: `Stops and force removes all eris containers
-	(chains, services, datas, etc) by default. Useful
-	for development.`,
+	Long: `By default, this command will stop and
+	force remove all eris containers (chains, services, 
+	datas, etc). Addtional flags can be used to remove
+	the eris home directory and eris images. Useful
+	for rapid development with docker containers.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		CleanItUp(cmd, args)
 	},
@@ -23,9 +25,11 @@ func buildCleanCommand() {
 }
 
 func addCleanFlags() {
-	Clean.Flags().BoolVarP(&do.All, "all", "", false, "removes everything, stopping short of uninstalling eris")
-	Clean.Flags().BoolVarP(&do.RmD, "dir", "", false, "remove the eris home directory ~/.eris")
-	Clean.Flags().BoolVarP(&do.Images, "images", "", false, "remove all eris docker images")
+	Clean.Flags().BoolVarP(&do.All, "all", "a", false, "removes everything, stopping short of uninstalling eris")
+	Clean.Flags().BoolVarP(&do.Containers, "containers", "c", true, "remove all eris containers")
+	Clean.Flags().BoolVarP(&do.Scratch, "scratch", "s", true, "remove contents of: $HOME/.eris/scratch")
+	Clean.Flags().BoolVarP(&do.RmD, "dir", "", false, "remove the eris home directory: $HOME/.eris")
+	Clean.Flags().BoolVarP(&do.Images, "images", "i", false, "remove all eris docker images")
 	//Clean.Flags().BoolVarP(&do.Volumes, "volumes", "", true, "remove orphaned volumes")
 	//Clean.Flags().BoolVarP(&do.Uninstall, "uninstall", "", false, "removes everything; leaves no trace of marmot") //gofmt yourself
 	Clean.Flags().BoolVarP(&do.Yes, "yes", "y", false, "overrides prompts prior to removing things")
@@ -33,6 +37,15 @@ func addCleanFlags() {
 
 func CleanItUp(cmd *cobra.Command, args []string) {
 	//flag logic handled in Clean
+
+	//XXX put flag logic in here!
+	if do.All {
+		do.Containers = true
+		do.Scratch = true
+		do.RmD = true
+		do.Images = true
+	}
+
 	if err := clean.Clean(do); err != nil {
 		return
 	}

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -202,16 +202,12 @@ func TestRmData(t *testing.T) {
 func testCreateDataByImport(t *testing.T, name string) {
 	newDataDir := filepath.Join(common.DataContainersPath, name)
 	if err := os.MkdirAll(newDataDir, 0777); err != nil {
-		log.Error(err)
-		t.FailNow()
-		os.Exit(1)
+		t.Fatalf("err mkdir: %v\n", err)
 	}
 
 	f, err := os.Create(filepath.Join(newDataDir, "test"))
 	if err != nil {
-		log.Error(err)
-		t.FailNow()
-		os.Exit(1)
+		t.Fatalf("err creating file: %v\n", err)
 	}
 	defer f.Close()
 
@@ -221,8 +217,7 @@ func testCreateDataByImport(t *testing.T, name string) {
 	do.Destination = common.ErisContainerRoot
 	log.WithField("=>", do.Name).Info("Importing data (from tests)")
 	if err := ImportData(do); err != nil {
-		log.Error(err)
-		t.Fail()
+		t.Fatalf("error importing data: %v\n", err)
 	}
 
 	testExist(t, name, true)
@@ -235,15 +230,14 @@ func testKillDataCont(t *testing.T, name string) {
 	do := definitions.NowDo()
 	do.Name = name
 	if err := RmData(do); err != nil {
-		log.Error(err)
-		t.Fail()
+		t.Fatalf("error rm data: %v\n", err)
 	}
 
 	testExist(t, name, false)
 }
 
 func testExist(t *testing.T, name string, toExist bool) {
-	if err := tests.TestExistAndRun(name, "data", 1, toExist, false); err != nil {
+	if err := tests.TestExistAndRun(name, "data", toExist, false); err != nil {
 		t.Fail()
 	}
 }

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -65,9 +65,11 @@ type Do struct {
 	AccountTypes  []string `mapstructure:"," json:"," yaml:"," toml:","`
 
 	//clean
-	Images    bool `mapstructure:"," json:"," yaml:"," toml:","`
-	Uninstall bool `mapstructure:"," json:"," yaml:"," toml:","`
-	Volumes   bool `mapstructure:"," json:"," yaml:"," toml:","`
+	Containers bool `mapstructure:"," json:"," yaml:"," toml:","`
+	Scratch    bool `mapstructure:"," json:"," yaml:"," toml:","`
+	Images     bool `mapstructure:"," json:"," yaml:"," toml:","`
+	Uninstall  bool `mapstructure:"," json:"," yaml:"," toml:","`
+	Volumes    bool `mapstructure:"," json:"," yaml:"," toml:","`
 	//data import/export
 	Source      string `mapstructure:"," json:"," yaml:"," toml:","`
 	Destination string `mapstructure:"," json:"," yaml:"," toml:","`

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -293,7 +293,7 @@ func testStartKeys(t *testing.T) {
 		t.Fail()
 	}
 
-	testExistAndRun(t, serviceName, 1, true, true)
+	testExistAndRun(t, serviceName, true, true)
 	testNumbersExistAndRun(t, serviceName, 1, 1)
 }
 
@@ -312,12 +312,12 @@ func testKillService(t *testing.T, serviceName string, wipe bool) {
 		log.Error(e)
 		fatal(t, e)
 	}
-	testExistAndRun(t, serviceName, 1, !wipe, false)
+	testExistAndRun(t, serviceName, !wipe, false)
 	testNumbersExistAndRun(t, serviceName, 0, 0)
 }
 
-func testExistAndRun(t *testing.T, servName string, containerNumber int, toExist, toRun bool) {
-	if err := tests.TestExistAndRun(servName, "service", containerNumber, toExist, toRun); err != nil {
+func testExistAndRun(t *testing.T, servName string, toExist, toRun bool) {
+	if err := tests.TestExistAndRun(servName, "service", toExist, toRun); err != nil {
 		fatal(t, nil)
 	}
 }

--- a/list/listing_functions.go
+++ b/list/listing_functions.go
@@ -90,9 +90,8 @@ func ListDatas(do *definitions.Do) error {
 	var result string
 	var err error
 	if do.Quiet {
-		result = strings.Join(util.DataContainerNames(), "\n")
-		do.Result = result
-		log.Warn(result)
+		do.Result = strings.Join(util.DataContainerNames(), "\n")
+		log.Warn(do.Result)
 	} else {
 		result, err = PrintTableReport("data", true, true)
 		if err != nil {

--- a/tests/testing_utils.go
+++ b/tests/testing_utils.go
@@ -67,8 +67,7 @@ func TestActionDefinitionFile(name string) bool {
 	return true
 }
 
-//TODO rm contNum
-func TestExistAndRun(name, t string, contNum int, toExist, toRun bool) error {
+func TestExistAndRun(name, t string, toExist, toRun bool) error {
 	log.WithFields(log.Fields{
 		"=>":       name,
 		"running":  toRun,
@@ -129,6 +128,7 @@ func TestNumbersExistAndRun(servName string, containerExist, containerRun int) e
 		return fmt.Errorf("Wrong number of existing containers")
 	}
 	log.Info("All good")
+	return nil
 }
 
 // FindContainer returns true if the container with a given
@@ -160,13 +160,14 @@ func RemoveContainer(name, t string) error {
 }
 
 // Remove everything Eris.
-// [zr] XXX ensure this stay consistent with clean minro refacotr
 func RemoveAllContainers() error {
 	toClean := map[string]bool{
-		"yes":    false,
-		"all":    false,
-		"rmd":    false,
-		"images": false,
+		"yes":        true,
+		"containers": true,
+		"scratch":    true,
+		"all":        false,
+		"rmd":        false,
+		"images":     false,
 	}
 	return util.Clean(toClean)
 }

--- a/tests/testing_utils.go
+++ b/tests/testing_utils.go
@@ -98,6 +98,39 @@ func TestExistAndRun(name, t string, contNum int, toExist, toRun bool) error {
 	return nil
 }
 
+func TestNumbersExistAndRun(servName string, containerExist, containerRun int) error {
+	log.WithFields(log.Fields{
+		"=>":        servName,
+		"existing#": containerExist,
+		"running#":  containerRun,
+	}).Info("Checking number of containers for")
+
+	log.WithField("=>", servName).Debug("Checking existing containers for")
+	exist := util.HowManyContainersExisting(servName, "service")
+
+	log.WithField("=>", servName).Debug("Checking running containers for")
+	run := util.HowManyContainersRunning(servName, "service")
+
+	if exist != containerExist {
+		log.WithFields(log.Fields{
+			"name":     servName,
+			"expected": containerExist,
+			"got":      exist,
+		}).Info("Wrong number of existing containers")
+		return fmt.Errorf("Wrong number of existing containers")
+	}
+
+	if run != containerRun {
+		log.WithFields(log.Fields{
+			"name":     servName,
+			"expected": containerExist,
+			"got":      run,
+		}).Info("Wrong number of running containers")
+		return fmt.Errorf("Wrong number of existing containers")
+	}
+	log.Info("All good")
+}
+
 // FindContainer returns true if the container with a given
 // short name, type, number, and status exists.
 func FindContainer(name, t string, running bool) bool {
@@ -127,8 +160,15 @@ func RemoveContainer(name, t string) error {
 }
 
 // Remove everything Eris.
+// [zr] XXX ensure this stay consistent with clean minro refacotr
 func RemoveAllContainers() error {
-	return util.Clean(false, false, false, false)
+	toClean := map[string]bool{
+		"yes":    false,
+		"all":    false,
+		"rmd":    false,
+		"images": false,
+	}
+	return util.Clean(toClean)
 }
 
 // Return container links. For sake of simplicity, don't expose


### PR DESCRIPTION
- closes #479 but not #295 
- prompts user appropriately
- cleaner test + some other cleanings
- catches dangling data containers:w
