### PR TITLE
Don't autoinitialize when running `eris init`

### DIFF
--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -18,7 +18,7 @@ var newName string = "yeah lets test shit"
 var hash string
 
 func TestMain(m *testing.M) {
-	log.SetFormatter(logger.ErisFormatter{})
+	log.SetFormatter(logger.ConsoleFormatter(log.DebugLevel))
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -29,7 +29,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	log.SetFormatter(logger.ErisFormatter{})
+	log.SetFormatter(logger.ConsoleFormatter(log.DebugLevel))
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -16,11 +16,11 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/eris-ltd/common/go/common"
 	logger "github.com/eris-ltd/common/go/log"
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 func TestMain(m *testing.M) {
-	log.SetFormatter(logger.ErisFormatter{})
+	log.SetFormatter(logger.ConsoleFormatter(log.DebugLevel))
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)

--- a/cmd/eris.go
+++ b/cmd/eris.go
@@ -58,7 +58,7 @@ Complete documentation is available at https://docs.erisindustries.com
 			return
 		}
 
-		if !util.DoesDirExist(ErisRoot) {
+		if !util.DoesDirExist(ErisRoot) && cmd.Use != "init" {
 			log.Warn("Eris root directory doesn't exist. The marmots will initialize it for you")
 			do := definitions.NowDo()
 			do.Yes = true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,7 +16,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	log.SetFormatter(logger.ErisFormatter{})
+	log.SetFormatter(logger.ConsoleFormatter(log.DebugLevel))
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -17,7 +17,7 @@ var dataName string = "dataTest1"
 var newName string = "dataTest2"
 
 func TestMain(m *testing.M) {
-	log.SetFormatter(logger.ErisFormatter{})
+	log.SetFormatter(logger.ConsoleFormatter(log.DebugLevel))
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -26,7 +26,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	log.SetFormatter(logger.ErisFormatter{})
+	log.SetFormatter(logger.ConsoleFormatter(log.DebugLevel))
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)
@@ -114,7 +114,7 @@ func TestGetFiles(t *testing.T) {
 		}
 	}
 	if !passed {
-	// final time will throw
+		// final time will throw
 		if err := GetFiles(do); err != nil {
 			t.Fatalf("err getting files %v\n", err)
 		}

--- a/initialize/initialize_test.go
+++ b/initialize/initialize_test.go
@@ -27,8 +27,7 @@ var chnDefDir = filepath.Join(chnDir, "default")
 var toadUp bool
 
 func TestMain(m *testing.M) {
-
-	log.SetFormatter(logger.ErisFormatter{})
+	log.SetFormatter(logger.ConsoleFormatter(log.DebugLevel))
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.SetFormatter(logger.ErisFormatter{})
+	log.SetFormatter(logger.ConsoleFormatter(log.DebugLevel))
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.SetFormatter(logger.ErisFormatter{})
+	log.SetFormatter(logger.ConsoleFormatter(log.DebugLevel))
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)

--- a/pkgs/packages_test.go
+++ b/pkgs/packages_test.go
@@ -29,7 +29,7 @@ var badPkg string = filepath.Join(AppsPath, "bad", "package.json")
 var emptyPkg string = filepath.Join(AppsPath, "empty", "package.json")
 
 func TestMain(m *testing.M) {
-	log.SetFormatter(logger.ErisFormatter{})
+	log.SetFormatter(logger.ConsoleFormatter(log.DebugLevel))
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -23,7 +23,7 @@ import (
 const servName = "ipfs"
 
 func TestMain(m *testing.M) {
-	log.SetFormatter(logger.ErisFormatter{})
+	log.SetFormatter(logger.ConsoleFormatter(log.DebugLevel))
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)

--- a/util/migrate_dirs_test.go
+++ b/util/migrate_dirs_test.go
@@ -27,7 +27,7 @@ var apps string = filepath.Join(erisDir, "apps")
 var newDirs = []string{chains, apps}
 
 func TestMain(m *testing.M) {
-	log.SetFormatter(logger.ErisFormatter{})
+	log.SetFormatter(logger.ConsoleFormatter(log.DebugLevel))
 
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)

--- a/vendor/github.com/eris-ltd/common/README.md
+++ b/vendor/github.com/eris-ltd/common/README.md
@@ -1,0 +1,2 @@
+# common
+common tidbits of go

--- a/vendor/github.com/eris-ltd/common/go/types/types.go
+++ b/vendor/github.com/eris-ltd/common/go/types/types.go
@@ -1,0 +1,233 @@
+package types
+
+import (
+	"time"
+)
+
+type (
+
+	// A default object that implements 'Event'
+	Event struct {
+		Event     string
+		Target    string
+		Resource  interface{}
+		Source    string
+		TimeStamp time.Time
+	}
+
+	Addresses struct {
+		ActiveAddress string
+		AddressList   []string
+	}
+
+	Account struct {
+		Address string
+		Balance string
+		Nonce   string
+		Script  string
+		Storage *Storage
+
+		IsScript bool
+	}
+
+	// Ordered map for storage in an account or generalized table
+	Storage struct {
+		// hex strings for eth, arrays of strings (cols) for sql dbs
+		Storage map[string]string
+		Order   []string
+	}
+
+	// Ordered map for all accounts
+	State struct {
+		State map[string]*Storage // map addrs to map of storage to value
+		Order []string            // ordered addrs and ordered storage inside
+	}
+
+	WorldState struct {
+		Accounts map[string]*Account
+		Order    []string
+	}
+
+	BlockMini struct {
+		Number           string
+		Hash             string
+		Transactions     int
+		PrevHash         string
+		AccountsAffected []*AccountMini
+	}
+
+	StateAtArgs struct {
+		Address string
+		Storage string
+	}
+
+	TransactionArgs struct {
+		BlockHash string
+		TxHash    string
+	}
+
+	Block struct {
+		Number       string
+		Time         int
+		Nonce        string
+		Hash         string
+		PrevHash     string
+		Difficulty   string
+		Coinbase     string
+		Transactions []*Transaction
+		Uncles       []string
+		GasLimit     string
+		GasUsed      string
+		MinGasPrice  string
+		TxRoot       string
+		UncleRoot    string
+	}
+
+	Transaction struct {
+		ContractCreation bool
+		Nonce            string
+		Hash             string
+		Sender           string
+		Recipient        string
+		Value            string
+		Gas              string
+		GasCost          string
+		BlockHash        string
+		Inputs           []*Input
+		Outputs          []*Output
+		Error            string
+	}
+
+	Input struct {
+		PrevOut struct {
+			Address string
+			Number  int64
+			Type    int64
+			Value   int64
+		}
+		Script string
+	}
+
+	Output struct {
+		Address string
+		Number  int64
+		Type    int64
+		Value   int64
+	}
+
+	TxIndata struct {
+		Recipient string
+		Gas       string
+		GasCost   string
+		Value     string
+		// endline is the separator for tx data. Each string is padded with 0's to become 32 bytes.
+		Data string
+	}
+
+	TxReceipt struct {
+		Success  bool   // If transaction hash was created basically.
+		Compiled bool   // If a contract was created, and the txdata was successfully compiled.
+		Address  string // If a contract was created.
+		Hash     string // Transaction hash
+		Error    string
+	}
+
+	AccountMini struct {
+		// Modified (0), Added (1), Deleted(2)
+		Flag     int
+		Contract bool
+		Address  string
+		Nonce    string
+		Balance  string
+	}
+)
+
+func ToMap(obj interface{}) map[string]interface{} {
+	mp := make(map[string]interface{})
+	switch o := obj.(type) {
+	case *Addresses:
+		mp["ActiveAddress"] = o.ActiveAddress
+		mp["AddressList"] = o.AddressList
+		break
+	case *Account:
+		mp["Address"] = o.Address
+		mp["Balance"] = o.Balance
+		mp["IsScript"] = o.IsScript
+		mp["Nonce"] = o.Nonce
+		mp["Script"] = o.Script
+		mp["Storage"] = ToMap(o.Storage)
+		break
+	case *Storage:
+		mp["Order"] = o.Order
+		mp["Storage"] = o.Storage
+		break
+	case *State:
+		mp["Order"] = o.Order
+		stmp := make(map[string]map[string]interface{})
+		for k, v := range o.State {
+			stmp[k] = ToMap(v)
+		}
+		mp["Storage"] = stmp
+		break
+	case *WorldState:
+		mp["Order"] = o.Order
+		stmp := make(map[string]map[string]interface{})
+		for k, v := range o.Accounts {
+			stmp[k] = ToMap(v)
+		}
+		mp["Accounts"] = stmp
+		break
+	case *AccountMini:
+		mp["Address"] = o.Address
+		mp["Balance"] = o.Balance
+		mp["Contract"] = o.Contract
+		mp["Flag"] = o.Flag
+		mp["Nonce"] = o.Nonce
+		break
+	case *BlockMini:
+		mp["Hash"] = o.Hash
+		mp["Number"] = o.Number
+		mp["PrevHash"] = o.PrevHash
+		mp["Transactions"] = o.Transactions
+		aamp := make([]map[string]interface{}, len(o.AccountsAffected))
+		for k, v := range o.AccountsAffected {
+			aamp[k] = ToMap(v)
+		}
+		break
+	case *Block:
+		mp["Coinbase"] = o.Coinbase
+		mp["Difficulty"] = o.Difficulty
+		mp["GasLimit"] = o.GasLimit
+		mp["GasUsed"] = o.GasUsed
+		mp["Hash"] = o.Hash
+		mp["MinGasPrice"] = o.MinGasPrice
+		mp["Nonce"] = o.Nonce
+		mp["Number"] = o.Number
+		mp["PrevHash"] = o.PrevHash
+		mp["Time"] = o.Time
+		mp["TxRoot"] = o.TxRoot
+		mp["UncleRoot"] = o.UncleRoot
+		mp["Uncles"] = o.Uncles
+
+		mp["Transactions"] = o.Transactions
+		txmp := make([]map[string]interface{}, len(o.Transactions))
+		for k, v := range o.Transactions {
+			txmp[k] = ToMap(v)
+		}
+		break
+	case *Transaction:
+		mp["BlockHash"] = o.BlockHash
+		mp["ContractCreation"] = o.ContractCreation
+		mp["Error"] = o.Error
+		mp["Gas"] = o.Gas
+		mp["GasCost"] = o.GasCost
+		mp["Hash"] = o.Hash
+		mp["Nonce"] = o.Nonce
+		mp["Recipient"] = o.Recipient
+		mp["Sender"] = o.Sender
+		mp["Value"] = o.Value
+		break
+	}
+
+	return mp
+}


### PR DESCRIPTION
This PR includes:

* Don't autoinitialize when the Eris root directory is not present and the `eris init` command is invoked. This prevents from initializing the Eris root directory 2 times.
* Make the `eris clean` command clean containers with and without labels (containers with `eris_` names). This accounts for a (not frequent) situation that due to a bug, occasionally data containers are created without labels — this adds a degree of comfort for users who won't need to invoke the `docker rm` command. (The bug is fixed on #develop.)
* Use proper logger initialization in tests.