### PR TITLE
`--proxy` flag for `eris init`

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -28,6 +28,7 @@ func addInitFlags() {
 	Init.Flags().BoolVarP(&do.Pull, "pull-images", "", true, "by default, pulls and/or update latest primary images. use flag to skip pulling/updating of images.")
 	Init.Flags().BoolVarP(&do.Yes, "yes", "y", false, "over-ride command-line prompts")
 	Init.Flags().StringVarP(&do.Source, "source", "", "rawgit", "source from which to download definition files for the eris platform. if toadserver fails, use: rawgit")
+	Init.Flags().StringVarP(&do.Proxy, "proxy", "", "", "use a proxy with format: (http://proxyIp:proxyPort). respects $HTTP_PROXY but over-riden by this flag.")
 	Init.Flags().BoolVarP(&do.Quiet, "testing", "", false, "DO NOT USE (for testing only)")
 }
 

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -35,6 +35,7 @@ type Do struct {
 	Type          string   `mapstructure:"," json:"," yaml:"," toml:","`
 	Task          string   `mapstructure:"," json:"," yaml:"," toml:","`
 	Tail          string   `mapstructure:"," json:"," yaml:"," toml:","`
+	Proxy         string   `mapstructure:"," json:"," yaml:"," toml:","`
 	ChainName     string   `mapstructure:"," json:"," yaml:"," toml:","`
 	ChainType     string   `mapstructure:"," json:"," yaml:"," toml:","`
 	GenesisFile   string   `mapstructure:"," json:"," yaml:"," toml:","`

--- a/initialize/init.go
+++ b/initialize/init.go
@@ -99,15 +99,15 @@ func InitDefaults(do *definitions.Do, newDir bool) error {
 
 	tsErrorFix := "toadserver may be down: re-run with `--source=rawgit`"
 
-	if err := dropServiceDefaults(srvPath, do.Source); err != nil {
+	if err := dropServiceDefaults(srvPath, do.Source, do.Proxy); err != nil {
 		return fmt.Errorf("%v\n%s\n", err, tsErrorFix)
 	}
 
-	if err := dropActionDefaults(actPath, do.Source); err != nil {
+	if err := dropActionDefaults(actPath, do.Source, do.Proxy); err != nil {
 		return fmt.Errorf("%v\n%s\n", err, tsErrorFix)
 	}
 
-	if err := dropChainDefaults(chnPath, do.Source); err != nil {
+	if err := dropChainDefaults(chnPath, do.Source, do.Proxy); err != nil {
 		return fmt.Errorf("%v\n%s\n", err, tsErrorFix)
 	}
 

--- a/initialize/init.go
+++ b/initialize/init.go
@@ -27,7 +27,6 @@ func Initialize(do *definitions.Do) error {
 		if err := checkIfMigrationRequired(do.Yes); err != nil {
 			return nil
 		}
-
 	}
 
 	if do.Pull { //true by default; if imgs already exist, will check for latest anyways
@@ -97,8 +96,8 @@ func InitDefaults(do *definitions.Do, newDir bool) error {
 	actPath = common.ActionsPath
 	chnPath = common.ChainsPath
 
-	tsErrorFix := "toadserver may be down: re-run with `--source=rawgit`"
-
+	tsErrorFix := "error getting files from github"
+	//"toadserver may be down: re-run with `--source=rawgit`"
 	if err := dropServiceDefaults(srvPath, do.Source, do.Proxy); err != nil {
 		return fmt.Errorf("%v\n%s\n", err, tsErrorFix)
 	}

--- a/initialize/initialize_test.go
+++ b/initialize/initialize_test.go
@@ -97,31 +97,31 @@ func testDrops(dir, kind string) error {
 	case "services":
 		//pull from toadserver
 		if toadUp {
-			if err := dropServiceDefaults(dirToad, "toadserver"); err != nil {
+			if err := dropServiceDefaults(dirToad, "toadserver", ""); err != nil {
 				ifExit(err)
 			}
 		}
 		//pull from rawgit
-		if err := dropServiceDefaults(dirGit, "rawgit"); err != nil {
+		if err := dropServiceDefaults(dirGit, "rawgit", ""); err != nil {
 			ifExit(err)
 		}
 	case "actions":
 		if toadUp {
-			if err := dropActionDefaults(dirToad, "toadserver"); err != nil {
+			if err := dropActionDefaults(dirToad, "toadserver", ""); err != nil {
 				ifExit(err)
 			}
 		}
-		if err := dropActionDefaults(dirGit, "rawgit"); err != nil {
+		if err := dropActionDefaults(dirGit, "rawgit", ""); err != nil {
 			ifExit(err)
 		}
 
 	case "chains":
 		if toadUp {
-			if err := dropChainDefaults(dirToad, "toadserver"); err != nil {
+			if err := dropChainDefaults(dirToad, "toadserver", ""); err != nil {
 				ifExit(err)
 			}
 		}
-		if err := dropChainDefaults(dirGit, "rawgit"); err != nil {
+		if err := dropChainDefaults(dirGit, "rawgit", ""); err != nil {
 			ifExit(err)
 		}
 	}

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -27,8 +27,8 @@ import (
 
 // XXX all files in this sequence must be added to both
 // the respective GH repo & mindy testnet (pinkpenguin.interblock.io:46657/list_names)
-func dropServiceDefaults(dir, from string) error {
-	if err := drops(ver.SERVICE_DEFINITIONS, "services", dir, from); err != nil {
+func dropServiceDefaults(dir, from, proxy string) error {
+	if err := drops(ver.SERVICE_DEFINITIONS, "services", dir, from, proxy); err != nil {
 		return err
 	}
 	if err := writeDefaultFile(common.ServicesPath, "keys.toml", defServiceKeys); err != nil {
@@ -40,8 +40,8 @@ func dropServiceDefaults(dir, from string) error {
 	return nil
 }
 
-func dropActionDefaults(dir, from string) error {
-	if err := drops(ver.ACTION_DEFINITIONS, "actions", dir, from); err != nil {
+func dropActionDefaults(dir, from, proxy string) error {
+	if err := drops(ver.ACTION_DEFINITIONS, "actions", dir, from, proxy); err != nil {
 		return err
 	}
 	if err := writeDefaultFile(common.ActionsPath, "do_not_use.toml", defAct); err != nil {
@@ -50,8 +50,8 @@ func dropActionDefaults(dir, from string) error {
 	return nil
 }
 
-func dropChainDefaults(dir, from string) error {
-	if err := drops(ver.CHAIN_DEFINITIONS, "chains", dir, from); err != nil {
+func dropChainDefaults(dir, from, proxy string) error {
+	if err := drops(ver.CHAIN_DEFINITIONS, "chains", dir, from, proxy); err != nil {
 		return err
 	}
 
@@ -186,7 +186,7 @@ This is likely a network performance issue with our Docker hosting provider`)
 	return nil
 }
 
-func drops(files []string, typ, dir, from string) error {
+func drops(files []string, typ, dir, from, proxy string) error {
 	//to get from rawgit
 	var repo string
 	if typ == "services" {
@@ -218,14 +218,14 @@ func drops(files []string, typ, dir, from string) error {
 				"from": url,
 				"to":   dir,
 			}).Debug("Moving file")
-			if err := ipfs.DownloadFromUrlToFile(url, file, dir); err != nil {
+			if err := ipfs.DownloadFromUrlToFile(url, file, dir, proxy); err != nil {
 				return err
 			}
 		}
 	} else if from == "rawgit" {
 		for _, file := range files {
 			log.WithField(file, dir).Debug("Getting file from GitHub, dropping into:")
-			if err := util.GetFromGithub("eris-ltd", repo, "master", archPrefix+file, dir, file); err != nil {
+			if err := util.GetFromGithub("eris-ltd", repo, "master", archPrefix+file, dir, file, proxy); err != nil {
 				return err
 			}
 		}

--- a/perform/perform.go
+++ b/perform/perform.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/eris-ltd/eris-cli/config"

--- a/perform/perform.go
+++ b/perform/perform.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 	"unicode"
 
 	"github.com/eris-ltd/eris-cli/config"

--- a/util/readers.go
+++ b/util/readers.go
@@ -61,7 +61,7 @@ func UnpackTarball(tarBallPath, installPath string) error {
 	return UntarForDocker(reader, "", installPath)
 }
 
-func GetFromGithub(org, repo, branch, path, directory, fileName string) error {
+func GetFromGithub(org, repo, branch, path, directory, fileName, proxy string) error {
 	url := "https://raw.githubusercontent.com/" + strings.Join([]string{org, repo, branch, path}, "/")
-	return ipfs.DownloadFromUrlToFile(url, fileName, directory)
+	return ipfs.DownloadFromUrlToFile(url, fileName, directory, proxy)
 }

--- a/vendor/github.com/eris-ltd/common/go/ipfs/readers.go
+++ b/vendor/github.com/eris-ltd/common/go/ipfs/readers.go
@@ -23,7 +23,7 @@ func GetFromIPFS(hash, fileName, dirName string) error {
 		"file": fileName,
 		"hash": hash,
 	}).Warn("Getting file from IPFS")
-	return DownloadFromUrlToFile(url, fileName, dirName)
+	return DownloadFromUrlToFile(url, fileName, dirName, "") // no proxy for IPFS ?
 }
 
 func CatFromIPFS(fileHash string) (string, error) {
@@ -106,8 +106,8 @@ func ListPinnedFromIPFS() (string, error) {
 	return result, nil
 }
 
-func DownloadFromUrlToFile(url, fileName, dirName string) error {
-	tokens := strings.Split(url, "/")
+func DownloadFromUrlToFile(url0, fileName, dirName, proxyURL string) error {
+	tokens := strings.Split(url0, "/")
 	if fileName == "" {
 		fileName = tokens[len(tokens)-1]
 	}
@@ -116,7 +116,7 @@ func DownloadFromUrlToFile(url, fileName, dirName string) error {
 	endPath := path.Join(dirName, fileName)
 	if dirName != "" {
 		log.WithFields(log.Fields{
-			"from": url,
+			"from": url0,
 			"to":   endPath,
 		}).Warn("Downloading")
 		checkDir, err := os.Stat(dirName)
@@ -132,7 +132,7 @@ func DownloadFromUrlToFile(url, fileName, dirName string) error {
 		}
 	} else {
 		log.WithFields(log.Fields{
-			"from": url,
+			"from": url0,
 			"to":   fileName,
 		}).Warn("Downloading")
 	}


### PR DESCRIPTION
- `eris init --proxy=http://proxyIp:proxyPort` will use the specified proxy
- closes #505 

- in addition, the function `QueryYesOrNo()` has been moved from `package util` to the `/common` repository (closes #675) (see https://github.com/eris-ltd/common/pull/37)