### PR TITLE
by default eris should not allocate containers a tty

### DIFF
--- a/perform/perform.go
+++ b/perform/perform.go
@@ -960,7 +960,7 @@ func configureServiceContainer(srv *def.Service, ops *def.Operation) docker.Crea
 			AttachStdin:     false,
 			AttachStdout:    false,
 			AttachStderr:    false,
-			Tty:             true,
+			Tty:             false,
 			OpenStdin:       false,
 			Env:             srv.Environment,
 			Labels:          ops.Labels,


### PR DESCRIPTION
This pull request fixes our logspout problem.

Glider's image does not logspout containers which are started with a tty. Since we expressly give a tty to interactive containers, and since they are the only ones which *should* get a tty, I have changed this default. 