### PR TITLE
Handle the situation when Eris root directory is missing and `eris init` is not called yet

### DIFF
--- a/chains/operate.go
+++ b/chains/operate.go
@@ -360,6 +360,7 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 	}
 	log.WithField("image", chain.Service.Image).Debug("Chain loaded")
 	chain.Operations.PublishAllPorts = do.Operations.PublishAllPorts // TODO: remove this and marshall into struct from cli directly
+	chain.Operations.Ports = do.Operations.Ports
 
 	// cmd should be "new" or "install"
 	chain.Service.Command = cmd

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -86,7 +86,7 @@ be tarballs or zip files, and **they will contain the private keys** so please
 be aware of that.
 
 The make process will *not* start a chain for you. You will want to use
-the [eris chains new chainName --dir chainName] for that which will import all 
+the [eris chains new chainName --dir chainName] for that which will import all
 of the files which make creates into containers and start your shiny new chain.
 
 If you have any questions on eris chains make, please see the eris-cm (chain manager)

--- a/cmd/eris.go
+++ b/cmd/eris.go
@@ -57,6 +57,14 @@ Complete documentation is available at https://docs.erisindustries.com
 			return
 		}
 
+		if !util.DoesDirExist(ErisRoot) {
+			log.Warn("Eris root directory doesn't exist. The marmots will initialize it for you")
+			if err := InitErisDir(); err != nil {
+				log.Errorf("Error: couldn't initialize the Eris root directory: %v", err)
+			}
+			log.Warn()
+		}
+
 		// Compare Docker client API versions.
 		dockerVersion, err := util.DockerClientVersion()
 		if err != nil {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -47,6 +47,8 @@ func buildFlag(cmd *cobra.Command, do *definitions.Do, flag, typ string) { //doe
 		//exec (services, chains)
 	case "publish":
 		cmd.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish random ports")
+	case "ports":
+		cmd.PersistentFlags().StringVarP(&do.Operations.Ports, "ports", "", "", "reassign ports")
 	case "interactive":
 		cmd.Flags().BoolVarP(&do.Operations.Interactive, "interactive", "i", false, "interactive shell")
 		//update

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -130,8 +130,16 @@ service into the background so its logs will not be viewable
 from the command line.
 
 To stop the service use:      [eris services stop NAME].
-To view a service's logs use: [eris services logs NAME].`,
+To view a service's logs use: [eris services logs NAME].
+
+You can redefine service ports accessible over the network with
+the --ports flag.
+`,
 	Run: StartService,
+
+	Example: `$ eris services start ipfs --ports 17000 -- map the first port from the definition file to the host port 17000
+$ eris services start ipfs --ports 17000,18000- -- redefine the first and the second port mappings and autoincrement the rest
+$ eris services start ipfs --ports 50000:5001 -- redefine the specific port mapping (published host port:exposed container port)`,
 }
 
 var servicesInspect = &cobra.Command{
@@ -246,6 +254,7 @@ func addServicesFlags() {
 	buildFlag(servicesExec, do, "links", "service")
 	servicesExec.Flags().StringVarP(&do.Operations.Volume, "volume", "", "", fmt.Sprintf("mount a volume %v/VOLUME on a host machine to a %v/VOLUME on a container", ErisRoot, ErisContainerRoot))
 	buildFlag(servicesExec, do, "publish", "service")
+	buildFlag(servicesExec, do, "ports", "service")
 	buildFlag(servicesExec, do, "interactive", "service")
 
 	buildFlag(servicesUpdate, do, "pull", "service")
@@ -259,6 +268,7 @@ func addServicesFlags() {
 	buildFlag(servicesRm, do, "rm-volumes", "service")
 
 	buildFlag(servicesStart, do, "publish", "service")
+	buildFlag(servicesStart, do, "ports", "service")
 	buildFlag(servicesStart, do, "env", "service")
 	buildFlag(servicesStart, do, "links", "service")
 	buildFlag(servicesStart, do, "chain", "service")

--- a/definitions/operation.go
+++ b/definitions/operation.go
@@ -14,6 +14,7 @@ type Operation struct {
 	AppName           string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	DockerHostConn    string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	Volume            string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
+	Ports             string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	Labels            map[string]string `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	PublishAllPorts   bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	CapAdd            []string          `mapstructure:",omitempty", json:",omitempty" yaml:",omitempty" toml:",omitempty"`

--- a/initialize/init.go
+++ b/initialize/init.go
@@ -13,7 +13,6 @@ import (
 )
 
 func Initialize(do *definitions.Do) error {
-	log.Warn("Checking for Eris root directory")
 	newDir, err := checkThenInitErisRoot(do.Quiet)
 	if err != nil {
 		return err
@@ -86,16 +85,16 @@ func InitDefaults(do *definitions.Do, newDir bool) error {
 func checkThenInitErisRoot(force bool) (bool, error) {
 	var newDir bool
 	if force { //for testing only
-		log.Warn("Force initializing eris root directory")
+		log.Warn("Force initializing Eris root directory")
 		if err := common.InitErisDir(); err != nil {
 			return true, fmt.Errorf("Error:\tcould not initialize the eris root directory.\n%s\n", err)
 		}
 		return true, nil
 	}
 	if !util.DoesDirExist(common.ErisRoot) {
-		log.Warn("Eris root directory does not exist. The marmots will initialize this directory for you")
+		log.Warn("Eris root directory doesn't exist. The marmots will initialize it for you")
 		if err := common.InitErisDir(); err != nil {
-			return true, fmt.Errorf("Error:\tcould not initialize the eris root directory.\n%s\n", err)
+			return true, fmt.Errorf("Error: couldn't initialize the Eris root directory: %v", err)
 		}
 		newDir = true
 	} else { // ErisRoot exists, prompt for overwrite
@@ -116,7 +115,7 @@ func checkIfCanOverwrite(doYes bool) error {
 	if doYes {
 		return nil
 	}
-	log.WithField("path", common.ErisRoot).Warn("Eris root directory already exists")
+	log.WithField("path", common.ErisRoot).Warn("Eris root directory")
 	log.WithFields(log.Fields{
 		"services path": common.ServicesPath,
 		"actions path":  common.ActionsPath,

--- a/list/containers.go
+++ b/list/containers.go
@@ -243,7 +243,7 @@ func render(buf *bytes.Buffer, t string, truncate bool, header, format string) e
 	if header != "" {
 		// Tabs are necessary so that the Tabwriter doesn't break
 		// on a newline (1 tab per column).
-		buf.WriteString("\t\t\t\t\t\n")
+		buf.WriteString("\t\t\t\t\t\t\n")
 	}
 	return nil
 }

--- a/util/containers.go
+++ b/util/containers.go
@@ -324,12 +324,3 @@ func SetLabel(labels map[string]string, name, value string) map[string]string {
 
 	return labels
 }
-
-// PortAndProtocol splits the port setting into a port and protocol
-// type (defaulting to "tcp").
-func PortAndProtocol(port string) docker.Port {
-	if len(strings.Split(port, "/")) == 1 {
-		port += "/tcp"
-	}
-	return docker.Port(port)
-}

--- a/util/ports.go
+++ b/util/ports.go
@@ -1,0 +1,108 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// PortAndProtol adds the protocol tag '/tcp' to the bare port number
+// if it's missing.
+func PortAndProtocol(port string) string {
+	if len(strings.Split(port, "/")) == 1 {
+		port += "/tcp"
+	}
+	return port
+}
+
+// PortComponents splits the port element from the definition file
+// into 3 components: an IP address (if any), the published port number,
+// and the exposed port number. The protocol tag is added to the exposed
+// port if it's missing (“8080” -> “8080/tcp”).
+//
+// Expected inputs:
+//
+//           published
+//           published:exposed
+//        IP:published:exposed
+//
+func PortComponents(port string) (ip, exposed, published string) {
+	if port == "" {
+		return "", "", ""
+	}
+
+	components := strings.Split(port, ":")
+
+	if strings.Count(port, ":") == 2 {
+		return components[0], components[1], PortAndProtocol(components[2])
+	}
+	if strings.Count(port, ":") == 1 {
+		return "", components[0], PortAndProtocol(components[1])
+	}
+	return "", port, PortAndProtocol(port)
+}
+
+// MapPorts reassigns ports mappings (usually taken from the chain or service
+// definition file) according to a list. MapPorts returns a map with keys
+// - exposed (container) ports and values - published ports (ports accessible
+// on the host network).
+//
+// Reassignment rules:
+//   <n>      - map the published port <n> to the container port in `ports`
+//              at this current position (slice-wise)
+//   <n>:<m>  - map the published port <n> to container port <m> in `ports`
+//   <n>-     - map the published port <n> to the exposed port in ports
+//              at this current position (slice-wise), and use the consecutive
+//              port numbers for the remaining ports in `ports`.
+//
+func MapPorts(ports, assignments []string) map[string]string {
+	m := make(map[string]string)
+
+	// First pass. Default mapping from the definition file.
+	for _, entry := range ports {
+		_, published, exposed := PortComponents(entry)
+
+		m[exposed] = published
+	}
+
+	// Second pass. Reassign ports.
+	var (
+		autoincrement     bool
+		autoincrementPort int
+	)
+	for i, entry := range ports {
+		_, _, exposed := PortComponents(entry)
+		if i < len(assignments) {
+			switch {
+			// Explicit mapping, e.g. “9001:9009”.
+			case strings.Contains(assignments[i], ":"):
+				_, published, exposed := PortComponents(assignments[i])
+				m[exposed] = published
+
+			// Autoincrement mapping, e.g. “9001-”.
+			case strings.HasSuffix(assignments[i], "-"):
+				rangeStart := strings.TrimRight(assignments[i], "-")
+
+				var err error
+				autoincrementPort, err = strconv.Atoi(rangeStart)
+				if err != nil {
+					continue
+				}
+
+				autoincrement = true
+
+				m[exposed] = rangeStart
+
+			// Simple reassignment.
+			default:
+				m[exposed] = assignments[i]
+			}
+		} else if autoincrement {
+			autoincrementPort += 1
+
+			m[exposed] = fmt.Sprintf("%d", autoincrementPort)
+		}
+	}
+
+	return m
+}

--- a/util/ports_test.go
+++ b/util/ports_test.go
@@ -1,0 +1,234 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+var PortAndProtocolTests = []struct {
+	in, out string
+}{
+	{"", "/tcp"},
+	{"53/udp", "53/udp"},
+	{"53", "53/tcp"},
+	{"53/tcp", "53/tcp"},
+	{"53/", "53/"},
+	{"53/test", "53/test"},
+}
+
+func TestPortAndProtocol(t *testing.T) {
+	for _, test := range PortAndProtocolTests {
+		if actual := PortAndProtocol(test.in); actual != test.out {
+			t.Fatalf("expected %q, got %v", test.out, actual)
+		}
+	}
+}
+
+var PortComponentsTests = []struct {
+	in, ip, published, exposed string
+}{
+	{"", "", "", ""},
+	{"8080", "", "8080", "8080/tcp"},
+	{"8080:8080", "", "8080", "8080/tcp"},
+	{"8080:8080/tcp", "", "8080", "8080/tcp"},
+	{"53:53/udp", "", "53", "53/udp"},
+
+	{"", "", "", ""},
+	{"127.0.0.1:8080:8080", "127.0.0.1", "8080", "8080/tcp"},
+	{"127.0.0.1:8080:8080/tcp", "127.0.0.1", "8080", "8080/tcp"},
+	{"127.0.0.1:53:53/udp", "127.0.0.1", "53", "53/udp"},
+	{"127.0.0.1:40:40/test", "127.0.0.1", "40", "40/test"},
+}
+
+func TestPortComponents(t *testing.T) {
+	for _, test := range PortComponentsTests {
+		ip, published, exposed := PortComponents(test.in)
+
+		if ip != test.ip {
+			t.Fatalf("expected IP %q, got %q, input %q", test.ip, ip, test.in)
+		}
+
+		if published != test.published {
+			t.Fatalf("expected published port %q, got %q, input %q", test.published, published, test.in)
+		}
+
+		if exposed != test.exposed {
+			t.Fatalf("expected exposed port %q, got %q, input %q", test.exposed, exposed, test.in)
+		}
+
+	}
+}
+
+var MapPortsTests = []struct {
+	name     string
+	ports    []string
+	mappings []string
+	out      map[string]string
+}{
+	{
+		"#1",
+		[]string{},
+		[]string{},
+		map[string]string{},
+	},
+	{
+		"#2",
+		[]string{"8080:8081"},
+		[]string{"8081"},
+		map[string]string{
+			"8081/tcp": "8081",
+		},
+	},
+	{
+		"#3",
+		[]string{"8080:8081"},
+		[]string{"8088"},
+		map[string]string{
+			"8081/tcp": "8088",
+		},
+	},
+	{
+		"#4",
+		[]string{"8080:8081"},
+		[]string{"8088:8080"},
+		map[string]string{
+			"8081/tcp": "8080",
+			"8080/tcp": "8088",
+		},
+	},
+	{
+		"#5",
+		[]string{"9000", "9001", "9002"},
+		[]string{},
+		map[string]string{
+			"9000/tcp": "9000",
+			"9001/tcp": "9001",
+			"9002/tcp": "9002",
+		},
+	},
+	{
+		"#6",
+		[]string{"9000:9000", "9001:9001", "9002:9002"},
+		[]string{},
+		map[string]string{
+			"9000/tcp": "9000",
+			"9001/tcp": "9001",
+			"9002/tcp": "9002",
+		},
+	},
+	{
+		"#7. mix",
+		[]string{"9002:9000", "9001:9001", "9000:9002"},
+		[]string{},
+		map[string]string{
+			"9000/tcp": "9002",
+			"9001/tcp": "9001",
+			"9002/tcp": "9000",
+		},
+	},
+	{
+		"#8. mix",
+		[]string{"9002:9000", "9001:9001", "9000:9002"},
+		[]string{"6001:9002", "6000:9001", "5999:9000", "5998:8999"},
+		map[string]string{
+			"9000/tcp": "5999",
+			"9001/tcp": "6000",
+			"9002/tcp": "6001",
+		},
+	},
+
+	{
+		"#9",
+		[]string{"9000:9001", "9001:9002", "9002:9003"},
+		[]string{},
+		map[string]string{
+			"9001/tcp": "9000",
+			"9002/tcp": "9001",
+			"9003/tcp": "9002",
+		},
+	},
+	{
+		"#10",
+		[]string{"9000", "9001", "9002"},
+		[]string{"9900-"},
+		map[string]string{
+			"9000/tcp": "9900",
+			"9001/tcp": "9901",
+			"9002/tcp": "9902",
+		},
+	},
+	{
+		"#11",
+		[]string{"9002", "9001", "9000"},
+		[]string{"9900-"},
+		map[string]string{
+			"9002/tcp": "9900",
+			"9001/tcp": "9901",
+			"9000/tcp": "9902",
+		},
+	},
+	{
+		"#12",
+		[]string{"9000:9000", "9001:9001", "9002:9002"},
+		[]string{"5000", "5010", "5020"},
+		map[string]string{
+			"9000/tcp": "5000",
+			"9001/tcp": "5010",
+			"9002/tcp": "5020",
+		},
+	},
+	{
+		"#13. handling ips",
+		[]string{"127.0.0.1:9000:9000", "9001:9001", "127.0.0.1:9002:9002"},
+		[]string{"5000", "5010", "5020"},
+		map[string]string{
+			"9000/tcp": "5000",
+			"9001/tcp": "5010",
+			"9002/tcp": "5020",
+		},
+	},
+	{
+		"#14",
+		[]string{"127.0.0.1:9000:9000/tcp", "9001:9001/tcp", "127.0.0.1:9002:9002/tcp"},
+		[]string{"5000", "5010", "5020"},
+		map[string]string{
+			"9000/tcp": "5000",
+			"9001/tcp": "5010",
+			"9002/tcp": "5020",
+		},
+	},
+	{
+		"#15",
+		[]string{"9000:9000", "9001:9001", "9002:9002"},
+		[]string{"5000-", "6000-"},
+		map[string]string{
+			"9000/tcp": "5000",
+			"9001/tcp": "6000",
+			"9002/tcp": "6001",
+		},
+	},
+	{
+		"#16. broken range",
+		[]string{"9001:9000"},
+		[]string{"xxxx-", "6000-"},
+		map[string]string{
+			"9000/tcp": "9001",
+		},
+	},
+	{
+		"#17. broken range",
+		[]string{"9001:9000"},
+		[]string{"-", "6000-"},
+		map[string]string{
+			"9000/tcp": "9001",
+		},
+	},
+}
+
+func TestMapPorts(t *testing.T) {
+	for _, test := range MapPortsTests {
+		if actual := MapPorts(test.ports, test.mappings); reflect.DeepEqual(actual, test.out) != true {
+			t.Fatalf("%s. expected %v, got %v, input ports:%v, mappings:%v", test.name, test.out, actual, test.ports, test.mappings)
+		}
+	}
+}


### PR DESCRIPTION
This PR closes the #512 issue.