### PR TITLE
logsrotate -> logrotate

### DIFF
--- a/chains/operate.go
+++ b/chains/operate.go
@@ -116,7 +116,7 @@ func startChain(do *definitions.Do, exec bool) (buf *bytes.Buffer, err error) {
 		return nil, nil
 	}
 
-	// boot the dependencies (eg. keys, logsrotate)
+	// boot the dependencies (eg. keys, logrotate)
 	if err := bootDependencies(chain, do); err != nil {
 		return nil, err
 	}
@@ -177,8 +177,8 @@ func startChain(do *definitions.Do, exec bool) (buf *bytes.Buffer, err error) {
 // boot chain dependencies
 // TODO: this currently only supports simple services (with no further dependencies)
 func bootDependencies(chain *definitions.Chain, do *definitions.Do) error {
-	if do.Logsrotate {
-		chain.Dependencies.Services = append(chain.Dependencies.Services, "logsrotate")
+	if do.Logrotate {
+		chain.Dependencies.Services = append(chain.Dependencies.Services, "logrotate")
 	}
 	if chain.Dependencies != nil {
 		name := do.Name

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -415,7 +415,7 @@ func addChainsFlags() {
 	buildFlag(chainsNew, do, "publish", "chain")
 	buildFlag(chainsNew, do, "links", "chain")
 	buildFlag(chainsNew, do, "api", "chain")
-	chainsNew.PersistentFlags().BoolVarP(&do.Logsrotate, "logsrotate", "z", false, "turn on logsrotate as a dependency to handle long output")
+	chainsNew.PersistentFlags().BoolVarP(&do.Logrotate, "logrotate", "z", false, "turn on logrotate as a dependency to handle long output")
 
 	// buildFlag(chainsRegister, do, "links", "chain")
 	// buildFlag(chainsRegister, do, "env", "chain")
@@ -436,7 +436,7 @@ func addChainsFlags() {
 	buildFlag(chainsStart, do, "env", "chain")
 	buildFlag(chainsStart, do, "links", "chain")
 	buildFlag(chainsStart, do, "api", "chain")
-	chainsStart.PersistentFlags().BoolVarP(&do.Logsrotate, "logsrotate", "z", false, "turn on logsrotate as a dependency to handle long output")
+	chainsStart.PersistentFlags().BoolVarP(&do.Logrotate, "logrotate", "z", false, "turn on logrotate as a dependency to handle long output")
 
 	buildFlag(chainsLogs, do, "follow", "chain")
 	buildFlag(chainsLogs, do, "tail", "chain")

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -9,7 +9,7 @@ type Do struct {
 	Quiet         bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	All           bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Follow        bool     `mapstructure:"," json:"," yaml:"," toml:","`
-	Logsrotate    bool     `mapstructure:"," json:"," yaml:"," toml:","`
+	Logrotate     bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Run           bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Rm            bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	RmD           bool     `mapstructure:"," json:"," yaml:"," toml:","`

--- a/version/files.go
+++ b/version/files.go
@@ -11,7 +11,7 @@ var (
 		"ipfs.toml",
 		"keys.toml",
 		"logspout.toml",
-		"logsrotate.toml",
+		"logrotate.toml",
 		"mindy.toml",
 		"openbazaar.toml",
 		"rethinkdb.toml",


### PR DESCRIPTION
- re-names all instances of `logsrotate` to `logrotate`, as the service is called
- tied to https://github.com/eris-ltd/eris-services/pull/35
- closes #618 