### PR TITLE
config: useful viper error, closes #639

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,7 +65,7 @@ func LoadViperConfig(configPath, configName, typ string) (*viper.Viper, error) {
 	conf.SetConfigName(configName)
 	err := conf.ReadInConfig()
 	if err != nil {
-		return nil, fmt.Errorf("Unable to load the %s's config for the %s in %s.\nCheck your known %ss with [eris %ss ls --known]", typ, configName, configPath, typ, typ)
+		return nil, fmt.Errorf("Unable to load the %s's config for the %s in %s.\nCheck your known %ss with [eris %ss ls --known]\nThere may also be an error with the formatting of the .toml file:\n%v", typ, configName, configPath, typ, typ, err)
 	}
 
 	return conf, nil


### PR DESCRIPTION
example:
Then:
`eris service start marmot`
where `marmot.toml` has `data_container = truth` (rather than true)
error message => 
```
Unable to load the service's config for the marmot in /root/.eris/services.
Check your known services with [eris services ls --known]
```
Now:
```
Unable to load the service's config for the marmot in /root/.eris/services.
Check your known services with [eris services ls --known]
There may also be an error with the formatting of the .toml file:
While parsing config: Near line 15 (last key parsed 'service.data_container'): Expected "tru", but found "trt" instead.
```
