### PR TITLE
Do not assume bash is installed.

### DIFF
--- a/services/services_test.go
+++ b/services/services_test.go
@@ -143,7 +143,7 @@ func TestExecService(t *testing.T) {
 		t.Fatalf("expected to execute service, got %v", err)
 	}
 
-	if !strings.Contains(buf.String(), ".bashrc") {
+	if !strings.Contains(buf.String(), ".") {
 		t.Fatalf("expected a file in the exec output, got %v", buf.String())
 	}
 }


### PR DESCRIPTION
Needed to pass tests on alpine base images.