### PR TITLE
check chain and address flags on `eris pkgs do`

### DIFF
--- a/cmd/pkgs.go
+++ b/cmd/pkgs.go
@@ -106,6 +106,12 @@ func PackagesDo(cmd *cobra.Command, args []string) {
 		do.Path, err = os.Getwd()
 		IfExit(err)
 	}
+	if do.ChainName == "" {
+		IfExit(fmt.Errorf("please provide the name of a running chain with --chain"))
+	}
+	if do.DefaultAddr == "" {
+		IfExit(fmt.Errorf("please provide the address to deploy from with --address"))
+	}
 	IfExit(pkgs.RunPackage(do))
 }
 


### PR DESCRIPTION
closes #627 + address check (until we implement "checked out" addrs)