### PR TITLE
ipfs object/directory support for files

### DIFF
--- a/cmd/data.go
+++ b/cmd/data.go
@@ -59,7 +59,11 @@ var dataImport = &cobra.Command{
 	Short: "Import from a host folder to a named data container's directory",
 	Long: `Import from a host folder to a named data container's directory.
 Requires src and dest for each host and container, respectively.
-Container path enters at /home/eris/.eris and destination dir must exist.`,
+Container path enters at /home/eris/.eris and destination directory
+will be created in container if it does not exist.
+
+Command will also create a new data container if data container
+(NAME) does not exist.`,
 	Run: ImportData,
 }
 

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -59,8 +59,7 @@ var dataImport = &cobra.Command{
 	Short: "Import from a host folder to a named data container's directory",
 	Long: `Import from a host folder to a named data container's directory.
 Requires src and dest for each host and container, respectively.
-Container path enters at /home/eris/.eris
-Source (host) path must be absolute and destination dir must exist.`,
+Container path enters at /home/eris/.eris and destination dir must exist.`,
 	Run: ImportData,
 }
 
@@ -69,8 +68,7 @@ var dataExport = &cobra.Command{
 	Short: "Export a named data container's directory to a host directory",
 	Long: `Export a named data container's directory to a host directory.
 Requires src and dest for each container and host, respectively.
-Container path enters at /home/eris/.eris
-Destination (host) path can be relative.`,
+Container path enters at /home/eris/.eris.`,
 	Run: ExportData,
 }
 

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -41,20 +41,17 @@ func buildFilesCommand() {
 }
 
 var filesImport = &cobra.Command{
-	Use:   "get HASH [FILE]",
-	Short: "Pull files from IPFS via a hash and save them locally.",
-	Long: `Pull files from IPFS via a hash and save them locally.
-
-Optionally pass in a CSV with: get --csv=FILE`,
-	Run: FilesGet,
+	Use:   "get HASH FILE/DIR",
+	Short: "Pull files/objects from IPFS via a hash and save them locally.",
+	Long:  `Pull files/objects from IPFS via a hash and save them locally.`,
+	Run:   FilesGet,
 }
 
 var filesExport = &cobra.Command{
-	Use:   "put FILE",
-	Short: "Post files to IPFS.",
-	Long: `Post files to IPFS.
-
-Optionally post all contents of a directory with: put --dir=DIRNAME`,
+	Use:   "put FILE/DIR",
+	Short: "Post files or whole directories to IPFS.",
+	Long: `Post files or whole directories to IPFS.
+Directories will be added as objects in the MerkleDAG.`,
 	Run: FilesPut,
 }
 
@@ -64,7 +61,6 @@ var filesCache = &cobra.Command{
 	Long: `Cache files to IPFS' local daemon.
 
 It caches files locally via IPFS pin, by hash.
-Optionally pass in a CSV with: cache --csv=[FILE].
 
 NOTE: "put" will "cache" recursively by default.`,
 	Run: FilesPin,
@@ -96,80 +92,49 @@ var filesCached = &cobra.Command{
 // cli flags
 func addFilesFlags() {
 
-	buildFlag(filesImport, do, "csv", "files")
-	filesImport.Flags().StringVarP(&do.NewName, "dirname", "", "", "name of new directory to dump IPFS files from --csv")
 	filesExport.Flags().StringVarP(&do.Gateway, "gateway", "", "", "specify a hosted gateway. default is IPFS' gateway; type \"eris\" for our gateway, or use your own with \"http://yourhost\"")
-	//TODO `put files --dir -r` once pr to ipfs is merged
-	filesExport.Flags().BoolVarP(&do.AddDir, "dir", "", false, "add all files from a directory (note: this will not create an ipfs object). returns a log file (ipfs_hashes.csv) to pass into `eris files get`")
-
-	//command will ignore fileName but that's ok
-	buildFlag(filesCache, do, "csv", "files")
 
 	filesCached.Flags().BoolVarP(&do.Rm, "rma", "", false, "remove all cached files")
 	filesCached.Flags().StringVarP(&do.Hash, "rm", "", "", "remove a cached file by hash")
 }
 
 func FilesGet(cmd *cobra.Command, args []string) {
-	if do.CSV == "" {
-		IfExit(ArgCheck(2, "eq", cmd, args))
-		do.Name = args[0]
-		do.Path = args[1]
-	} else {
-		do.Name = ""
-		do.Path = ""
-	}
+	IfExit(ArgCheck(2, "eq", cmd, args))
+	do.Name = args[0]
+	do.Path = args[1]
 	IfExit(files.GetFiles(do))
 }
 
 func FilesPut(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "eq", cmd, args))
-
 	do.Name = args[0]
-	err := files.PutFiles(do)
-	IfExit(err)
-	log.Warn(do.Result)
+	IfExit(files.PutFiles(do))
+	//log.Warn(do.Result)
 }
 
 func FilesPin(cmd *cobra.Command, args []string) {
-	if do.CSV == "" {
-		if len(args) != 1 {
-			cmd.Help()
-			return
-		}
-		do.Name = args[0]
-	} else {
-		do.Name = ""
-	}
-	err := files.PinFiles(do)
-	IfExit(err)
+	IfExit(ArgCheck(1, "eq", cmd, args))
+	do.Name = args[0]
+	IfExit(files.PinFiles(do))
 	log.Warn(do.Result)
 }
 
 func FilesCat(cmd *cobra.Command, args []string) {
-	if len(args) != 1 {
-		cmd.Help()
-		return
-	}
+	IfExit(ArgCheck(1, "eq", cmd, args))
 	do.Name = args[0]
-	err := files.CatFiles(do)
-	IfExit(err)
+	IfExit(files.CatFiles(do))
 	log.Warn(do.Result)
 
 }
 
 func FilesList(cmd *cobra.Command, args []string) {
-	if len(args) != 1 {
-		cmd.Help()
-		return
-	}
+	IfExit(ArgCheck(1, "eq", cmd, args))
 	do.Name = args[0]
-	err := files.ListFiles(do)
-	IfExit(err)
+	IfExit(files.ListFiles(do))
 	log.Warn(do.Result)
 }
 
 func FilesManageCached(cmd *cobra.Command, args []string) {
-	err := files.ManagePinned(do)
-	IfExit(err)
+	IfExit(files.ManagePinned(do))
 	log.Warn(do.Result)
 }

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -2,9 +2,7 @@ package files
 
 import (
 	"bytes"
-	//"fmt"
 	"io/ioutil"
-	//"strings"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -1,29 +1,31 @@
 package files
 
 import (
-	"fmt"
+	"bytes"
+	//"fmt"
+	"io/ioutil"
+	//"strings"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/eris-ltd/eris-cli/definitions"
+	"github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/tests"
 
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	logger "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
 )
 
-var erisDir string = filepath.Join(os.TempDir(), "eris")
-
-var DEAD bool // XXX: don't double panic (TODO: Flushing twice blocks)
-func fatal(t *testing.T, err error) {
-	if !DEAD {
-		tests.TestsTearDown()
-		DEAD = true
-		panic(err)
-	}
-}
+var (
+	erisDir      = filepath.Join(os.TempDir(), "eris")
+	newDir       = filepath.Join(erisDir, "addRecursively")
+	fileInNewDir = filepath.Join(newDir, "recurse.toml")
+	content      = "test contents"
+	filename     = filepath.Join(erisDir, "test-file.toml")
+)
 
 func TestMain(m *testing.M) {
 	log.SetFormatter(logger.ErisFormatter{})
@@ -35,17 +37,13 @@ func TestMain(m *testing.M) {
 	// Prevent CLI from starting IPFS.
 	os.Setenv("ERIS_SKIP_ENSURE", "true")
 
-	tests.IfExit(testsInit())
+	tests.IfExit(tests.TestsInit("files"))
 	exitCode := m.Run()
 	tests.IfExit(tests.TestsTearDown())
 	os.Exit(exitCode)
 }
 
 func TestPutFiles(t *testing.T) {
-	var (
-		content  = "test contents"
-		filename = filepath.Join(erisDir, "test-file.toml")
-	)
 	tests.FakeDefinitionFile(erisDir, "test-file", content)
 
 	do := definitions.NowDo()
@@ -66,23 +64,23 @@ func TestPutFiles(t *testing.T) {
 	defer ipfs.Close()
 
 	if err := PutFiles(do); err != nil {
-		fatal(t, err)
+		t.Fatalf("err putting files: %v\n", err)
 	}
 
 	if expected := "/ipfs/"; ipfs.Path() != expected {
-		fatal(t, fmt.Errorf("Called the wrong endpoint; expected %v, got %v\n", expected, ipfs.Path()))
+		t.Fatalf("called the wrong endpoint; expected %v, got %v\n", expected, ipfs.Path())
 	}
 
 	if expected := "POST"; ipfs.Method() != expected {
-		fatal(t, fmt.Errorf("Used the wrong HTTP method; expected %v, got %v\n", expected, ipfs.Method()))
+		t.Fatalf("Used the wrong HTTP method; expected %v, got %v\n", expected, ipfs.Method())
 	}
 
 	if ipfs.Body() != content {
-		fatal(t, fmt.Errorf("Put the bad file; expected %q, got %q\n", content, ipfs.Body()))
+		t.Fatalf("Put the bad file; expected %q, got %q\n", content, ipfs.Body())
 	}
 
 	if hash != do.Result {
-		fatal(t, fmt.Errorf("Hash mismatch; expected %q, got %q\n", hash, do.Result))
+		t.Fatalf("Hash mismatch; expected %q, got %q\n", hash, do.Result)
 	}
 
 	log.WithField("result", do.Result).Debug("Finished putting a file")
@@ -90,13 +88,13 @@ func TestPutFiles(t *testing.T) {
 
 func TestGetFiles(t *testing.T) {
 	var (
-		filename = filepath.Join(erisDir, "tset file.toml")
-		content  = "test contents"
 		hash     = "QmcJdniiSKMp5az3fJvkbJTANd7bFtDoUkov3a8pkByWkv"
+		fileName = filepath.Join(erisDir, "tset file.toml")
 	)
+
 	do := definitions.NowDo()
 	do.Name = hash
-	do.Path = filename
+	do.Path = fileName
 
 	// Fake IPFS server.
 	os.Setenv("ERIS_IPFS_HOST", "http://127.0.0.1")
@@ -108,26 +106,135 @@ func TestGetFiles(t *testing.T) {
 	defer ipfs.Close()
 
 	if err := GetFiles(do); err != nil {
-		fatal(t, err)
+		t.Fatalf("err getting files %v\n", err)
 	}
 
 	if expected := "/ipfs/" + hash; ipfs.Path() != expected {
-		fatal(t, fmt.Errorf("Called the wrong endpoint; expected %v, got %v\n", expected, ipfs.Path()))
+		t.Fatalf("Called the wrong endpoint; expected %v, got %v\n", expected, ipfs.Path())
 	}
 
 	if expected := "GET"; ipfs.Method() != expected {
-		fatal(t, fmt.Errorf("Used the wrong HTTP method; expected %v, got %v\n", expected, ipfs.Method()))
+		t.Fatalf("Used the wrong HTTP method; expected %v, got %v\n", expected, ipfs.Method())
 	}
 
-	if returned := tests.FileContents(filename); content != returned {
-		fatal(t, fmt.Errorf("Returned unexpected content; expected %q, got %q", content, returned))
+	if returned := tests.FileContents(fileName); content != returned {
+		t.Fatalf("Returned unexpected content; expected %q, got %q", content, returned)
 	}
 }
 
-func testsInit() error {
-	if err := tests.TestsInit("files"); err != nil {
-		return err
+// no fake servers for the time being
+// all in one so we don't have to wake ipfs up twice
+func TestPutAndGetDirectory(t *testing.T) {
+	testStartIPFS(t)
+	defer testKillIPFS(t)
+
+	testPutDirectoryToIPFS(t)
+	testGetDirectoryFromIPFS(t)
+
+	pathGot := filepath.Join(erisDir, "recurse.toml")
+	pathPut := fileInNewDir
+
+	fGot, err := ioutil.ReadFile(pathGot)
+	if err != nil {
+		t.Fatalf("err reading filepath got: %s\n%v\n", pathGot, err)
 	}
 
-	return nil
+	fPut, err := ioutil.ReadFile(pathPut)
+	if err != nil {
+		t.Fatalf("err reading filepath put: %s\n%v\n", pathPut, err)
+	}
+
+	if !bytes.Equal(fGot, fPut) {
+		t.Fatalf("files not equal. got (%s), expecting (%s)", string(fGot), string(fPut))
+	}
+}
+
+func testGetDirectoryFromIPFS(t *testing.T) {
+	var err error
+	hash := "QmYwjCPtWkduz81UnAqMJYCag5pock5y2S8yZQEd4qoyzf"
+
+	do := definitions.NowDo()
+	do.Name = hash
+	do.Path = erisDir
+
+	passed := false
+	for i := 0; i < 10; i++ { //usually needs 3-4
+		_, err = importDirectory(do)
+		if err != nil {
+			time.Sleep(2 * time.Second)
+			continue
+		} else {
+			passed = true
+			break
+		}
+	}
+
+	if !passed {
+		_, err = importDirectory(do)
+		if err != nil {
+			t.Fatalf("error putting dir to IPFS: %v\n", err)
+
+		}
+	}
+}
+
+// get a dir up in there
+// adapted from agent/agent_test.go
+// eventually deduplicate
+func testPutDirectoryToIPFS(t *testing.T) {
+	var err error
+
+	if err := os.MkdirAll(newDir, 0777); err != nil {
+		t.Fatalf("err mkdir: %v\n", err)
+	}
+
+	if err := ioutil.WriteFile(fileInNewDir, []byte(content), 0777); err != nil {
+		t.Fatalf("err writing file: %v\n", err)
+	}
+
+	do := definitions.NowDo()
+	do.Name = newDir
+
+	passed := false
+	for i := 0; i < 10; i++ { //usually needs 3-4
+		_, err = exportDirectory(do)
+		if err != nil {
+			time.Sleep(2 * time.Second)
+			continue
+		} else {
+			passed = true
+			break
+		}
+	}
+
+	if !passed {
+		_, err = exportDirectory(do)
+		if err != nil {
+			t.Fatalf("error putting dir to IPFS: %v\n", err)
+
+		}
+	}
+}
+
+func testStartIPFS(t *testing.T) {
+	do := definitions.NowDo()
+	do.Name = "ipfs"
+	do.Operations.Args = []string{"ipfs"}
+	do.Operations.PublishAllPorts = false
+	if err := services.StartService(do); err != nil {
+		t.Fatalf("expected service to start, got %v", err)
+	}
+	// because it might help ... ?
+	time.Sleep(1 * time.Second)
+}
+
+func testKillIPFS(t *testing.T) {
+	do := definitions.NowDo()
+	do.Name = "ipfs"
+	do.Operations.Args = []string{"ipfs"}
+	do.Rm = true
+	do.RmD = true
+	if err := services.KillService(do); err != nil {
+		t.Fatalf("expected service to be stopped, got %v", err)
+	}
 }

--- a/files/handle.go
+++ b/files/handle.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -85,13 +86,6 @@ func exportDirectory(do *definitions.Do) (*bytes.Buffer, error) {
 	// will be removed later
 	do.Destination = filepath.Join(ErisContainerRoot, "scratch", "data", do.Source)
 	do.Name = "ipfs"
-
-	//TODO rm when data-import merged
-	arguments := []string{"mkdir", "--parents", do.Destination}
-	_, err := services.ExecHandler("ipfs", arguments)
-	if err != nil {
-		return nil, err
-	}
 
 	do.Operations.Args = nil
 	do.Operations.PublishAllPorts = true

--- a/files/handle.go
+++ b/files/handle.go
@@ -2,73 +2,73 @@ package files
 
 import (
 	"bytes"
-	"encoding/csv"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
+	//	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/eris-ltd/eris-cli/config"
+	"github.com/eris-ltd/eris-cli/data"
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/services"
+	"github.com/eris-ltd/eris-cli/util"
 
 	log "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/ipfs"
 )
 
 func GetFiles(do *definitions.Do) error {
 	ensureRunning()
-	var err error
-	if do.CSV != "" {
-		log.WithFields(log.Fields{
-			"from": do.CSV,
-			"to":   do.NewName,
-		}).Debug("Importing files")
-		err = importFiles(do.CSV, do.NewName)
 
-	} else {
+	dirBool := checkPath(do.Path)
+
+	if dirBool {
 		log.WithFields(log.Fields{
-			"file": do.Name,
+			"hash": do.Name,
 			"path": do.Path,
-		}).Debug("Importing a file")
-		err = importFile(do.Name, do.Path)
+		}).Warn("Getting a directory")
+		buf, err := importDirectory(do)
+		if err != nil {
+			return err
+		}
+		log.Warn("Directory object getted succesfully.")
+		log.Warn(util.TrimString(buf.String()))
+		//get like you put dir
+	} else {
+		if err := importFile(do.Name, do.Path); err != nil {
+			return err
+		}
+		do.Result = "success"
 	}
-	if err != nil {
-		return err
-	}
-	do.Result = "success"
 	return nil
 }
 
 func PutFiles(do *definitions.Do) error {
 	ensureRunning()
 
-	if do.Gateway != "" {
-		_, err := url.Parse(do.Gateway)
-		if err != nil {
-			return fmt.Errorf("Invalid gateway URL provided %v\n", err)
-		}
-		log.WithField("gateway", do.Gateway).Debug("Posting to")
-	} else {
-		log.Debug("Posting to gateway.ipfs.io")
+	if err := checkGatewayFlag(do); err != nil {
+		return err
 	}
 
-	if do.AddDir {
-		log.WithFields(log.Fields{
-			"dir":     do.Name,
-			"gateway": do.Gateway,
-		}).Debug("Adding contents of a directory")
-		hashes, err := exportDir(do.Name, do.Gateway)
+	//check if do.Name is dir or file ...
+	f, err := os.Stat(do.Name)
+	if err != nil {
+		return err
+	}
+
+	if f.IsDir() {
+		//can't use gateway - check & throw err
+		log.WithField("dir", do.Name).Warn("Adding contents of a directory")
+		buf, err := exportDirectory(do)
 		if err != nil {
 			return err
 		}
-		do.Result = hashes
+		log.Warn("Directory object added succesfully")
+		log.Warn(util.TrimString(buf.String()))
 	} else {
-		log.WithFields(log.Fields{
-			"file":    do.Name,
-			"gateway": do.Gateway,
-		}).Debug("Adding a file")
 		hash, err := exportFile(do.Name, do.Gateway)
 		if err != nil {
 			return err
@@ -78,27 +78,118 @@ func PutFiles(do *definitions.Do) error {
 	return nil
 }
 
+func exportDirectory(do *definitions.Do) (*bytes.Buffer, error) {
+
+	// path to dir on host
+	do.Source = do.Name
+	// path to dest in cont (doesn't exist, need to make it)
+	// will be removed later
+	do.Destination = filepath.Join(ErisContainerRoot, "scratch", "data", do.Source)
+	do.Name = "ipfs"
+
+	//TODO rm when data-import merged
+	do.Operations.Interactive = false
+	do.Operations.PublishAllPorts = true
+	do.Operations.Args = []string{"mkdir", "--parents", do.Destination}
+	_, err := services.ExecService(do)
+	if err != nil {
+		return nil, err
+	}
+
+	do.Operations.Args = nil
+	do.Operations.PublishAllPorts = false
+	if err := data.ImportData(do); err != nil {
+		return nil, err
+	}
+
+	ip := new(bytes.Buffer)
+	config.GlobalConfig.Writer = ip
+
+	do.Operations.Interactive = false
+	do.Operations.PublishAllPorts = true
+	do.Operations.Args = []string{"NetworkSettings.IPAddress"}
+
+	if err := services.InspectService(do); err != nil {
+		return nil, err
+	}
+	api := fmt.Sprintf("/ip4/%s/tcp/5001", util.TrimString(ip.String()))
+
+	do.Operations.Interactive = false
+	do.Operations.PublishAllPorts = true
+	do.Operations.Args = []string{"ipfs", "add", "-r", do.Destination, "--api", api}
+
+	buf, err := services.ExecService(do)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+func importDirectory(do *definitions.Do) (*bytes.Buffer, error) {
+	hash := do.Name
+
+	// path to dir on host
+	// path to source in cont (doesn't exist, need to make it)
+	// exec'ing ipfs get will save files in Root hash named dir
+
+	ip := new(bytes.Buffer)
+	config.GlobalConfig.Writer = ip
+	do.Name = "ipfs"
+	do.Operations.Interactive = false
+	do.Operations.PublishAllPorts = true
+	do.Operations.Args = []string{"NetworkSettings.IPAddress"}
+
+	if err := services.InspectService(do); err != nil {
+		return nil, err
+	}
+	api := fmt.Sprintf("/ip4/%s/tcp/5001", util.TrimString(ip.String()))
+
+	do.Operations.Interactive = false
+	do.Operations.PublishAllPorts = true
+	//will save to /home/eris/.eris in hash dir.
+	do.Operations.Args = []string{"ipfs", "get", hash, "--api", api}
+
+	buf, err := services.ExecService(do)
+	if err != nil {
+		return nil, err
+	}
+
+	//get src/dest right
+	//on host
+	do.Destination = do.Path
+	do.Source = filepath.Join(ErisContainerRoot, hash)
+	do.Operations.Args = nil
+	do.Operations.PublishAllPorts = false
+	if err := data.ExportData(do); err != nil {
+		return nil, err
+	}
+
+	_, err = os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	theDir := filepath.Join(do.Destination, hash)
+	newDir := do.Destination
+
+	if err := data.MoveOutOfDirAndRmDir(theDir, newDir); err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+
+}
 func PinFiles(do *definitions.Do) error {
 	ensureRunning()
-	if do.CSV != "" {
-		log.WithField("=>", do.CSV).Debug("Pinning all files from")
-		hashes, err := pinFiles(do.CSV)
-		if err != nil {
-			return err
-		}
-		do.Result = hashes
-
-	} else {
-		log.WithFields(log.Fields{
-			"file": do.Name,
-			"path": do.Path,
-		}).Debug("Pinning a file")
-		hash, err := pinFile(do.Name)
-		if err != nil {
-			return err
-		}
-		do.Result = hash
+	log.WithFields(log.Fields{
+		"file": do.Name,
+		"path": do.Path,
+	}).Debug("Pinning a file")
+	hash, err := pinFile(do.Name)
+	if err != nil {
+		return err
 	}
+	do.Result = hash
 	return nil
 }
 
@@ -164,6 +255,11 @@ func ManagePinned(do *definitions.Do) error {
 func importFile(hash, fileName string) error {
 	var err error
 
+	log.WithFields(log.Fields{
+		"from hash": hash,
+		"to path":   fileName,
+	}).Debug("Importing a file")
+
 	if log.GetLevel() > 0 {
 		err = ipfs.GetFromIPFS(hash, fileName, "", os.Stdout)
 	} else {
@@ -175,37 +271,14 @@ func importFile(hash, fileName string) error {
 	return nil
 }
 
-func importFiles(csvfile, newdir string) error {
-	var err error
-
-	csvFile, err := os.Open(csvfile)
-	if err != nil {
-		return fmt.Errorf("error opening csv file: %v\n", err)
-	}
-	defer csvFile.Close()
-
-	reader := csv.NewReader(csvFile)
-	rawCSVdata, err := reader.ReadAll()
-	if err != nil {
-		return fmt.Errorf("error reading csv file: %v\n", err)
-	}
-
-	for _, each := range rawCSVdata {
-		if log.GetLevel() > 0 {
-			err = ipfs.GetFromIPFS(each[0], each[1], newdir, os.Stdout)
-		} else {
-			err = ipfs.GetFromIPFS(each[0], each[1], newdir, bytes.NewBuffer([]byte{}))
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func exportFile(fileName, gateway string) (string, error) {
 	var hash string
 	var err error
+
+	log.WithFields(log.Fields{
+		"file":    fileName,
+		"gateway": gateway,
+	}).Debug("Adding a file")
 
 	if log.GetLevel() > 0 {
 		hash, err = ipfs.SendToIPFS(fileName, gateway, os.Stdout)
@@ -217,45 +290,6 @@ func exportFile(fileName, gateway string) (string, error) {
 	}
 
 	return hash, nil
-}
-
-func exportDir(dirName, gateway string) (string, error) {
-	var hashes string
-	var err error
-
-	files, err := ioutil.ReadDir(dirName)
-	if err != nil {
-		return "", fmt.Errorf("error reading directory %v\n", err)
-	}
-	gwd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("error getting working directory %v\n", err)
-	}
-	hashArray := make([]string, len(files))
-	fileNames := make([]string, len(files))
-	//the dir ends up in the loop & tries to post
-	for i := range files {
-		//hacky
-		file := filepath.Join(gwd, dirName, files[i].Name())
-		if log.GetLevel() > 0 {
-			hashArray[i], err = ipfs.SendToIPFS(file, gateway, os.Stdout)
-		} else {
-			hashArray[i], err = ipfs.SendToIPFS(file, gateway, bytes.NewBuffer([]byte{}))
-		}
-		if err != nil {
-			return "", fmt.Errorf("error reading file %v\n", err)
-		}
-		fileNames[i] = files[i].Name()
-	}
-
-	err = writeCsv(hashArray, fileNames)
-	if err != nil {
-		return "", err
-	}
-
-	hashes = strings.Join(hashArray, "\n")
-
-	return hashes, nil
 }
 
 func pinFile(fileHash string) (string, error) {
@@ -271,36 +305,6 @@ func pinFile(fileHash string) (string, error) {
 		return "", err
 	}
 	return hash, nil
-}
-
-func pinFiles(csvfile string) (string, error) {
-	var err error
-
-	csvFile, err := os.Open(csvfile)
-	if err != nil {
-		return "", fmt.Errorf("error opening csv file: %v\n", err)
-	}
-	defer csvFile.Close()
-
-	reader := csv.NewReader(csvFile)
-	rawCSVdata, err := reader.ReadAll()
-	if err != nil {
-		return "", fmt.Errorf("error reading csv file: %v\n", err)
-	}
-
-	hashArray := make([]string, len(rawCSVdata))
-	for i, each := range rawCSVdata {
-		if log.GetLevel() > 0 {
-			hashArray[i], err = ipfs.PinToIPFS(each[0], os.Stdout)
-		} else {
-			hashArray[i], err = ipfs.PinToIPFS(each[0], bytes.NewBuffer([]byte{}))
-		}
-		if err != nil {
-			return "", err
-		}
-	}
-	hashes := strings.Join(hashArray, "\n")
-	return hashes, nil
 }
 
 func catFile(fileHash string) (string, error) {
@@ -379,28 +383,6 @@ func rmPinnedByHash(hash string) (string, error) {
 //---------------------------------------------------------
 // helpers
 
-func writeCsv(hashArray, fileNames []string) error {
-	strToWrite := make([][]string, len(hashArray))
-	for i := range hashArray {
-		strToWrite[i] = []string{hashArray[i], fileNames[i]}
-
-	}
-
-	csvfile, err := os.Create("ipfs_hashes.csv")
-	if err != nil {
-		return fmt.Errorf("error creating csv file: %v", err)
-	}
-	defer csvfile.Close()
-
-	w := csv.NewWriter(csvfile)
-	w.WriteAll(strToWrite)
-
-	if err := w.Error(); err != nil {
-		return fmt.Errorf("error writing csv: %v", err)
-	}
-	return nil
-}
-
 func ensureRunning() {
 	doNow := definitions.NowDo()
 	doNow.Name = "ipfs"
@@ -410,4 +392,30 @@ func ensureRunning() {
 		return
 	}
 	log.Info("IPFS is running")
+}
+
+func checkGatewayFlag(do *definitions.Do) error {
+	if do.Gateway != "" {
+		_, err := url.Parse(do.Gateway)
+		if err != nil {
+			return fmt.Errorf("Invalid gateway URL provided %v\n", err)
+		}
+		log.WithField("gateway", do.Gateway).Debug("Posting to")
+	} else {
+		log.Debug("Posting to gateway.ipfs.io")
+	}
+	return nil
+}
+
+func checkPath(path string) bool {
+	dirBool := false
+	thing := strings.Split(path, ".")
+	if len(thing) == 1 {
+		log.Warn("No file extension detected, assuming directory.")
+		return true
+	} else {
+		log.Warn("File extension detected, assuming file.")
+		return false
+	}
+	return dirBool
 }

--- a/files/handle.go
+++ b/files/handle.go
@@ -145,7 +145,7 @@ func importDirectory(do *definitions.Do) (*bytes.Buffer, error) {
 	}
 
 	do.Destination = do.Path
-	do.Source = filepath.Join(ErisContainerRoot, hash)
+	do.Source = path.Join(ErisContainerRoot, hash)
 	do.Operations.Args = nil
 	do.Operations.PublishAllPorts = false
 	if err := data.ExportData(do); err != nil {
@@ -156,7 +156,7 @@ func importDirectory(do *definitions.Do) (*bytes.Buffer, error) {
 	if err != nil {
 		return nil, err
 	}
-	theDir := filepath.Join(do.Destination, hash)
+	theDir := path.Join(do.Destination, hash)
 	newDir := do.Destination
 
 	if err := data.MoveOutOfDirAndRmDir(theDir, newDir); err != nil {

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -76,8 +76,7 @@ func TestGetPubKey(t *testing.T) {
 		fatal(t, err)
 	}
 
-	pubBytes := pub.Bytes()
-	pubkey := util.TrimString(string(pubBytes))
+	pubkey := util.TrimString(pub.String())
 
 	key := new(bytes.Buffer)
 	config.GlobalConfig.Writer = key

--- a/services/operate.go
+++ b/services/operate.go
@@ -146,6 +146,7 @@ func ExecHandler(srvName string, args []string) (buf *bytes.Buffer, err error) {
 	do.Name = srvName
 	do.Operations.Interactive = false
 	do.Operations.Args = args
+	do.Operations.PublishAllPorts = true
 	return ExecService(do)
 }
 


### PR DESCRIPTION
`eris files put someDir/` => add that directory recursively. equal to `ipfs add -r someDir/`; detects if file/dir & behaves accordingly. output includes root `HASH` of the object (directory) used to `get`

`eris files get HASH newDir` => will create `newDir` and dump all the contents of `someDir` into `newDir`; get detects object(dir)/file type to get based on whether or not an extension if given at `newDir`

**Note:** this PR deprecates all `.csv` functionality that `eris files put/get` had

closes #380 