### PR TITLE
Fix Circle CI false positives

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -108,7 +108,8 @@ check_build() {
   then
     echo "Could not build eris image. Rebuilding eris image."
     sleep 5
-    build_eris $BRANCH
+    build_eris $BRANCH &
+    wait $!
     build_result=$?
     check_build "rebuild"
   elif [ "$build_result" -ne 0 ] && [ ! -z $1 ]


### PR DESCRIPTION
Fix occasional erroneous "green" results on Circle CI when retrying to rebuild the Eris image.