### PR TITLE
Remove the word “API” and HTTP status codes from Docker client errors

### DIFF
--- a/cmd/eris.go
+++ b/cmd/eris.go
@@ -75,7 +75,7 @@ Complete documentation is available at https://docs.erisindustries.com
 		// Compare Docker client API versions.
 		dockerVersion, err := util.DockerClientVersion()
 		if err != nil {
-			IfExit(fmt.Errorf("There was an error connecting to your docker daemon.\nCome back after you have resolved the issue and the marmots will be happy to service your blockchain management needs\n\n%v", err))
+			IfExit(fmt.Errorf("There was an error connecting to your Docker daemon.\nCome back after you have resolved the issue and the marmots will be happy to service your blockchain management needs: %v", util.DockerError(err)))
 		}
 		marmot := "Come back after you have upgraded and the marmots will be happy to service your blockchain management needs"
 		if !util.CompareVersions(dockerVersion, dVerMin) {

--- a/data/operate.go
+++ b/data/operate.go
@@ -81,13 +81,13 @@ func ImportData(do *definitions.Do) error {
 		log.WithField("=>", containerName).Info("Copying into container")
 		log.WithField("path", do.Source).Debug()
 		if err := util.DockerClient.UploadToContainer(srv.Operations.SrvContainerName, opts); err != nil {
-			return err
+			return util.DockerError(err)
 		}
 
 		//required b/c `docker cp` (UploadToContainer) goes in as root
 		// and eris images have the `eris` user by default
 		if err := runData(containerName, []string{"chown", "--recursive", "eris", do.Destination}); err != nil {
-			return err
+			return util.DockerError(err)
 		}
 
 	} else {

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -146,7 +146,7 @@ func pullDefaultImages() error {
 				opts.Repository = image
 				opts.Registry = ver.ERIS_REG_BAK
 				if err := util.DockerClient.PullImage(opts, auth); err != nil {
-					ch <- err
+					ch <- util.DockerError(err)
 				}
 			}
 		}()

--- a/util/clean.go
+++ b/util/clean.go
@@ -65,13 +65,13 @@ func cleanHandler(toClean map[string]bool) error {
 func RemoveAllErisContainers() error {
 	contns, err := DockerClient.ListContainers(docker.ListContainersOptions{All: true})
 	if err != nil {
-		return fmt.Errorf("error listing containers: %v\n", err)
+		return fmt.Errorf("Error listing containers: %v", DockerError(err))
 	}
 
 	for _, container := range contns {
 		if container.Labels[def.LabelEris] == "true" {
 			if err := removeContainer(container.ID); err != nil {
-				return fmt.Errorf("error removing container: %v\n", err)
+				return fmt.Errorf("Error removing container: %v", DockerError(err))
 			}
 		}
 	}
@@ -116,7 +116,7 @@ func RemoveErisImages() error {
 	}
 	allTheImages, err := DockerClient.ListImages(opts)
 	if err != nil {
-		return err
+		return DockerError(err)
 	}
 
 	//get all repo tags & IDs
@@ -151,7 +151,7 @@ func RemoveErisImages() error {
 			"id": imageID,
 		}).Debug("Removing image")
 		if err := DockerClient.RemoveImage(imageID); err != nil {
-			return err
+			return DockerError(err)
 		}
 	}
 	return nil

--- a/util/containers_test.go
+++ b/util/containers_test.go
@@ -312,17 +312,17 @@ func create(t, name string) error {
 
 	_, err := DockerClient.CreateContainer(opts)
 	if err != nil {
-		return err
+		return DockerError(err)
 	}
 	return nil
 }
 
 func start(name string) error {
-	return DockerClient.StartContainer(name, nil)
+	return DockerError(DockerClient.StartContainer(name, nil))
 }
 
 func stop(name string) error {
-	return DockerClient.StopContainer(name, 10)
+	return DockerError(DockerClient.StopContainer(name, 10))
 }
 
 func remove(name string) error {

--- a/util/inspect.go
+++ b/util/inspect.go
@@ -43,7 +43,7 @@ func PrintInspectionReport(cont *docker.Container, field string) error {
 func PrintLineByContainerID(containerID string, existing bool) ([]string, error) {
 	cont, err := DockerClient.InspectContainer(containerID)
 	if err != nil {
-		return nil, err
+		return nil, DockerError(err)
 	}
 	return printLine(cont, existing)
 }
@@ -51,7 +51,7 @@ func PrintLineByContainerID(containerID string, existing bool) ([]string, error)
 func PrintPortMappings(id string, ports []string) error {
 	cont, err := DockerClient.InspectContainer(id)
 	if err != nil {
-		return err
+		return DockerError(err)
 	}
 
 	log.Warn(ParsePortMappings(cont.NetworkSettings.Ports, ports))


### PR DESCRIPTION
Make the Docker client errors look like this 
```
Error moving keys: Docker: Cannot link to a non running container: /cd-865e4f22-2287-4dae-b243-3d6bc494cdb4 AS /interactive-c56359f1-9c89-449f-b0e9-64d78b046f63/chain
```
instead of
```
Error moving keys: API error (500): Cannot link to a non running container: /cd-36677ba8-0707-4774-8485-53471a08089c AS /interactive-6bbd0adf-0f98-4be4-97c9-7fb16eaaaef7/chain
```