### PR TITLE
chains: --dir flag added to rm

### DIFF
--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -442,7 +442,7 @@ func TestRmChain(t *testing.T) {
 	do = def.NowDo()
 	do.Name = chainName
 	do.RmD = true
-	if err := RmChain(do); err != nil {
+	if err := RemoveChain(do); err != nil {
 		t.Fatalf("expected chain to be removed, got %v", err)
 	}
 	if util.Exists(def.TypeChain, chainName) {

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -449,7 +449,7 @@ func UpdateChain(do *definitions.Do) error {
 	return nil
 }
 
-func RmChain(do *definitions.Do) error {
+func RemoveChain(do *definitions.Do) error {
 	chain, err := loaders.LoadChainDefinition(do.Name, false)
 	if err != nil {
 		return err
@@ -473,6 +473,16 @@ func RmChain(do *definitions.Do) error {
 			return err
 		}
 	}
+
+	if do.RmHF {
+		dirPath := filepath.Join(ChainsPath, do.Name) // the dir
+
+		log.WithField("directory", dirPath).Warn("Removing directory")
+		if err := os.RemoveAll(dirPath); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/chains/operate.go
+++ b/chains/operate.go
@@ -268,7 +268,7 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 		if err != nil {
 			log.Infof("Error on setting up chain: %v", err)
 			log.Info("Cleaning up")
-			if err2 := RmChain(do); err2 != nil {
+			if err2 := RemoveChain(do); err2 != nil {
 				// maybe be less dramatic
 				err = fmt.Errorf("Tragic! Our marmots encountered an error during setupChain for %s.\nThey also failed to cleanup after themselves (remove containers) due to another error.\nFirst error =>\t\t\t%v\nCleanup error =>\t\t%v\n", containerName, err, err2)
 			}

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -473,12 +473,13 @@ func addChainsFlags() {
 	buildFlag(chainsExec, do, "ports", "chain")
 	buildFlag(chainsExec, do, "interactive", "chain")
 	buildFlag(chainsExec, do, "links", "chain")
-	chainsExec.Flags().StringVarP(&do.Image, "image", "", "", "Docker image")
+	chainsExec.Flags().StringVarP(&do.Image, "image", "", "", "docker image")
 
 	buildFlag(chainsRemove, do, "force", "chain")
 	buildFlag(chainsRemove, do, "file", "chain")
 	buildFlag(chainsRemove, do, "data", "chain")
 	buildFlag(chainsRemove, do, "rm-volumes", "chain")
+	chainsRemove.Flags().BoolVarP(&do.RmHF, "dir", "", false, "remove the chain directory in ~/.eris/chains")
 
 	buildFlag(chainsUpdate, do, "pull", "chain")
 	buildFlag(chainsUpdate, do, "timeout", "chain")
@@ -712,7 +713,7 @@ func RestartChain(cmd *cobra.Command, args []string) {
 func RmChain(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "ge", cmd, args))
 	do.Name = args[0]
-	IfExit(chns.RmChain(do))
+	IfExit(chns.RemoveChain(do))
 }
 
 func GraduateChain(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
- `eris chains rm oldChain --dir` will now remove the directory `~/.eris/chains/oldChain`
- this flag complements `eris chains rm oldChain --file` which removes the chain definition file:
`~/.eris/chains/oldChain.toml`
- `chains.RmChain()` renamed to `chains.RemoveChain()` for clarity
-  closes #664