### PR TITLE
Fix `eris chains cat ... genesis` command with non-existent chains

### DIFF
--- a/chains/manage.go
+++ b/chains/manage.go
@@ -314,7 +314,9 @@ func CatChain(do *definitions.Do) error {
 
 	buf, err := ExecChain(do)
 
-	io.Copy(config.GlobalConfig.Writer, buf)
+	if buf != nil {
+		io.Copy(config.GlobalConfig.Writer, buf)
+	}
 
 	return err
 }


### PR DESCRIPTION
This PR fixes a panic when executing an `eris chains cat` command on a non-existent container.

```
$ eris chains cat nonexistent genesis
Cannot start a chain I cannot find
(no panic)
```