### PR TITLE
import/export all keys + can use relative paths now

### DIFF
--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -108,9 +108,11 @@ the [eris services exec keys "ls /home/eris/.eris/keys/data"] command.`,
 func addKeysFlags() {
 	keysExport.Flags().StringVarP(&do.Destination, "dest", "", DefKeysPathHost, "destination for export on host")
 	keysExport.Flags().StringVarP(&do.Address, "addr", "", "", "address of key to export")
+	keysExport.Flags().BoolVarP(&do.All, "all", "", false, "export all keys. do not provide any arguments")
 
 	keysImport.Flags().StringVarP(&do.Source, "src", "", DefKeysPathHost, "source on host to import from. give full filepath to key")
 	keysImport.Flags().StringVarP(&do.Address, "addr", "", "", "address of key to import")
+	keysImport.Flags().BoolVarP(&do.All, "all", "", false, "import all keys. do not provide any arguments")
 
 	keysList.Flags().BoolVarP(&do.Host, "host", "", false, "list keys on host: looks in $HOME/.eris/keys/data")
 	keysList.Flags().BoolVarP(&do.Container, "container", "", false, "list keys in container: looks in /home/eris/.eris/keys/data")
@@ -119,7 +121,6 @@ func addKeysFlags() {
 
 func GenerateKey(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(0, "eq", cmd, args))
-
 	IfExit(keys.GenerateKey(do))
 }
 
@@ -130,14 +131,22 @@ func GetPubKey(cmd *cobra.Command, args []string) {
 }
 
 func ExportKey(cmd *cobra.Command, args []string) {
-	IfExit(ArgCheck(1, "eq", cmd, args))
-	do.Address = strings.TrimSpace(args[0])
+	if do.All {
+		IfExit(ArgCheck(0, "eq", cmd, args))
+	} else {
+		IfExit(ArgCheck(1, "eq", cmd, args))
+		do.Address = strings.TrimSpace(args[0])
+	}
 	IfExit(keys.ExportKey(do))
 }
 
 func ImportKey(cmd *cobra.Command, args []string) {
-	IfExit(ArgCheck(1, "eq", cmd, args))
-	do.Address = strings.TrimSpace(args[0])
+	if do.All {
+		IfExit(ArgCheck(0, "eq", cmd, args))
+	} else {
+		IfExit(ArgCheck(1, "eq", cmd, args))
+		do.Address = strings.TrimSpace(args[0])
+	}
 	IfExit(keys.ImportKey(do))
 }
 

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -44,11 +44,11 @@ func TestGenerateKey(t *testing.T) {
 	output := testListKeys("container")
 
 	if len(output) != 1 {
-		t.Fatalf("Expected one key, got (%v)\n", len(output))
+		t.Fatalf("Expected one key, got (%v)", len(output))
 	}
 
 	if address != output[0] {
-		t.Fatalf("Expected (%s), got (%s)\n", address, output[0])
+		t.Fatalf("Expected (%s), got (%s)", address, output[0])
 	}
 }
 
@@ -62,7 +62,7 @@ func TestGetPubKey(t *testing.T) {
 	pub := new(bytes.Buffer)
 	config.GlobalConfig.Writer = pub
 	if err := GetPubKey(doPub); err != nil {
-		t.Fatalf("error getting pubkey: %v\n", err)
+		t.Fatalf("error getting pubkey: %v", err)
 	}
 
 	pubkey := util.TrimString(pub.String())
@@ -72,13 +72,13 @@ func TestGetPubKey(t *testing.T) {
 	doKey := def.NowDo()
 	doKey.Address = doPub.Address
 	if err := ConvertKey(doKey); err != nil {
-		t.Fatalf("error converting key: %v\n", err)
+		t.Fatalf("error converting key: %v", err)
 	}
 
 	converted := regexp.MustCompile(`"pub_key":\[1,"([^"]+)"\]`).FindStringSubmatch(key.String())[1]
 
 	if converted != pubkey {
-		t.Fatalf("Expected (%s), got (%s)\n", pubkey, converted)
+		t.Fatalf("Expected (%s), got (%s)", pubkey, converted)
 	}
 }
 
@@ -93,7 +93,7 @@ func TestExportKeySingle(t *testing.T) {
 	//cat container contents of new key
 	catOut, err := srv.ExecHandler("keys", []string{"cat", keyPath})
 	if err != nil {
-		t.Fatalf("error exec-ing: %v\n", err)
+		t.Fatalf("error exec-ing: %v", err)
 	}
 
 	keyInCont := util.TrimString(catOut.String())
@@ -104,18 +104,18 @@ func TestExportKeySingle(t *testing.T) {
 
 	//export
 	if err := ExportKey(doExp); err != nil {
-		t.Fatalf("error exporting: %v\n", err)
+		t.Fatalf("error exporting: %v", err)
 	}
 
 	//cat host contents
 	key, err := ioutil.ReadFile(filepath.Join(doExp.Destination, address, address))
 	if err != nil {
-		t.Fatalf("error reading file: %v\n", err)
+		t.Fatalf("error reading file: %v", err)
 	}
 
 	keyOnHost := util.TrimString(string(key))
 	if keyInCont != keyOnHost {
-		t.Fatalf("Expected (%s), got (%s)\n", keyInCont, keyOnHost)
+		t.Fatalf("Expected (%s), got (%s)", keyInCont, keyOnHost)
 	}
 }
 
@@ -133,7 +133,7 @@ func TestImportKeyAll(t *testing.T) {
 
 	//export
 	if err := ExportKey(doExp); err != nil {
-		t.Fatalf("error exporting: %v\n", err)
+		t.Fatalf("error exporting: %v", err)
 	}
 
 	// kill container
@@ -147,9 +147,8 @@ func TestImportKeyAll(t *testing.T) {
 	doImp := def.NowDo()
 	doImp.All = true
 
-	//export
 	if err := ImportKey(doImp); err != nil {
-		t.Fatalf("error exporting: %v\n", err)
+		t.Fatalf("error exporting: %v", err)
 	}
 
 	// check that they in container
@@ -163,9 +162,8 @@ func TestImportKeyAll(t *testing.T) {
 	}
 
 	if i != 2 {
-		t.Fatalf("Expected 2 keys, got (%v)\n", i)
+		t.Fatalf("Expected 2 keys, got (%v)", i)
 	}
-
 }
 
 func TestExportKeyAll(t *testing.T) {
@@ -181,7 +179,7 @@ func TestExportKeyAll(t *testing.T) {
 	doExp.All = true
 	//export
 	if err := ExportKey(doExp); err != nil {
-		t.Fatalf("error exporting: %v\n", err)
+		t.Fatalf("error exporting: %v", err)
 	}
 	// check that they on host
 	output := testListKeys("host")
@@ -194,9 +192,8 @@ func TestExportKeyAll(t *testing.T) {
 	}
 
 	if i != 2 {
-		t.Fatalf("Expected 2 keys, got (%v)\n", i)
+		t.Fatalf("Expected 2 keys, got (%v)", i)
 	}
-
 }
 
 func TestImportKeySingle(t *testing.T) {
@@ -211,12 +208,12 @@ func TestImportKeySingle(t *testing.T) {
 	doExp.Destination = filepath.Join(KeysPath, "data") //is default set by flag
 
 	if err := ExportKey(doExp); err != nil {
-		t.Fatalf("error exporting key: %v\n", err)
+		t.Fatalf("error exporting key: %v", err)
 	}
 
 	key, err := ioutil.ReadFile(filepath.Join(doExp.Destination, address, address))
 	if err != nil {
-		t.Fatalf("error reading file: %v\n", err)
+		t.Fatalf("error reading file: %v", err)
 	}
 	//key b4 import
 	keyOnHost := util.TrimString(string(key))
@@ -225,7 +222,7 @@ func TestImportKeySingle(t *testing.T) {
 	keyPath := path.Join(ErisContainerRoot, "keys", "data", address)
 
 	if _, err := srv.ExecHandler("keys", []string{"rm", "-rf", keyPath}); err != nil {
-		t.Fatalf("error exec-ing: %v\n", err)
+		t.Fatalf("error exec-ing: %v", err)
 	}
 
 	doImp := def.NowDo()
@@ -234,7 +231,7 @@ func TestImportKeySingle(t *testing.T) {
 	doImp.Source = filepath.Join(KeysPath, "data")
 
 	if err := ImportKey(doImp); err != nil {
-		t.Fatalf("error importing key: %v\n", err)
+		t.Fatalf("error importing key: %v", err)
 	}
 
 	keyPathCat := path.Join(ErisContainerRoot, "keys", "data", address, address)
@@ -242,13 +239,13 @@ func TestImportKeySingle(t *testing.T) {
 	//cat container contents of new key
 	catOut, err := srv.ExecHandler("keys", []string{"cat", keyPathCat})
 	if err != nil {
-		t.Fatalf("error exec-ing: %v\n", err)
+		t.Fatalf("error exec-ing: %v", err)
 	}
 
 	keyInCont := util.TrimString(catOut.String())
 
 	if keyOnHost != keyInCont {
-		t.Fatalf("Expected (%s), got (%s)\n", keyOnHost, keyInCont)
+		t.Fatalf("Expected (%s), got (%s)", keyOnHost, keyInCont)
 	}
 }
 
@@ -274,7 +271,7 @@ func TestListKeyContainer(t *testing.T) {
 	}
 
 	if i != 2 {
-		t.Fatalf("Expected 2 keys, got (%v)\n", i)
+		t.Fatalf("Expected 2 keys, got (%v)", i)
 	}
 }
 
@@ -294,12 +291,12 @@ func TestListKeyHost(t *testing.T) {
 	doExp.Destination = filepath.Join(KeysPath, "data") //is default
 
 	if err := ExportKey(doExp); err != nil {
-		t.Fatalf("error exporting key: %v\n", err)
+		t.Fatalf("error exporting key: %v", err)
 	}
 
 	doExp.Address = addr1
 	if err := ExportKey(doExp); err != nil {
-		t.Fatalf("error exporting key: %v\n", err)
+		t.Fatalf("error exporting key: %v", err)
 	}
 
 	output := testListKeys("host")
@@ -312,11 +309,10 @@ func TestListKeyHost(t *testing.T) {
 	}
 
 	if i != 2 {
-		t.Fatalf("Expected 2 keys, got (%v)\n", i)
+		t.Fatalf("Expected 2 keys, got (%v)", i)
 	}
 }
 
-//
 func testListKeys(typ string) []string {
 	do := def.NowDo()
 
@@ -332,9 +328,7 @@ func testListKeys(typ string) []string {
 		tests.IfExit(err)
 	}
 
-	res := strings.Split(do.Result, ",")
-
-	return res
+	return strings.Split(do.Result, ",")
 }
 
 //returns an addr for tests
@@ -345,8 +339,7 @@ func testsGenAKey() string {
 	tests.IfExit(GenerateKey(doGen))
 
 	addrBytes := addr.Bytes()
-	address := util.TrimString(string(addrBytes))
-	return address
+	return util.TrimString(string(addrBytes))
 }
 
 func testStartKeys(t *testing.T) {
@@ -375,7 +368,7 @@ func testKillService(t *testing.T, serviceName string, wipe bool) {
 	}
 	e := srv.KillService(do)
 	if e != nil {
-		t.Fatalf("error killing services: %v\n", e)
+		t.Fatalf("error killing service: %v", e)
 	}
 	testExistAndRun(t, serviceName, !wipe, false)
 	testNumbersExistAndRun(t, serviceName, 0, 0)

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -2,7 +2,6 @@ package keys
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -21,16 +20,6 @@ import (
 	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 	logger "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/log"
 )
-
-var DEAD bool
-
-func fatal(t *testing.T, err error) {
-	if !DEAD {
-		tests.TestsTearDown()
-		DEAD = true
-		panic(err)
-	}
-}
 
 func TestMain(m *testing.M) {
 	log.SetFormatter(logger.ErisFormatter{})
@@ -55,11 +44,11 @@ func TestGenerateKey(t *testing.T) {
 	output := testListKeys("container")
 
 	if len(output) != 1 {
-		fatal(t, fmt.Errorf("Expected one key, got (%v)\n", len(output)))
+		t.Fatalf("Expected one key, got (%v)\n", len(output))
 	}
 
 	if address != output[0] {
-		fatal(t, fmt.Errorf("Expected (%s), got (%s)\n", address, output[0]))
+		t.Fatalf("Expected (%s), got (%s)\n", address, output[0])
 	}
 }
 
@@ -73,7 +62,7 @@ func TestGetPubKey(t *testing.T) {
 	pub := new(bytes.Buffer)
 	config.GlobalConfig.Writer = pub
 	if err := GetPubKey(doPub); err != nil {
-		fatal(t, err)
+		t.Fatalf("error getting pubkey: %v\n", err)
 	}
 
 	pubkey := util.TrimString(pub.String())
@@ -83,13 +72,13 @@ func TestGetPubKey(t *testing.T) {
 	doKey := def.NowDo()
 	doKey.Address = doPub.Address
 	if err := ConvertKey(doKey); err != nil {
-		fatal(t, err)
+		t.Fatalf("error converting key: %v\n", err)
 	}
 
 	converted := regexp.MustCompile(`"pub_key":\[1,"([^"]+)"\]`).FindStringSubmatch(key.String())[1]
 
 	if converted != pubkey {
-		fatal(t, fmt.Errorf("Expected (%s), got (%s)\n", pubkey, converted))
+		t.Fatalf("Expected (%s), got (%s)\n", pubkey, converted)
 	}
 }
 
@@ -104,7 +93,7 @@ func TestExportKeySingle(t *testing.T) {
 	//cat container contents of new key
 	catOut, err := srv.ExecHandler("keys", []string{"cat", keyPath})
 	if err != nil {
-		fatal(t, err)
+		t.Fatalf("error exec-ing: %v\n", err)
 	}
 
 	keyInCont := util.TrimString(catOut.String())
@@ -115,18 +104,18 @@ func TestExportKeySingle(t *testing.T) {
 
 	//export
 	if err := ExportKey(doExp); err != nil {
-		fatal(t, err)
+		t.Fatalf("error exporting: %v\n", err)
 	}
 
 	//cat host contents
 	key, err := ioutil.ReadFile(filepath.Join(doExp.Destination, address, address))
 	if err != nil {
-		fatal(t, err)
+		t.Fatalf("error reading file: %v\n", err)
 	}
 
 	keyOnHost := util.TrimString(string(key))
 	if keyInCont != keyOnHost {
-		fatal(t, fmt.Errorf("Expected (%s), got (%s)\n", keyInCont, keyOnHost))
+		t.Fatalf("Expected (%s), got (%s)\n", keyInCont, keyOnHost)
 	}
 }
 
@@ -142,12 +131,12 @@ func TestImportKeySingle(t *testing.T) {
 	doExp.Destination = filepath.Join(KeysPath, "data") //is default set by flag
 
 	if err := ExportKey(doExp); err != nil {
-		fatal(t, err)
+		t.Fatalf("error exporting key: %v\n", err)
 	}
 
 	key, err := ioutil.ReadFile(filepath.Join(doExp.Destination, address, address))
 	if err != nil {
-		fatal(t, err)
+		t.Fatalf("error reading file: %v\n", err)
 	}
 	//key b4 import
 	keyOnHost := util.TrimString(string(key))
@@ -156,7 +145,7 @@ func TestImportKeySingle(t *testing.T) {
 	keyPath := path.Join(ErisContainerRoot, "keys", "data", address)
 
 	if _, err := srv.ExecHandler("keys", []string{"rm", "-rf", keyPath}); err != nil {
-		fatal(t, err)
+		t.Fatalf("error exec-ing: %v\n", err)
 	}
 
 	doImp := def.NowDo()
@@ -165,7 +154,7 @@ func TestImportKeySingle(t *testing.T) {
 	doImp.Source = filepath.Join(KeysPath, "data")
 
 	if err := ImportKey(doImp); err != nil {
-		fatal(t, err)
+		t.Fatalf("error importing key: %v\n", err)
 	}
 
 	keyPathCat := path.Join(ErisContainerRoot, "keys", "data", address, address)
@@ -173,13 +162,13 @@ func TestImportKeySingle(t *testing.T) {
 	//cat container contents of new key
 	catOut, err := srv.ExecHandler("keys", []string{"cat", keyPathCat})
 	if err != nil {
-		fatal(t, err)
+		t.Fatalf("error exec-ing: %v\n", err)
 	}
 
 	keyInCont := util.TrimString(catOut.String())
 
 	if keyOnHost != keyInCont {
-		fatal(t, fmt.Errorf("Expected (%s), got (%s)\n", keyOnHost, keyInCont))
+		t.Fatalf("Expected (%s), got (%s)\n", keyOnHost, keyInCont)
 	}
 }
 
@@ -206,7 +195,7 @@ func TestListKeyContainer(t *testing.T) {
 	}
 
 	if i != 3 {
-		fatal(t, fmt.Errorf("Expected 3 keys, got (%v)\n", i))
+		t.Fatalf("Expected 3 keys, got (%v)\n", i)
 	}
 }
 
@@ -226,12 +215,12 @@ func TestListKeyHost(t *testing.T) {
 	doExp.Destination = filepath.Join(KeysPath, "data") //is default
 
 	if err := ExportKey(doExp); err != nil {
-		fatal(t, err)
+		t.Fatalf("error exporting key: %v\n", err)
 	}
 
 	doExp.Address = addr1
 	if err := ExportKey(doExp); err != nil {
-		fatal(t, err)
+		t.Fatalf("error exporting key: %v\n", err)
 	}
 
 	output := testListKeys("host")
@@ -244,7 +233,7 @@ func TestListKeyHost(t *testing.T) {
 	}
 
 	if i != 2 {
-		fatal(t, fmt.Errorf("Expected 2 keys, got (%v)\n", i))
+		t.Fatalf("Expected 2 keys, got (%v)\n", i)
 	}
 }
 
@@ -288,8 +277,7 @@ func testStartKeys(t *testing.T) {
 	log.WithField("=>", serviceName).Debug("Starting service (via tests)")
 	e := srv.StartService(do)
 	if e != nil {
-		log.Infof("Error starting service: %v", e)
-		t.Fail()
+		t.Fatalf("Error starting service: %v", e)
 	}
 
 	testExistAndRun(t, serviceName, true, true)
@@ -308,17 +296,14 @@ func testKillService(t *testing.T, serviceName string, wipe bool) {
 	}
 	e := srv.KillService(do)
 	if e != nil {
-		log.Error(e)
-		fatal(t, e)
+		t.Fatalf("error killing services: %v\n", e)
 	}
 	testExistAndRun(t, serviceName, !wipe, false)
 	testNumbersExistAndRun(t, serviceName, 0, 0)
 }
 
 func testExistAndRun(t *testing.T, servName string, toExist, toRun bool) {
-	if err := tests.TestExistAndRun(servName, "service", toExist, toRun); err != nil {
-		fatal(t, nil)
-	}
+	tests.IfExit(tests.TestExistAndRun(servName, "service", toExist, toRun))
 }
 
 func testNumbersExistAndRun(t *testing.T, servName string, containerExist, containerRun int) {
@@ -338,7 +323,7 @@ func testNumbersExistAndRun(t *testing.T, servName string, containerExist, conta
 			"expected": containerExist,
 			"got":      exist,
 		}).Error("Wrong number of existing containers")
-		fatal(t, nil)
+		t.Fatalf("Bad failure")
 	}
 
 	if run != containerRun {
@@ -347,7 +332,7 @@ func testNumbersExistAndRun(t *testing.T, servName string, containerExist, conta
 			"expected": containerExist,
 			"got":      run,
 		}).Error("Wrong number of running containers")
-		fatal(t, nil)
+		t.Fatalf("Bad failure")
 	}
 
 	log.Info("All good")

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -119,6 +119,86 @@ func TestExportKeySingle(t *testing.T) {
 	}
 }
 
+func TestImportKeyAll(t *testing.T) {
+	testStartKeys(t)
+
+	// gen some keys
+	addrs := make(map[string]bool)
+	addrs[testsGenAKey()] = true
+	addrs[testsGenAKey()] = true
+
+	// export them to host
+	doExp := def.NowDo()
+	doExp.All = true
+
+	//export
+	if err := ExportKey(doExp); err != nil {
+		t.Fatalf("error exporting: %v\n", err)
+	}
+
+	// kill container
+	testKillService(t, "keys", true)
+
+	// start keys
+	testStartKeys(t)
+	defer testKillService(t, "keys", true)
+
+	// eris keys import --all
+	doImp := def.NowDo()
+	doImp.All = true
+
+	//export
+	if err := ImportKey(doImp); err != nil {
+		t.Fatalf("error exporting: %v\n", err)
+	}
+
+	// check that they in container
+	output := testListKeys("container")
+
+	i := 0
+	for _, out := range output {
+		if addrs[util.TrimString(out)] == true {
+			i++
+		}
+	}
+
+	if i != 2 {
+		t.Fatalf("Expected 2 keys, got (%v)\n", i)
+	}
+
+}
+
+func TestExportKeyAll(t *testing.T) {
+	testStartKeys(t)
+	defer testKillService(t, "keys", true)
+	// gen some keys
+	addrs := make(map[string]bool)
+	addrs[testsGenAKey()] = true
+	addrs[testsGenAKey()] = true
+
+	// export them all
+	doExp := def.NowDo()
+	doExp.All = true
+	//export
+	if err := ExportKey(doExp); err != nil {
+		t.Fatalf("error exporting: %v\n", err)
+	}
+	// check that they on host
+	output := testListKeys("host")
+
+	i := 0
+	for _, out := range output {
+		if addrs[util.TrimString(out)] == true {
+			i++
+		}
+	}
+
+	if i != 2 {
+		t.Fatalf("Expected 2 keys, got (%v)\n", i)
+	}
+
+}
+
 func TestImportKeySingle(t *testing.T) {
 	testStartKeys(t)
 	defer testKillService(t, "keys", true)
@@ -183,7 +263,6 @@ func TestListKeyContainer(t *testing.T) {
 	addrs := make(map[string]bool)
 	addrs[testsGenAKey()] = true
 	addrs[testsGenAKey()] = true
-	addrs[testsGenAKey()] = true
 
 	output := testListKeys("container")
 
@@ -194,8 +273,8 @@ func TestListKeyContainer(t *testing.T) {
 		}
 	}
 
-	if i != 3 {
-		t.Fatalf("Expected 3 keys, got (%v)\n", i)
+	if i != 2 {
+		t.Fatalf("Expected 2 keys, got (%v)\n", i)
 	}
 }
 

--- a/keys/readers.go
+++ b/keys/readers.go
@@ -20,18 +20,20 @@ func ListKeys(do *definitions.Do) error {
 		if err != nil {
 			return err
 		}
-		if len(addrs) == 0 {
-			log.Warn("No keys found on host.")
-		} else {
-			hostAddrs := make([]string, len(addrs))
-			for i, addr := range addrs {
-				hostAddrs[i] = addr.Name()
-			}
-			do.Result = strings.Join(hostAddrs, ",")
-			log.WithField("=>", hostAddrs[0]).Warn("The keys on your host kind marmot:")
-			hostAddrs = append(hostAddrs[:0], hostAddrs[1:]...)
-			for _, addr := range hostAddrs {
-				log.WithField("=>", addr).Warn()
+		if !do.Quiet {
+			if len(addrs) == 0 {
+				log.Warn("No keys found on host.")
+			} else {
+				hostAddrs := make([]string, len(addrs))
+				for i, addr := range addrs {
+					hostAddrs[i] = addr.Name()
+				}
+				do.Result = strings.Join(hostAddrs, ",")
+				log.WithField("=>", hostAddrs[0]).Warn("The keys on your host kind marmot:")
+				hostAddrs = append(hostAddrs[:0], hostAddrs[1:]...)
+				for _, addr := range hostAddrs {
+					log.WithField("=>", addr).Warn()
+				}
 			}
 		}
 	}
@@ -48,13 +50,15 @@ func ListKeys(do *definitions.Do) error {
 		}
 		keysOutString := strings.Split(util.TrimString(keysOut.String()), "\n")
 		do.Result = strings.Join(keysOutString, ",")
-		if len(keysOutString) == 0 || keysOutString[0] == "" {
-			log.Warn("No keys found in container.")
-		} else {
-			log.WithField("=>", keysOutString[0]).Warn("The keys in your container kind marmot:")
-			keysOutString = append(keysOutString[:0], keysOutString[1:]...)
-			for _, addr := range keysOutString {
-				log.WithField("=>", addr).Warn()
+		if !do.Quiet {
+			if len(keysOutString) == 0 || keysOutString[0] == "" {
+				log.Warn("No keys found in container.")
+			} else {
+				log.WithField("=>", keysOutString[0]).Warn("The keys in your container kind marmot:")
+				keysOutString = append(keysOutString[:0], keysOutString[1:]...)
+				for _, addr := range keysOutString {
+					log.WithField("=>", addr).Warn()
+				}
 			}
 		}
 	}

--- a/keys/writers.go
+++ b/keys/writers.go
@@ -103,7 +103,7 @@ func ImportKey(do *definitions.Do) error {
 		keyArray := strings.Split(do.Result, ",")
 
 		for _, addr := range keyArray {
-			do.Source = path.Join(common.KeysPath, "data", addr)
+			do.Source = filepath.Join(common.KeysPath, "data", addr)
 			do.Destination = path.Join(common.ErisContainerRoot, "keys", "data", addr)
 			if err := data.ImportData(do); err != nil {
 				return err

--- a/keys/writers.go
+++ b/keys/writers.go
@@ -2,8 +2,10 @@ package keys
 
 import (
 	"io"
+	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/eris-ltd/eris-cli/config"
 	"github.com/eris-ltd/eris-cli/data"
@@ -52,12 +54,29 @@ func ExportKey(do *definitions.Do) error {
 		return err
 	}
 
-	//	do.Destination = ?
+	// do.Destination = given by flag default or overriden
+	if do.All && do.Address == "" {
+		doLs := definitions.NowDo()
+		doLs.Container = true
+		doLs.Host = false
+		doLs.Quiet = true
+		if err := ListKeys(doLs); err != nil {
+			return err
+		}
+		keyArray := strings.Split(do.Result, ",")
 
-	//src in container
-	do.Source = path.Join(ErisContainerRoot, "keys", "data", do.Address)
-	if err := data.ExportData(do); err != nil {
-		return err
+		for _, addr := range keyArray {
+			do.Destination = common.KeysPath
+			do.Source = path.Join(common.ErisContainerRoot, "keys", "data", addr)
+			if err := data.ExportData(do); err != nil {
+				return err
+			}
+		}
+	} else {
+		do.Source = path.Join(common.ErisContainerRoot, "keys", "data", do.Address)
+		if err := data.ExportData(do); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -67,23 +86,45 @@ func ImportKey(do *definitions.Do) error {
 	if err := srv.EnsureRunning(do); err != nil {
 		return err
 	}
-	dir := path.Join(ErisContainerRoot, "keys", "data", do.Address)
 
 	//src on host
 	//if default given (from flag), join addrs
-	if do.Source == filepath.Join(common.KeysPath, "data") {
-		do.Source = filepath.Join(common.KeysPath, "data", do.Address, do.Address)
-	} else { // either relative or absolute path given. get absolute
-		wd, err := os.Getwd()
-		if err != nil {
+	//dest in container
+	do.Destination = path.Join(common.ErisContainerRoot, "keys", "data", do.Address)
+
+	if do.All && do.Address == "" {
+		doLs := definitions.NowDo()
+		doLs.Container = false
+		doLs.Host = true
+		doLs.Quiet = true
+		if err := ListKeys(doLs); err != nil {
 			return err
 		}
-		do.Source = common.AbsolutePath(wd, do.Source)
-	}
-	//dest in container
-	do.Destination = dir
-	if err := data.ImportData(do); err != nil {
-		return err
+		keyArray := strings.Split(do.Result, ",")
+
+		for _, addr := range keyArray {
+			do.Source = path.Join(common.KeysPath, "data", addr)
+			do.Destination = path.Join(common.ErisContainerRoot, "keys", "data", addr)
+			if err := data.ImportData(do); err != nil {
+				return err
+			}
+		}
+		//list keys
+		//for each, import data
+
+	} else {
+		if do.Source == filepath.Join(common.KeysPath, "data") {
+			do.Source = filepath.Join(common.KeysPath, "data", do.Address, do.Address)
+		} else { // either relative or absolute path given. get absolute
+			wd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			do.Source = common.AbsolutePath(wd, do.Source)
+		}
+		if err := data.ImportData(do); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/keys/writers.go
+++ b/keys/writers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/eris-ltd/eris-cli/definitions"
 	srv "github.com/eris-ltd/eris-cli/services"
 
-	. "github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
+	"github.com/eris-ltd/eris-cli/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 )
 
 func GenerateKey(do *definitions.Do) error {
@@ -52,6 +52,8 @@ func ExportKey(do *definitions.Do) error {
 		return err
 	}
 
+	//	do.Destination = ?
+
 	//src in container
 	do.Source = path.Join(ErisContainerRoot, "keys", "data", do.Address)
 	if err := data.ExportData(do); err != nil {
@@ -69,8 +71,14 @@ func ImportKey(do *definitions.Do) error {
 
 	//src on host
 	//if default given (from flag), join addrs
-	if do.Source == filepath.Join(KeysPath, "data") {
-		do.Source = filepath.Join(KeysPath, "data", do.Address, do.Address)
+	if do.Source == filepath.Join(common.KeysPath, "data") {
+		do.Source = filepath.Join(common.KeysPath, "data", do.Address, do.Address)
+	} else { // either relative or absolute path given. get absolute
+		wd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		do.Source = common.AbsolutePath(wd, do.Source)
 	}
 	//dest in container
 	do.Destination = dir

--- a/util/clean.go
+++ b/util/clean.go
@@ -199,7 +199,7 @@ func canWeRemove(toClean map[string]bool) bool {
 		}).Warn("The marmots are about to remove")
 	}
 
-	fmt.Print("Please confirm (y/N): ")
+	fmt.Print("Please confirm (y/n): ")
 
 	fmt.Scanln(&input)
 	if input == "Y" || input == "y" || input == "YES" || input == "Yes" || input == "yes" {


### PR DESCRIPTION
new flag to move all keys to and from container <=> host
- `eris keys import/export --all` => provide no address; uses default paths
- [x] todo: test paths properly (when I haz moar bandwidth)
- [x] add test for this new feature

closes #597 and #607