### PR TITLE
Fix builds on Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ environment:
   PATH: '%PATH%;C:\bin'
   MACHINE_NAME: 'eris-test-win-%APPVEYOR_BUILD_ID%'
   SKIP_STACK: "true" # remove later when stack tests work on windows.
+  DOCKER_VERSION: 1.10.0
+  DOCKER_MACHINE_VERSION: 0.4.1
   AWS_ACCESS_KEY_ID:
     secure: qHdpZ2qgqg7LcbD1GJJ5JHPZJ1Bn0dQ8LoXgZpKrXBQ=
   AWS_SECRET_ACCESS_KEY:
@@ -28,9 +30,9 @@ build_script:
 
     choco install -yr jq
 
-    choco install -yr docker -version 1.10.0
+    choco install -yr docker -version %DOCKER_VERSION%
 
-    choco install -yr docker-machine -version 0.4.1
+    choco install -yr docker-machine -version %DOCKER_MACHINE_VERSION%
 
     cd c:\src\github.com\eris-ltd\eris-cli\cmd\eris
 

--- a/tests/machines/docker.sh
+++ b/tests/machines/docker.sh
@@ -50,7 +50,7 @@
 # -----------------------------------------------------------------------------
 # Set defaults
 
-default_docker="1.10.1"
+default_docker="1.10.2"
 
 # -----------------------------------------------------------------------------
 # Check Ubuntu
@@ -116,6 +116,7 @@ echo "Docker installed"
 
 echo "Restarting Newly Installed Docker"
 echo
+sed -i.bak -e 's/--raw-logs//g' /etc/init/docker.conf
 service docker start
 sleep 3 # boot time
 

--- a/tests/machines/setup.go
+++ b/tests/machines/setup.go
@@ -14,10 +14,9 @@ import (
 	"github.com/pborman/uuid"
 )
 
-var docker18s = []string{"1.8.0", "1.8.1", "1.8.2", "1.8.3"}
 var docker19s = []string{"1.9.0", "1.9.1"}
 var docker110s = []string{"1.10.2", "1.10.3"}
-var dockerAll = [][]string{docker18s, docker19s, docker110s}
+var dockerAll = [][]string{docker19s, docker110s}
 
 var dmDriver = "amazonec2"
 var script = "docker.sh"


### PR DESCRIPTION
* Edit out the discrepancy between the Ubuntu Upstart config `/etc/init/docker.conf` installed by the Docker Machine 0.4.1 containing an outdated Docker flag `--raw-logs` and the newer Docker version installed by the `docker.sh` script which doesn't expect that flag.