### PR TITLE
 Have all three CIs clean up docker-machine instances in AWS after test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
 
 script:
 - tests/test.sh
+- tests/dm_cleanup.sh
 
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,9 @@ build_script:
 
     go install
 
+after_test:
+  - bash c:\src\github.com\eris-ltd\eris-cli\tests\dm_cleanup.sh
+
 test_script:
 - cmd: >-
 

--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,7 @@ test:
   override:
     - "cd ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/cmd/eris && go install"
     - "tests/test.sh | tee $CIRCLE_ARTIFACTS/output.log ; test ${PIPESTATUS[0]} -eq 0"
+    - "tests/dm_cleanup.sh"
 
 deployment:
   master:

--- a/tests/dm_cleanup.sh
+++ b/tests/dm_cleanup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Cleans up if tests are interrupted.
+MACHINES=$(docker-machine ls -q)
+if [ $MACHINES ]; then
+    docker-machine rm --force $MACHINES
+fi
+


### PR DESCRIPTION
I ran this in CircleCI but I don't know if that's sufficient as a test, I did not attempt to interrupt any tests.