### PR TITLE
Native arm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ _testmain.go
 docs/eris-cli
 .goxc.local.json
 builds
+
+*.swp

--- a/cmd/pkgs.go
+++ b/cmd/pkgs.go
@@ -1,5 +1,7 @@
 // +build !arm
 
+// Conditional build for ARM relatd to the issure: https://github.com/eris-ltd/eris-cli/issues/751
+// TODO: Will be cleaned after issue fixed
 package commands
 
 import (

--- a/cmd/pkgs_arm.go
+++ b/cmd/pkgs_arm.go
@@ -1,3 +1,5 @@
+// Added for ARM since the issue: https://github.com/eris-ltd/eris-cli/issues/751
+// TODO: Remove after issue fixed.
 package commands
 
 import (

--- a/cmd/pkgs_arm.go
+++ b/cmd/pkgs_arm.go
@@ -1,5 +1,3 @@
-// +build !arm
-
 package commands
 
 import (
@@ -9,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/eris-ltd/eris-cli/pkgs"
-	"github.com/eris-ltd/eris-cli/version"
+	_ "github.com/eris-ltd/eris-cli/version"
 
 	. "github.com/eris-ltd/common/go/common"
 
@@ -115,7 +113,7 @@ func PackagesDo(cmd *cobra.Command, args []string) {
 }
 
 func formCompilers() string {
-	verSplit := strings.Split(version.VERSION, ".")
+	verSplit := strings.Split("0.11.3", ".")
 	maj, _ := strconv.Atoi(verSplit[0])
 	min, _ := strconv.Atoi(verSplit[1])
 	pat, _ := strconv.Atoi(verSplit[2])

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/eris-ltd/eris-cli/util"
@@ -17,9 +18,9 @@ import (
 
 	ver "github.com/eris-ltd/eris-cli/version"
 
-	log "github.com/eris-ltd/eris-logger"
 	"github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/common/go/ipfs"
+	log "github.com/eris-ltd/eris-logger"
 	docker "github.com/fsouza/go-dockerclient"
 )
 
@@ -177,6 +178,13 @@ func drops(files []string, typ, dir, from string) error {
 	} else if typ == "chains" {
 		repo = "eris-chains"
 	}
+	// on different arch
+	archPrefix := ""
+	if runtime.GOARCH == "arm" {
+		if repo != "eris-actions" {
+			archPrefix = "arm/"
+		}
+	}
 
 	if !util.DoesDirExist(dir) {
 		if err := os.MkdirAll(dir, 0777); err != nil {
@@ -197,7 +205,7 @@ func drops(files []string, typ, dir, from string) error {
 	} else if from == "rawgit" {
 		for _, file := range files {
 			log.WithField(file, dir).Debug("Getting file from GitHub, dropping into:")
-			if err := util.GetFromGithub("eris-ltd", repo, "master", file, dir, file, buf); err != nil {
+			if err := util.GetFromGithub("eris-ltd", repo, "master", archPrefix+file, dir, file, buf); err != nil {
 				return err
 			}
 		}

--- a/version/files.go
+++ b/version/files.go
@@ -1,4 +1,7 @@
+// +build !arm
+
 package version
+
 // DEPRECATION warning: to be replaced by pulling from toadserver
 // && [eris services ls] which'll query the toadserver for available
 // service definition files which can then be imported.

--- a/version/files_arm.go
+++ b/version/files_arm.go
@@ -1,0 +1,20 @@
+package version
+
+var (
+	SERVICE_DEFINITIONS = []string{
+	//"ipfs.toml",
+	//"keys.toml",
+	}
+
+	ACTION_DEFINITIONS = []string{
+		"chain_info.toml",
+		"dns_register.toml",
+		"keys_list.toml",
+	}
+
+	CHAIN_DEFINITIONS = []string{
+		"default.toml",
+		"config.toml",
+		"server_conf.toml",
+	}
+)

--- a/version/images.go
+++ b/version/images.go
@@ -1,3 +1,5 @@
+// +build !arm
+
 package version
 
 import (

--- a/version/images_arm.go
+++ b/version/images_arm.go
@@ -1,0 +1,19 @@
+package version
+
+import (
+	"fmt"
+)
+
+const ARCH = "arm"
+
+var (
+	ERIS_REG_DEF = "quay.io"
+	ERIS_REG_BAK = "" //dockerhub
+
+	ERIS_IMG_DATA = fmt.Sprintf("eris/data:%s-%s", ARCH, VERSION)
+	ERIS_IMG_KEYS = fmt.Sprintf("eris/keys:%s-%s", ARCH, VERSION)
+	ERIS_IMG_DB   = fmt.Sprintf("eris/erisdb:%s-%s", ARCH, VERSION)
+	ERIS_IMG_PM   = fmt.Sprintf("eris/epm:%s-%s", ARCH, VERSION)
+	ERIS_IMG_CM   = fmt.Sprintf("eris/eris-cm:%s-%s", ARCH, VERSION)
+	ERIS_IMG_IPFS = fmt.Sprintf("eris/ipfs:%s", ARCH)
+)

--- a/version/version.go
+++ b/version/version.go
@@ -2,6 +2,7 @@ package version
 
 const DOCKER_VER_MIN = "1.8.0"
 const DM_VER_MIN = "0.6.0"
+
 // must be the last line so the build script
 // picks it up
 const VERSION = "0.12.0"


### PR DESCRIPTION
- pull arm docker images from quay.io when underlying platform is arm by build constraint on version/images
- detect running platform and pull chain and services files for corresponding platform.
- `eris pkgs do` remote compiler 0.12.0 won't work, reduced to 0.11.3 for arm. 