### PR TITLE
Fix missing Eris root directory error after `clean --dir` or `clean --all`

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"github.com/eris-ltd/eris-cli/clean"
 
+	. "github.com/eris-ltd/common/go/common"
+
 	"github.com/spf13/cobra"
 )
 
@@ -33,7 +35,6 @@ func addCleanFlags() {
 }
 
 func CleanItUp(cmd *cobra.Command, args []string) {
-
 	if do.All {
 		do.Containers = true
 		do.Scratch = true
@@ -41,7 +42,5 @@ func CleanItUp(cmd *cobra.Command, args []string) {
 		do.Images = true
 	}
 
-	if err := clean.Clean(do); err != nil {
-		return
-	}
+	IfExit(clean.Clean(do))
 }

--- a/cmd/eris.go
+++ b/cmd/eris.go
@@ -93,9 +93,12 @@ Complete documentation is available at https://docs.erisindustries.com
 	},
 
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		err := config.SaveGlobalConfig(config.GlobalConfig.Config)
-		if err != nil {
-			log.Errorln(err)
+		if !util.DoesDirExist(ErisRoot) {
+			return
+		}
+
+		if err := config.SaveGlobalConfig(config.GlobalConfig.Config); err != nil {
+			log.Error(err)
 		}
 	},
 }


### PR DESCRIPTION
```
$ ./eris clean -y --all
(no errors)
```

```
$ ./eris clean -y --dir
(no errors)
```

Closes #644.