### PR TITLE
agent: download/install via tarball (additional functionality)

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -9,11 +9,9 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	//	"time"
 
 	"github.com/eris-ltd/eris-cli/chains"
 	"github.com/eris-ltd/eris-cli/definitions"
-	//	"github.com/eris-ltd/eris-cli/files"
 	"github.com/eris-ltd/eris-cli/keys"
 	"github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/tests"
@@ -136,7 +134,7 @@ func testMakeABundle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-
+	// [zr] we could pull these from GH ...?
 	// write to them
 	idiSol := `
 contract IdisContractsFTW {
@@ -268,17 +266,15 @@ func kill(t *testing.T, serviceName string, wipe bool) {
 	}
 }
 
-///TODO! deal with all this
+//TODO set this up right
 /*
 func _TestAuthenticateUser(t *testing.T) {
-	//TODO set this up right
 	user := "sire"
 	if !AuthenticateUser(user) {
 		t.Fatalf("permissioned denied")
 	}
 }
 
-// XXX ignoring this feature for now
 func _TestAuthenticateAgent(t *testing.T) {
 	// is the name of the agent registered with eris?
 	// similar to above, or duplicate??

--- a/agent/operate.go
+++ b/agent/operate.go
@@ -151,7 +151,7 @@ func InstallAgent(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-		} else if whichHash == "ipfs-hash" { // not directly tarball, get from ipfs
+		} else if whichHash == "ipfs-hash" {
 			if err := downloadBundleFromIPFS(params); err != nil {
 				errMsg := fmt.Sprintf("error downloading bundle: %v", err)
 				http.Error(w, errMsg, http.StatusInternalServerError)
@@ -182,18 +182,17 @@ func InstallAgent(w http.ResponseWriter, r *http.Request) {
 func checkHash(hash string) (string, error) {
 	splitHash := strings.Split(hash, ".")
 	if len(splitHash) >= 3 { // somefile.tar.gz for example
-		log.Warn("maybe a tarball")
 		lenTAR := len(splitHash) - 2
 		lenGZ := len(splitHash) - 1
 		//probably not ipfs hash & probably tar ball
 		if splitHash[lenGZ] == "gz" && splitHash[lenTAR] == "tar" {
-			log.Warn("is a tarball")
+			log.Debug("hash provided appears to be a tarball")
 			return "tarball", nil
 		}
 	}
 
 	if len(hash) == 46 { // ipfs hash
-		log.Warn("is a IPFs hash")
+		log.Debug("hash provided appears to be an IPFS hash")
 		return "ipfs-hash", nil
 	}
 

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -16,16 +16,17 @@ var Agents = &cobra.Command{
 An agent is local server that, when started,  exposes three endpoints:
   
   /chains	=> list running chains on the host (GET)
-  /download	=> download a tar'ed contract bundle
-  /install	=> download and deploy and tar'ed bundle
+  /download	=> download a tar'ed contract bundle (POST)
+  /install	=> download and deploy and tar'ed bundle (POST)
 
 The command is used to support the Eris Contracts Library Marketplace.
 
-Please see the pull request for more information about using the agent and its endpoints
+Please see the pull request for more information about using 
+the agent and its endpoints:
  
   https://github.com/eris-ltd/eris-cli/pull/632
   
-The agent is stopped with Ctrl+C`,
+The agent is stopped with ctrl+c.`,
 	Run: func(cmd *cobra.Command, args []string) { cmd.Help() },
 }
 
@@ -40,9 +41,8 @@ func buildAgentsCommand() {
 var agentStart = &cobra.Command{
 	Use:   "start",
 	Short: "Start the agent.",
-	Long: `Start the agent requires to deploy contract bundles
-	from the Eris Marketplace.`,
-	Run: StartAgent,
+	Long:  `Start the agent. Stop the agent with ctrl+c.`,
+	Run:   StartAgent,
 }
 
 /*var agentStop = &cobra.Command{


### PR DESCRIPTION
- the agent (#632) can now use tarballs directly (rather than IPFS hashes) for the `/download` and `/install` endpoints.
- this can be accomplished by a) replacing the `hash` fields from those endpoints with `anyFilename.tar.gz` and b) passing the tarball in the body of the request. 
- for example: (see #632 for tarball specification & full example) `curl -X POST 'http:localhost:17552/download?groupId=com.erisindustries&bundleId=marmoty-contracts&version=2.9.2&hash=myTarball.tar.gz' --data-binary "@myTarball.tar.gz"` is equivalent in functionality to the example in #632 but without the requirement that the tarball been added to ipfs. 
- an additional check that IPFS hash are the correct (46 characters) was added to the agent.
- closes #646 
