### PR TITLE
pkgs: import/export, closes #682

### DIFF
--- a/agent/operate.go
+++ b/agent/operate.go
@@ -274,7 +274,7 @@ func GetTarballFromIPFS(hash, installPath string) (string, error) {
 		}
 	}
 	do := definitions.NowDo()
-	do.Name = hash
+	do.Hash = hash
 
 	do.Path = filepath.Join(installPath, fmt.Sprintf("%s%s", hash, ".tar.gz"))
 	if err := files.GetFiles(do); err != nil {

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -100,7 +100,7 @@ func addFilesFlags() {
 
 func FilesGet(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(2, "eq", cmd, args))
-	do.Name = args[0] // hash
+	do.Hash = args[0]
 	do.Path = args[1] // where it is saved
 	// TODO make above a flag with `-o` (--output)
 	// similar to curl GET -o

--- a/cmd/pkgs.go
+++ b/cmd/pkgs.go
@@ -9,7 +9,6 @@ import (
 	"github.com/eris-ltd/eris-cli/pkgs"
 	"github.com/eris-ltd/eris-cli/version"
 
-	log "github.com/Sirupsen/logrus"
 	. "github.com/eris-ltd/common/go/common"
 
 	"github.com/spf13/cobra"
@@ -26,14 +25,9 @@ smart contract packages for use by your application.`,
 
 // build the contracts subcommand
 func buildPackagesCommand() {
-	// TODO: finish when the PR which is blocking
-	//   eris files put --dir is integrated into
-	//   ipfs
-	// [zr] looks like that's now the case ...
-	// XXX see https://github.com/ipfs/go-ipfs/pull/1845
-	// Packages.AddCommand(packagesImport)
-	// Packages.AddCommand(packagesExport)
 	Packages.AddCommand(packagesDo)
+	Packages.AddCommand(packagesImport)
+	Packages.AddCommand(packagesExport)
 	addPackagesFlags()
 }
 
@@ -41,12 +35,12 @@ var packagesImport = &cobra.Command{
 	Use:   "import HASH PACKAGE",
 	Short: "Pull a package of smart contracts from IPFS.",
 	Long: `Pull a package of smart contracts from IPFS
-via its hash and save it locally.`,
+via its hash and save it locally to ~/.eris/apps/PACKAGE.`,
 	Run: PackagesImport,
 }
 
 var packagesExport = &cobra.Command{
-	Use:   "export",
+	Use:   "export DIR",
 	Short: "Post a package of smart contracts to IPFS.",
 	Long:  `Post a package of smart contracts to IPFS.`,
 	Run:   PackagesExport,
@@ -88,16 +82,16 @@ func addPackagesFlags() {
 
 func PackagesImport(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(2, "eq", cmd, args))
-	do.Name = args[0]
-	do.Path = args[1]
-	IfExit(pkgs.GetPackage(do))
+	do.Hash = args[0]
+	do.Name = args[1]
+	IfExit(pkgs.ImportPackage(do))
 }
 
 func PackagesExport(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "eq", cmd, args))
 	do.Name = args[0]
-	IfExit(pkgs.PutPackage(do))
-	log.Warn(do.Result)
+	IfExit(pkgs.ExportPackage(do))
+	//log.Warn(do.Result) -> handled in above func
 }
 
 func PackagesDo(cmd *cobra.Command, args []string) {

--- a/cmd/pkgs.go
+++ b/cmd/pkgs.go
@@ -32,18 +32,21 @@ func buildPackagesCommand() {
 }
 
 var packagesImport = &cobra.Command{
-	Use:   "import HASH PACKAGE",
+	Use:   "import HASH NAME",
 	Short: "Pull a package of smart contracts from IPFS.",
 	Long: `Pull a package of smart contracts from IPFS
-via its hash and save it locally to ~/.eris/apps/PACKAGE.`,
+via its hash and save it locally to ~/.eris/apps/NAME.
+This package needs to have been added as directory to ipfs,
+with [eris pkgs export someDir/].`,
 	Run: PackagesImport,
 }
 
 var packagesExport = &cobra.Command{
 	Use:   "export DIR",
 	Short: "Post a package of smart contracts to IPFS.",
-	Long:  `Post a package of smart contracts to IPFS.`,
-	Run:   PackagesExport,
+	Long: `Post a package of smart contracts to IPFS.
+Give a path to a directory, which will be added to ipfs recusively.`,
+	Run: PackagesExport,
 }
 
 var packagesDo = &cobra.Command{
@@ -51,7 +54,7 @@ var packagesDo = &cobra.Command{
 	Short: "Deploy or test a package of smart contracts to a chain.",
 	Long: `Deploy or test a package of smart contracts to a chain.
 
-eris pkgs do will perform the required functionality included
+[eris pkgs do] will perform the required functionality included
 in a package definition file.`,
 	Run: PackagesDo,
 }
@@ -91,7 +94,6 @@ func PackagesExport(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "eq", cmd, args))
 	do.Name = args[0]
 	IfExit(pkgs.ExportPackage(do))
-	//log.Warn(do.Result) -> handled in above func
 }
 
 func PackagesDo(cmd *cobra.Command, args []string) {

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -91,7 +91,7 @@ func TestGetFiles(t *testing.T) {
 	)
 
 	do := definitions.NowDo()
-	do.Name = hash
+	do.Hash = hash
 	do.Path = fileName
 
 	// Fake IPFS server.
@@ -146,7 +146,7 @@ func testGetDirectoryFromIPFS(t *testing.T) {
 	hash := "QmYwjCPtWkduz81UnAqMJYCag5pock5y2S8yZQEd4qoyzf"
 
 	do := definitions.NowDo()
-	do.Name = hash
+	do.Hash = hash
 	do.Path = erisDir
 
 	passed := false

--- a/files/handle.go
+++ b/files/handle.go
@@ -67,7 +67,6 @@ func PutFiles(do *definitions.Do) error {
 	}
 
 	if f.IsDir() {
-		//can't use gateway - check & throw err
 		log.WithField("dir", do.Name).Warn("Adding contents of a directory")
 		buf, err := exportDirectory(do)
 		if err != nil {
@@ -386,8 +385,7 @@ func EnsureIPFSrunning() error {
 	doNow := definitions.NowDo()
 	doNow.Name = "ipfs"
 	if err := services.EnsureRunning(doNow); err != nil {
-		fmt.Printf("Failed to ensure IPFS is running: %v", err)
-		return err
+		return fmt.Errorf("Failed to ensure IPFS is running: %v", err)
 	}
 	log.Info("IPFS is running")
 	return nil

--- a/files/handle.go
+++ b/files/handle.go
@@ -25,16 +25,15 @@ func GetFiles(do *definitions.Do) error {
 		return err
 	}
 
-	// where Object is a directory added recursively to ipfs
-	// do.Name is the hash // which is fucking annoying
-	dirBool, err := isHashAnObject(do.Name)
+	// where Object is a directory already added recursively to ipfs
+	dirBool, err := isHashAnObject(do.Hash)
 	if err != nil {
 		return err
 	}
 
 	if dirBool {
 		log.WithFields(log.Fields{
-			"hash": do.Name,
+			"hash": do.Hash,
 			"path": do.Path,
 		}).Warn("Getting a directory")
 		buf, err := importDirectory(do)
@@ -44,7 +43,7 @@ func GetFiles(do *definitions.Do) error {
 		log.Warn("Directory object getted succesfully.")
 		log.Warn(util.TrimString(buf.String()))
 	} else {
-		if err := importFile(do.Name, do.Path); err != nil {
+		if err := importFile(do.Hash, do.Path); err != nil {
 			return err
 		}
 	}
@@ -119,7 +118,7 @@ func exportDirectory(do *definitions.Do) (*bytes.Buffer, error) {
 }
 
 func importDirectory(do *definitions.Do) (*bytes.Buffer, error) {
-	hash := do.Name
+	hash := do.Hash
 
 	ip := new(bytes.Buffer)
 	config.GlobalConfig.Writer = ip

--- a/files/handle.go
+++ b/files/handle.go
@@ -26,7 +26,7 @@ func GetFiles(do *definitions.Do) error {
 	}
 
 	// where Object is a directory added recursively to ipfs
-	// do.Name is the hash
+	// do.Name is the hash // which is fucking annoying
 	dirBool, err := isHashAnObject(do.Name)
 	if err != nil {
 		return err

--- a/pkgs/manage.go
+++ b/pkgs/manage.go
@@ -13,8 +13,6 @@ import (
 )
 
 func ImportPackage(do *definitions.Do) error {
-	// do.Hash
-	// do.Name -> ~/.eris/apps/do.Name
 
 	doGet := definitions.NowDo()
 	doGet.Hash = do.Hash
@@ -22,22 +20,20 @@ func ImportPackage(do *definitions.Do) error {
 	if err := files.GetFiles(doGet); err != nil {
 		return err
 	}
-
-	log.Warn("some erro msg or instruction")
+	log.WithField("path", doGet.Path).Warn("Your package has been succesfully added to")
 
 	return nil
 }
 
 func ExportPackage(do *definitions.Do) error {
 
-	//ensure path is dir
+	// ensure path is dir
 	f, err := os.Stat(do.Name)
 	if err != nil {
 		return err
 	}
-
 	if !f.IsDir() {
-		return fmt.Errorf("path (%s) is not a directory; please provide a path to a directory")
+		return fmt.Errorf("path (%s) is not a directory; please provide a path to a directory", do.Name)
 	}
 
 	doPut := definitions.NowDo()
@@ -46,6 +42,7 @@ func ExportPackage(do *definitions.Do) error {
 		return err
 	}
 
-	log.Warn("output from PutFiles & instructions")
+	log.Warn("The last entry in the list above is the hash required for [eris pkgs import].")
+
 	return nil
 }

--- a/pkgs/manage.go
+++ b/pkgs/manage.go
@@ -17,7 +17,7 @@ func ImportPackage(do *definitions.Do) error {
 	// do.Name -> ~/.eris/apps/do.Name
 
 	doGet := definitions.NowDo()
-	doGet.Name = do.Hash
+	doGet.Hash = do.Hash
 	doGet.Path = filepath.Join(common.AppsPath, do.Name)
 	if err := files.GetFiles(doGet); err != nil {
 		return err

--- a/pkgs/manage.go
+++ b/pkgs/manage.go
@@ -3,17 +3,27 @@ package pkgs
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/files"
 
 	log "github.com/Sirupsen/logrus"
-	//. "github.com/eris-ltd/common/go/common"
+	"github.com/eris-ltd/common/go/common"
 )
 
 func ImportPackage(do *definitions.Do) error {
-	// do.Path
+	// do.Hash
 	// do.Name -> ~/.eris/apps/do.Name
+
+	doGet := definitions.NowDo()
+	doGet.Name = do.Hash
+	doGet.Path = filepath.Join(common.AppsPath, do.Name)
+	if err := files.GetFiles(doGet); err != nil {
+		return err
+	}
+
+	log.Warn("some erro msg or instruction")
 
 	return nil
 }

--- a/pkgs/manage.go
+++ b/pkgs/manage.go
@@ -1,26 +1,41 @@
 package pkgs
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/eris-ltd/eris-cli/definitions"
+	"github.com/eris-ltd/eris-cli/files"
+
+	log "github.com/Sirupsen/logrus"
+	//. "github.com/eris-ltd/common/go/common"
 )
 
-// TODO: finish when the PR which is blocking
-//   eris files put --dir is integrated into
-//   ipfs
-func GetPackage(do *definitions.Do) error {
-	// do.Name = args[0]
-	// do.Path = args[1]
+func ImportPackage(do *definitions.Do) error {
+	// do.Path
+	// do.Name -> ~/.eris/apps/do.Name
 
 	return nil
 }
 
-// TODO: finish when the PR which is blocking
-//   eris files put --dir is integrated into
-//   ipfs
-func PutPackage(do *definitions.Do) error {
-	// do.Name = args[0]
-	var hash string = ""
+func ExportPackage(do *definitions.Do) error {
 
-	do.Result = hash
+	//ensure path is dir
+	f, err := os.Stat(do.Name)
+	if err != nil {
+		return err
+	}
+
+	if !f.IsDir() {
+		return fmt.Errorf("path (%s) is not a directory; please provide a path to a directory")
+	}
+
+	doPut := definitions.NowDo()
+	doPut.Name = do.Name
+	if err := files.PutFiles(doPut); err != nil {
+		return err
+	}
+
+	log.Warn("output from PutFiles & instructions")
 	return nil
 }

--- a/services/manage.go
+++ b/services/manage.go
@@ -39,9 +39,8 @@ func ImportService(do *definitions.Do) error {
 	}
 
 	_, err = loaders.LoadServiceDefinition(do.Name, false)
-	//XXX add protections?
 	if err != nil {
-		return fmt.Errorf("Your service definition file looks improperly formatted and will not marshal.")
+		return fmt.Errorf("error loading service:\n%v", err)
 	}
 
 	do.Result = "success"
@@ -59,6 +58,7 @@ func NewService(do *definitions.Do) error {
 	//get maintainer info
 	srv.Maintainer.Name, srv.Maintainer.Email, err = config.GitConfigUser()
 	if err != nil {
+		// don't return -> field not required
 		log.Debug(err.Error())
 	}
 


### PR DESCRIPTION
- These two new commands: `eris pkgs import/export` get and put smart contracts packages to and from IPFS.
- `pkgs export someDir/` is essentially an alias to `files put` but requires a directory as path
- `pkgs import HASH NAME` requires the hash output from `export` and will put its contents in `~/.eris/apps/NAME`.
- under the hood, the `files.GetFiles()` function was `s/do.Name/do.Hash` for better clarity
- closes #682 

## Usage
- requires a running chain
```
eris services start ipfs
eris pkgs export $GOPATH/src/github.com/eris-ltd/eris-pm/tests/fixtures/app01/`
eris pkgs import QmRY9EUxjjrXRtbbBHpXexdp4PeL4UQG6m1DxJRDBko3RN aNewName`
cd $HOME/.eris/apps/aNewName
eris pkgs do --chain someChain --address yourAddress
```
