### PR TITLE
flag to remove service

### DIFF
--- a/cmd/services.go
+++ b/cmd/services.go
@@ -266,6 +266,7 @@ func addServicesFlags() {
 	buildFlag(servicesRm, do, "file", "service")
 	buildFlag(servicesRm, do, "data", "service")
 	buildFlag(servicesRm, do, "rm-volumes", "service")
+	servicesRm.Flags().BoolVarP(&do.RmImage, "image", "", false, "remove the services' docker image")
 
 	buildFlag(servicesStart, do, "publish", "service")
 	buildFlag(servicesStart, do, "ports", "service")

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -13,6 +13,7 @@ type Do struct {
 	Logrotate     bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Run           bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Rm            bool     `mapstructure:"," json:"," yaml:"," toml:","`
+	RmImage       bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	RmD           bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	RmHF          bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Services      bool     `mapstructure:"," json:"," yaml:"," toml:","`

--- a/perform/perform.go
+++ b/perform/perform.go
@@ -638,6 +638,14 @@ func DockerRemove(srv *def.Service, ops *def.Operation, withData, volumes, force
 	return nil
 }
 
+// DockerRemoveImage removes the image specified by name
+func DockerRemoveImage(name string, force bool) error {
+	removeOpts := docker.RemoveImageOptions{
+		Force:         force,
+	}
+	return util.DockerClient.RemoveImageExtended(name, removeOpts)
+}
+
 // ContainerExists returns true if the container specified
 // by a long name exists, false otherwise.
 func ContainerExists(name string) bool {

--- a/services/manage.go
+++ b/services/manage.go
@@ -229,8 +229,13 @@ func RmService(do *definitions.Do) error {
 			return err
 		}
 		if util.IsService(service.Service.Name, false) {
-			err = perform.DockerRemove(service.Service, service.Operations, do.RmD, do.Volumes, do.Force)
-			if err != nil {
+			if err := perform.DockerRemove(service.Service, service.Operations, do.RmD, do.Volumes, do.Force); err != nil {
+				return err
+			}
+		}
+
+		if do.RmImage {
+			if err := perform.DockerRemoveImage(service.Service.Image, true); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
closes #637 
e.g. `eris services rm tor --image` will remove the image specified in `~/.eris/services/tor.toml`