### PR TITLE
`loaders` package tests

### DIFF
--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -21,28 +21,12 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit("actions"))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
 	exitCode := m.Run()
 
 	log.Info("Tearing tests down")
 	tests.IfExit(tests.TestsTearDown())
 	os.Exit(exitCode)
-}
-
-func TestLoadActionDefinition(t *testing.T) {
-	var e error
-	actionName = strings.Replace(actionName, " ", "_", -1)
-	act, _, e := LoadActionDefinition(actionName)
-	if e != nil {
-		log.Errorf("Error: action did not load properly: %v", e)
-		t.FailNow()
-	}
-
-	actionName = strings.Replace(actionName, "_", " ", -1)
-	if act.Name != actionName {
-		log.Errorf("Error: improper action name on LOAD. expected: %s got: %s", actionName, act.Name)
-		t.Fail()
-	}
 }
 
 func TestDoAction(t *testing.T) {

--- a/actions/manage.go
+++ b/actions/manage.go
@@ -131,10 +131,6 @@ func RenameAction(do *definitions.Do) error {
 	}
 	log.WithField("file", oldFile).Debug("Found action definition file")
 
-	// if !strings.Contains(oldFile, ActionsPath) {
-	// 	oldFile = filepath.Join(ActionsPath, oldFile) + ".toml"
-	// }
-
 	var newFile string
 	newNameBase := strings.Replace(strings.Replace(do.NewName, " ", "_", -1), filepath.Ext(do.NewName), "", 1)
 
@@ -162,9 +158,8 @@ func RenameAction(do *definitions.Do) error {
 	}
 
 	log.WithField("file", oldFile).Debug("Removing old file")
-	os.Remove(oldFile)
 
-	return nil
+	return os.Remove(oldFile)
 }
 
 func RmAction(do *definitions.Do) error {

--- a/actions/manage.go
+++ b/actions/manage.go
@@ -13,8 +13,8 @@ import (
 	"github.com/eris-ltd/eris-cli/perform"
 	"github.com/eris-ltd/eris-cli/util"
 
-	log "github.com/eris-ltd/eris-logger"
 	. "github.com/eris-ltd/common/go/common"
+	log "github.com/eris-ltd/eris-logger"
 )
 
 func NewAction(do *definitions.Do) error {
@@ -44,7 +44,7 @@ func ImportAction(do *definitions.Do) error {
 	if s[0] == "ipfs" {
 
 		var err error
-		ipfsService, err := loaders.LoadServiceDefinition("ipfs", false)
+		ipfsService, err := loaders.LoadServiceDefinition("ipfs")
 		if err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ func ExportAction(do *definitions.Do) error {
 		return err
 	}
 
-	ipfsService, err := loaders.LoadServiceDefinition("ipfs", false)
+	ipfsService, err := loaders.LoadServiceDefinition("ipfs")
 	if err != nil {
 		return err
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -55,10 +55,9 @@ func TestListChains(t *testing.T) {
 
 }
 
-// ensure url format satifies required schema
+// Ensure url format satisfies required schema
 //TODO parse each kinds of payload (chains, dowload, install)
 func TestParsePayload(t *testing.T) {
-
 	toTest := map[string]string{
 		"groupId":   bundleInfo["groupId"],  // needed to buildpath
 		"bundleId":  bundleInfo["bundleId"], // ibid
@@ -237,7 +236,7 @@ func testKillChain(t *testing.T, chainName string) {
 	doCh.Rm = true
 	doCh.Force = true
 	if err := chains.KillChain(doCh); err != nil {
-		t.Fatal("error killing chain: %v\n", err)
+		t.Fatalf("error killing chain: %v", err)
 	}
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -44,7 +44,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit("agent"))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
 
 	exitCode := m.Run()
 	tests.IfExit(tests.TestsTearDown())

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -19,9 +19,9 @@ import (
 	"github.com/eris-ltd/eris-cli/util"
 	"github.com/eris-ltd/eris-cli/version"
 
-	log "github.com/eris-ltd/eris-logger"
 	. "github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/common/go/ipfs"
+	log "github.com/eris-ltd/eris-logger"
 )
 
 // MakeChain runs the `eris-cm make` command in a docker container.
@@ -175,7 +175,7 @@ func ImportChain(do *definitions.Do) error {
 //  do.Operations.Args - fields to inspect in the form Major.Minor or "all" (required)
 //
 func InspectChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false)
+	chain, err := loaders.LoadChainDefinition(do.Name)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func InspectChain(do *definitions.Do) error {
 //  do.Tail    - number of lines to display (can be "all") (optional)
 //
 func LogsChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false)
+	chain, err := loaders.LoadChainDefinition(do.Name)
 	if err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func LogsChain(do *definitions.Do) error {
 //  do.Name - name of the chain (required)
 //
 func ExportChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false)
+	chain, err := loaders.LoadChainDefinition(do.Name)
 	if err != nil {
 		return err
 	}
@@ -327,7 +327,7 @@ func CatChain(do *definitions.Do) error {
 //  do.Name - name of the chain to display port mappings for (required)
 //
 func PortsChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false)
+	chain, err := loaders.LoadChainDefinition(do.Name)
 	if err != nil {
 		return err
 	}
@@ -370,7 +370,7 @@ func RenameChain(do *definitions.Do) error {
 		}).Info("Renaming chain")
 
 		log.WithField("=>", do.Name).Debug("Loading chain definition file")
-		chainDef, err := loaders.LoadChainDefinition(do.Name, false)
+		chainDef, err := loaders.LoadChainDefinition(do.Name)
 		if err != nil {
 			return err
 		}
@@ -431,7 +431,7 @@ func RenameChain(do *definitions.Do) error {
 }
 
 func UpdateChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false)
+	chain, err := loaders.LoadChainDefinition(do.Name)
 	if err != nil {
 		return err
 	}
@@ -452,7 +452,7 @@ func UpdateChain(do *definitions.Do) error {
 }
 
 func RemoveChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false)
+	chain, err := loaders.LoadChainDefinition(do.Name)
 	if err != nil {
 		return err
 	}
@@ -520,7 +520,7 @@ func RegisterChain(do *definitions.Do) error {
 		return fmt.Errorf("Registration requires you to have a data container for the chain. Could not find data for %s", do.Name)
 	}
 
-	chain, err := loaders.LoadChainDefinition(do.Name, false)
+	chain, err := loaders.LoadChainDefinition(do.Name)
 	if err != nil {
 		return err
 	}
@@ -560,7 +560,7 @@ func RegisterChain(do *definitions.Do) error {
 }
 
 func checkKeysRunningOrStart() error {
-	srv, err := loaders.LoadServiceDefinition("keys", false)
+	srv, err := loaders.LoadServiceDefinition("keys")
 	if err != nil {
 		return err
 	}

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -556,7 +556,7 @@ func RegisterChain(do *definitions.Do) error {
 
 	_, err = perform.DockerRunData(chain.Operations, chain.Service)
 
-	return nil
+	return err
 }
 
 func checkKeysRunningOrStart() error {

--- a/chains/operate.go
+++ b/chains/operate.go
@@ -44,7 +44,7 @@ func InstallChain(do *definitions.Do) error {
 }
 
 func KillChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name, false)
+	chain, err := loaders.LoadChainDefinition(do.Name)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func ThrowAwayChain(do *definitions.Do) error {
 
 //------------------------------------------------------------------------
 func startChain(do *definitions.Do, exec bool) (buf *bytes.Buffer, err error) {
-	chain, err := loaders.LoadChainDefinition(do.Name, false)
+	chain, err := loaders.LoadChainDefinition(do.Name)
 	if err != nil {
 		log.Error("Cannot start a chain I cannot find")
 		do.Result = "no file"
@@ -187,7 +187,7 @@ func bootDependencies(chain *definitions.Chain, do *definitions.Do) error {
 		}).Info("Booting chain dependencies")
 		for _, srvName := range chain.Dependencies.Services {
 			do.Name = srvName
-			srv, err := loaders.LoadServiceDefinition(do.Name, false)
+			srv, err := loaders.LoadServiceDefinition(do.Name)
 			if err != nil {
 				return err
 			}
@@ -204,7 +204,7 @@ func bootDependencies(chain *definitions.Chain, do *definitions.Do) error {
 		do.Name = name // undo side effects
 
 		for _, chainName := range chain.Dependencies.Chains {
-			chn, err := loaders.LoadChainDefinition(chainName, false)
+			chn, err := loaders.LoadChainDefinition(chainName)
 			if err != nil {
 				return err
 			}
@@ -338,7 +338,7 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 		return err
 	}
 
-	chain := loaders.MockChainDefinition(do.Name, do.ChainID, false)
+	chain := loaders.MockChainDefinition(do.Name, do.ChainID)
 
 	//set maintainer info
 	chain.Maintainer.Name, chain.Maintainer.Email, err = config.GitConfigUser()
@@ -354,7 +354,7 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 		}
 	}
 
-	chain, err = loaders.LoadChainDefinition(do.Name, false)
+	chain, err = loaders.LoadChainDefinition(do.Name)
 	if err != nil {
 		return err
 	}

--- a/chains/operate.go
+++ b/chains/operate.go
@@ -137,7 +137,6 @@ func startChain(do *definitions.Do, exec bool) (buf *bytes.Buffer, err error) {
 	}).Debug()
 
 	if exec {
-
 		if do.Image != "" {
 			chain.Service.Image = do.Image
 		}

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit("clean"))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
 
 	exitCode := m.Run()
 	tests.IfExit(tests.TestsTearDown())

--- a/cmd/actions.go
+++ b/cmd/actions.go
@@ -155,11 +155,11 @@ var actionsRemove = &cobra.Command{
 }
 
 func addActionsFlags() {
-	buildFlag(actionsDo, do, "quiet", "action")
-	buildFlag(actionsDo, do, "chain", "action")
 	buildFlag(actionsDo, do, "services", "action")
+	actionsDo.Flags().StringVarP(&do.ChainName, "chain", "c", "", "run action against a particular chain")
+	actionsDo.Flags().BoolVarP(&do.Quiet, "quiet", "q", false, "suppress action output")
 
-	buildFlag(actionsRemove, do, "file", "action")
+	actionsRemove.Flags().BoolVarP(&do.File, "file", "f", false, "remove action definition file")
 
 	buildFlag(actionsList, do, "known", "action")
 	actionsList.Flags().BoolVarP(&do.JSON, "json", "", false, "machine readable output")

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -405,11 +405,10 @@ func addChainsFlags() {
 	chainsMake.PersistentFlags().BoolVarP(&do.Known, "known", "", false, "use csv for a set of known keys to assemble genesis.json (requires both --accounts and --validators flags")
 	chainsMake.PersistentFlags().StringVarP(&do.ChainMakeActs, "accounts", "", "", "comma separated list of the accounts.csv files you would like to utilize (requires --known flag)")
 	chainsMake.PersistentFlags().StringVarP(&do.ChainMakeVals, "validators", "", "", "comma separated list of the validators.csv files you would like to utilize (requires --known flag)")
-	buildFlag(chainsMake, do, "data", "chain-make")
+	chainsMake.PersistentFlags().BoolVarP(&do.RmD, "data", "x", true, "remove data containers after stopping")
 
 	// [csk]: the flags below are commented out to reduce the complexity of this command. chains new should just use dirs....
 	// buildFlag(chainsNew, do, "config", "chain")
-	// buildFlag(chainsNew, do, "csv", "chain")
 	// buildFlag(chainsNew, do, "serverconf", "chain")
 	// chainsNew.PersistentFlags().StringVarP(&do.GenesisFile, "genesis", "g", "", "genesis.json file")
 	// chainsNew.PersistentFlags().StringSliceVarP(&do.ConfigOpts, "options", "", nil, "space separated <key>=<value> pairs to set in config.toml")

--- a/cmd/eris.go
+++ b/cmd/eris.go
@@ -53,7 +53,6 @@ Complete documentation is available at https://docs.erisindustries.com
 			return
 		}
 
-
 		util.DockerConnect(do.Verbose, do.MachineName)
 		ipfs.IpfsHost = config.GlobalConfig.Config.IpfsHost
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -11,9 +11,7 @@ import (
 //XXX flags were not deduplicated if only one known instance of being used
 //this command can probably be refactored...it's quite the bloated
 func buildFlag(cmd *cobra.Command, do *definitions.Do, flag, typ string) { //doesn't return anything; just sets the command
-	//typ always given but not always needed. also useful for restrictions
 	switch flag {
-	//listing functions (services, chains)
 	case "known":
 		cmd.Flags().BoolVarP(&do.Known, "known", "k", false, fmt.Sprintf("list all the %s definition files that exist", typ))
 	case "existing":
@@ -21,14 +19,8 @@ func buildFlag(cmd *cobra.Command, do *definitions.Do, flag, typ string) { //doe
 	case "running":
 		cmd.Flags().BoolVarP(&do.Running, "running", "r", false, fmt.Sprintf("list all the current containers which are running for a %s", typ))
 	case "quiet":
-		if typ == "action" {
-			cmd.Flags().BoolVarP(&do.Quiet, "quiet", "q", false, "suppress action output")
-		} else {
-			cmd.Flags().BoolVarP(&do.Quiet, "quiet", "q", false, "machine parsable output")
-		}
-
-	// stopping (services, chains) & other...eg timeout
-	case "force": //collect discrepancies here...
+		cmd.Flags().BoolVarP(&do.Quiet, "quiet", "q", false, "machine parsable output")
+	case "force":
 		cmd.Flags().BoolVarP(&do.Force, "force", "f", false, "kill the container instantly without waiting to exit") //why do we even have a timeout??
 	case "timeout":
 		cmd.Flags().UintVarP(&do.Timeout, "timeout", "t", 10, "manually set the timeout; overridden by --force")
@@ -39,50 +31,25 @@ func buildFlag(cmd *cobra.Command, do *definitions.Do, flag, typ string) { //doe
 	case "rm":
 		cmd.Flags().BoolVarP(&do.Rm, "rm", "r", false, "remove containers after stopping")
 	case "data":
-		if typ == "chain-make" {
-			cmd.Flags().BoolVarP(&do.RmD, "data", "x", true, "remove data containers after stopping")
-		} else {
-			cmd.Flags().BoolVarP(&do.RmD, "data", "x", false, "remove data containers after stopping")
-		}
-		//exec (services, chains)
+		cmd.Flags().BoolVarP(&do.RmD, "data", "x", false, "remove data containers after stopping")
 	case "publish":
 		cmd.PersistentFlags().BoolVarP(&do.Operations.PublishAllPorts, "publish", "p", false, "publish random ports")
 	case "ports":
 		cmd.PersistentFlags().StringVarP(&do.Operations.Ports, "ports", "", "", "reassign ports")
 	case "interactive":
 		cmd.Flags().BoolVarP(&do.Operations.Interactive, "interactive", "i", false, "interactive shell")
-		//update
 	case "pull":
 		cmd.Flags().BoolVarP(&do.Pull, "pull", "p", false, fmt.Sprintf("pull an updated version of the %s's base service image from docker hub", typ))
 	case "env":
 		cmd.PersistentFlags().StringSliceVarP(&do.Env, "env", "e", nil, "multiple env vars can be passed using the KEY1=val1,KEY2=val2 syntax") //last digit; 1 or 2?
 	case "links":
 		cmd.PersistentFlags().StringSliceVarP(&do.Links, "links", "l", nil, "multiple containers can be linked can be passed using the KEY1:val1,KEY2:val2 syntax")
-		//logs
 	case "follow":
 		cmd.Flags().BoolVarP(&do.Follow, "follow", "f", false, "follow logs, like tail -f")
 	case "tail":
 		cmd.Flags().StringVarP(&do.Tail, "tail", "t", "150", "number of lines to show from end of logs")
-		//remove
 	case "file":
-		if typ == "action" {
-			cmd.Flags().BoolVarP(&do.File, "file", "f", false, fmt.Sprintf("remove %s definition file", typ))
-		} else {
-			cmd.Flags().BoolVarP(&do.File, "file", "", false, fmt.Sprintf("remove %s definition file as well as %s container", typ, typ))
-		}
-	case "chain":
-		if typ == "service" {
-			cmd.Flags().StringVarP(&do.ChainName, "chain", "c", "", "specify a chain the service depends on")
-		} else if typ == "action" {
-			cmd.Flags().StringVarP(&do.ChainName, "chain", "c", "", "run action against a particular chain")
-		} else {
-		}
-	case "csv":
-		if typ == "chain" {
-			cmd.PersistentFlags().StringVarP(&do.CSV, "csv", "", "", "render a genesis.json from a csv file")
-		} else if typ == "files" {
-			cmd.Flags().StringVarP(&do.CSV, "csv", "", "", "specify a .csv with entries of format: hash,fileName")
-		}
+		cmd.Flags().BoolVarP(&do.File, "file", "", false, fmt.Sprintf("remove %s definition file as well as %s container", typ, typ))
 	case "services":
 		cmd.Flags().StringSliceVarP(&do.ServicesSlice, "services", "s", []string{}, "comma separated list of services to start")
 	case "config":

--- a/cmd/man_template.go
+++ b/cmd/man_template.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Rendering Cobra commands directly to groff_mdoc(7).
-// This method is preffered here to using Cobra's GenMan() and GenManTree()
+// This method is preferred here to using Cobra's GenMan() and GenManTree()
 // functions. Those unjustifiably use intermediary Markdown format and in turn
 // convert it to the old-fashioned and less flexible groff_man(7)
 // macros using the "github.com/cpuguy83/go-md2man/md2man" package.

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -272,7 +272,7 @@ func addServicesFlags() {
 	buildFlag(servicesStart, do, "ports", "service")
 	buildFlag(servicesStart, do, "env", "service")
 	buildFlag(servicesStart, do, "links", "service")
-	buildFlag(servicesStart, do, "chain", "service")
+	servicesStart.Flags().StringVarP(&do.ChainName, "chain", "c", "", "specify a chain the service depends on")
 
 	buildFlag(servicesStop, do, "rm", "service")
 	buildFlag(servicesStop, do, "volumes", "service")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -3,8 +3,8 @@ package commands
 import (
 	"github.com/eris-ltd/eris-cli/update"
 
-	"github.com/spf13/cobra"
 	. "github.com/eris-ltd/common/go/common"
+	"github.com/spf13/cobra"
 )
 
 var Update = &cobra.Command{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -374,7 +374,7 @@ Verbose = true
 `)
 	defer removeErisDir()
 
-	config, err := LoadViperConfig(configErisDir, "eris", "test")
+	config, err := LoadViperConfig(configErisDir, "eris")
 	if err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
@@ -403,7 +403,7 @@ func TestLoadViperConfigEmpty(t *testing.T) {
 	placeErisConfig(``)
 	defer removeErisDir()
 
-	config, err := LoadViperConfig(configErisDir, "eris", "test")
+	config, err := LoadViperConfig(configErisDir, "eris")
 	if err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
@@ -432,21 +432,21 @@ func TestLoadViperConfigBad(t *testing.T) {
 	placeErisConfig(`*`)
 	defer removeErisDir()
 
-	_, err := LoadViperConfig(configErisDir, "eris", "test")
+	_, err := LoadViperConfig(configErisDir, "eris")
 	if err == nil {
 		t.Fatalf("expected failure, got nil")
 	}
 }
 
 func TestLoadViperConfigNonExistent1(t *testing.T) {
-	_, err := LoadViperConfig(configErisDir, "eris", "test")
+	_, err := LoadViperConfig(configErisDir, "eris")
 	if err == nil {
 		t.Fatalf("expected failure, got nil")
 	}
 }
 
 func TestLoadViperConfigNonExistent2(t *testing.T) {
-	_, err := LoadViperConfig(configErisDir, "12345", "test")
+	_, err := LoadViperConfig(configErisDir, "12345")
 	if err == nil {
 		t.Fatalf("expected failure, got nil")
 	}

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit("data"))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
 
 	exitCode := m.Run()
 	tests.IfExit(tests.TestsTearDown())

--- a/data/operate.go
+++ b/data/operate.go
@@ -47,7 +47,7 @@ func ImportData(do *definitions.Do) error {
 		exists := perform.ContainerExists(srv.Operations.SrvContainerName)
 
 		if !exists {
-			return fmt.Errorf("There is no data container for service %q", do.Name, srv.Operations.SrvContainerName)
+			return fmt.Errorf("There is no data container for service %q", do.Name)
 		}
 		if err := checkErisContainerRoot(do, "import"); err != nil {
 			return err

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -66,8 +66,8 @@ type Do struct {
 	ConfigOpts    []string `mapstructure:"," json:"," yaml:"," toml:","`
 	AccountTypes  []string `mapstructure:"," json:"," yaml:"," toml:","`
 
-	// update 
-	Branch  string `mapstructure:"," json:"," yaml:"," toml:","`
+	// update
+	Branch string `mapstructure:"," json:"," yaml:"," toml:","`
 	// XXX below requested by @kootpv. to implement once command is stable
 	// Commit  string `mapstructure:"," json:"," yaml:"," toml:","`
 	// Version string `mapstructure:"," json:"," yaml:"," toml:","`

--- a/definitions/operation.go
+++ b/definitions/operation.go
@@ -19,9 +19,9 @@ type Operation struct {
 	Ports             string            `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	Labels            map[string]string `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 	PublishAllPorts   bool              `json:",omitempty" yaml:",omitempty" toml:",omitempty"`
-	CapAdd            []string          `mapstructure:",omitempty", json:",omitempty" yaml:",omitempty" toml:",omitempty"`
-	CapDrop           []string          `mapstructure:",omitempty", json:",omitempty" yaml:",omitempty" toml:",omitempty"`
-	Args              []string          `mapstructure:",omitempty", json:",omitempty" yaml:",omitempty" toml:",omitempty"`
+	CapAdd            []string          `mapstructure:",omitempty" json:",omitempty" yaml:",omitempty" toml:",omitempty"`
+	CapDrop           []string          `mapstructure:",omitempty" json:",omitempty" yaml:",omitempty" toml:",omitempty"`
+	Args              []string          `mapstructure:",omitempty" json:",omitempty" yaml:",omitempty" toml:",omitempty"`
 }
 
 func BlankOperation() *Operation {

--- a/definitions/pkg.go
+++ b/definitions/pkg.go
@@ -21,14 +21,14 @@ type Package struct {
 	// Dependencies to be booted before the package is ran
 	Dependencies *Dependencies `mapstructure:"dependencies" json:"dependencies" yaml:"dependencies" toml:"dependencies"`
 
-	Maintainer *Maintainer `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
-	Location   *Location   `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
-	AppType    *AppType    `json:"app_type,omitempty" yaml:"app_type,omitempty" toml:"app_type,omitempty"`
-	Chain      *Chain
-	Srvs       []*Service
-	Operations *Operation
+	Maintainer        *Maintainer `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
+	Location          *Location   `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
+	AppType           *AppType    `json:"app_type,omitempty" yaml:"app_type,omitempty" toml:"app_type,omitempty"`
+	Chain             *Chain
+	Srvs              []*Service
+	Operations        *Operation
 	SkipContractsPath bool
-	SkipABIPath bool
+	SkipABIPath       bool
 }
 
 func BlankPackageDefinition() *PackageDefinition {

--- a/definitions/service_definition.go
+++ b/definitions/service_definition.go
@@ -10,7 +10,7 @@ type ServiceDefinition struct {
 	Chain string `json:"chain,omitempty" yaml:"chain,omitempty" toml:"chain,omitempty"`
 
 	Service      *Service      `json:"service" yaml:"service" toml:"service"`
-	Dependencies *Dependencies `json:"dependencies,omitempty", yaml:"dependencies,omitempty" toml:"dependencies,omitempty"`
+	Dependencies *Dependencies `json:"dependencies,omitempty" yaml:"dependencies,omitempty" toml:"dependencies,omitempty"`
 	Maintainer   *Maintainer   `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
 	Location     *Location     `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
 	Machine      *Machine      `json:"machine,omitempty" yaml:"machine,omitempty" toml:"machine,omitempty"`

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -25,9 +25,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	// log.SetLevel(log.ErrorLevel)
+	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)
-	log.SetLevel(log.DebugLevel)
+	// log.SetLevel(log.DebugLevel)
 
 	// Prevent CLI from starting IPFS.
 	os.Setenv("ERIS_SKIP_ENSURE", "true")

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 	// Prevent CLI from starting IPFS.
 	os.Setenv("ERIS_SKIP_ENSURE", "true")
 
-	tests.IfExit(tests.TestsInit("files"))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
 	exitCode := m.Run()
 	tests.IfExit(tests.TestsTearDown())
 	os.Exit(exitCode)

--- a/files/handle.go
+++ b/files/handle.go
@@ -15,9 +15,9 @@ import (
 	"github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/util"
 
-	log "github.com/eris-ltd/eris-logger"
 	. "github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/common/go/ipfs"
+	log "github.com/eris-ltd/eris-logger"
 )
 
 func GetFiles(do *definitions.Do) error {
@@ -412,10 +412,9 @@ func isHashAnObject(ipfsHash string) (bool, error) {
 	if err != nil {
 		return dirBool, err
 	}
-	if util.TrimString(result) == "" { //not a dir
-		return dirBool, nil // false
-	} else { //something is in there, must be a dir
+	if util.TrimString(result) != "" { //not a dir
 		return true, nil
 	}
+
 	return dirBool, nil
 }

--- a/initialize/initialize_test.go
+++ b/initialize/initialize_test.go
@@ -35,7 +35,6 @@ func TestMain(m *testing.M) {
 	toadUp = toadServerUp()
 
 	exitCode := m.Run()
-	log.Info("Commensing with Tests Tear Down.")
 	ifExit(testsTearDown())
 	os.Exit(exitCode)
 }
@@ -93,6 +92,7 @@ func testDrops(dir, kind string) error {
 	if err := os.MkdirAll(dirGit, 0777); err != nil {
 		ifExit(err)
 	}
+
 	switch kind {
 	case "services":
 		//pull from toadserver
@@ -125,6 +125,13 @@ func testDrops(dir, kind string) error {
 			ifExit(err)
 		}
 	}
+
+	readDirs(dirToad, dirGit, toadUp)
+
+	return nil
+}
+
+func readDirs(dirToad, dirGit string, toadUp bool) {
 	//read dirs
 	toads, err := ioutil.ReadDir(dirToad)
 	if err != nil {
@@ -149,7 +156,7 @@ func testDrops(dir, kind string) error {
 			}
 		}
 	}
-	return nil
+
 }
 
 func toadServerUp() bool {

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit("keys"))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
 
 	exitCode := m.Run()
 	tests.IfExit(tests.TestsTearDown())

--- a/list/containers.go
+++ b/list/containers.go
@@ -234,7 +234,7 @@ func render(buf *bytes.Buffer, t string, truncate bool, header, format string) e
 		}
 
 		if err := tmplTable.Execute(buf, container); err != nil {
-			return fmt.Errorf("Listing template exec error: %v\n")
+			return fmt.Errorf("Listing template exec error: %v\n", err)
 		}
 
 		buf.WriteString("\n")

--- a/list/definitions.go
+++ b/list/definitions.go
@@ -48,11 +48,9 @@ func Known(t, format string) error {
 		return jsonKnown(definitions)
 	case format != "":
 		return customKnown(definitions, format)
-	default:
-		return columnizeKnown(definitions)
 	}
 
-	return nil
+	return columnizeKnown(definitions)
 }
 
 func jsonKnown(definitions []Definition) error {

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -10,15 +10,16 @@ import (
 	"github.com/eris-ltd/eris-cli/util"
 	"github.com/eris-ltd/eris-cli/version"
 
-	. "github.com/eris-ltd/common/go/common"
+	"github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-logger"
 
 	"github.com/spf13/viper"
 )
 
+// Standard package commands.
 const (
 	ErisChainStart    = "run"
-	ErisChainStartApi = "api"
+	ErisChainStartAPI = "api"
 	ErisChainInstall  = "install"
 	ErisChainNew      = "new"
 	ErisChainRegister = "register"
@@ -37,7 +38,7 @@ func LoadChainDefinition(chainName string) (*definitions.Chain, error) {
 		return nil, err
 	}
 
-	definition, err := config.LoadViperConfig(filepath.Join(ChainsPath), chainName)
+	definition, err := config.LoadViperConfig(filepath.Join(common.ChainsPath), chainName)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +63,9 @@ func LoadChainDefinition(chainName string) (*definitions.Chain, error) {
 	return chain, nil
 }
 
-// Convert the chain def to a service def but keep the "eris_chains" containers prefix and set the chain id
+// ChainsAsAService convert the chain definition to a service one
+// and set the CHAIN_ID environment variable. ChainsAsAService
+// can return config load errors.
 func ChainsAsAService(chainName string) (*definitions.ServiceDefinition, error) {
 	chain, err := LoadChainDefinition(chainName)
 	if err != nil {
@@ -94,10 +97,15 @@ func ChainsAsAService(chainName string) (*definitions.ServiceDefinition, error) 
 	return s, nil
 }
 
+// ConnectToAChain operates in two ways
+//  - if link is true, sets srv.Links to point to a chain container specifiend by name:internalName
+//  - if mount is true, sets srv.VolumesFrom to point to a chain container specified by name
 func ConnectToAChain(srv *definitions.Service, ops *definitions.Operation, name, internalName string, link, mount bool) {
 	connectToAService(srv, ops, definitions.TypeChain, name, internalName, link, mount)
 }
 
+// MockChainDefinition creates a chain definition with necessary fields
+// already filled in.
 func MockChainDefinition(chainName, chainID string) *definitions.Chain {
 	chn := definitions.BlankChain()
 	chn.Name = chainName
@@ -139,7 +147,7 @@ func MarshalChainDefinition(definition *viper.Viper, chain *definitions.Chain) e
 }
 
 func setChainDefaults(chain *definitions.Chain) error {
-	cfg, err := config.LoadViperConfig(filepath.Join(ChainsPath), "default")
+	cfg, err := config.LoadViperConfig(filepath.Join(common.ChainsPath), "default")
 	if err != nil {
 		return err
 	}

--- a/loaders/loaders_test.go
+++ b/loaders/loaders_test.go
@@ -1,0 +1,856 @@
+package loaders
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/eris-ltd/common/go/common"
+	def "github.com/eris-ltd/eris-cli/definitions"
+	"github.com/eris-ltd/eris-cli/tests"
+	"github.com/eris-ltd/eris-cli/util"
+	ver "github.com/eris-ltd/eris-cli/version"
+
+	log "github.com/eris-ltd/eris-logger"
+)
+
+type ab struct {
+	name string
+	a, b interface{}
+}
+
+func TestMain(m *testing.M) {
+	log.SetLevel(log.ErrorLevel)
+	// log.SetLevel(log.InfoLevel)
+	// log.SetLevel(log.DebugLevel)
+
+	tests.IfExit(tests.TestsInit(tests.DontPull))
+
+	exitCode := m.Run()
+
+	tests.IfExit(tests.TestsTearDown())
+
+	os.Exit(exitCode)
+}
+
+func TestLoadChainDefinitionEmptyDefault(t *testing.T) {
+	const (
+		name = "test"
+
+		definition = `
+name = "` + name + `"
+chain_id = "` + name + `"
+description = "test chain"
+
+[service]
+name           = "random name"
+image          = "test image"
+data_container = true
+ports          = [ "1234" ]
+`
+	)
+
+	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", ``); err != nil {
+		t.Fatalf("cannot place a default definition file")
+	}
+	if err := tests.FakeDefinitionFile(common.ChainsPath, name, definition); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	d, err := LoadChainDefinition(name)
+	if err != nil {
+		t.Fatalf("expected to load chain definition, got %v", err)
+	}
+
+	for _, entry := range []ab{
+		{`Name`, d.Name, name},
+		{`ChainID`, d.ChainID, name},
+		{`ContainerType`, d.Operations.ContainerType, def.TypeChain},
+		{`SrvContainerName`, d.Operations.SrvContainerName, util.ChainContainerName(name)},
+		{`DataContainerName`, d.Operations.DataContainerName, util.DataContainerName(name)},
+
+		{`Labels["ERIS"]`, d.Operations.Labels[def.LabelEris], "true"},
+		{`Labels["NAME"]`, d.Operations.Labels[def.LabelShortName], name},
+		{`Labels["TYPE"]`, d.Operations.Labels[def.LabelType], def.TypeChain},
+
+		{`Service.Name`, d.Service.Name, name},
+		{`Service.AutoData`, d.Service.AutoData, true},
+		{`Service.Image`, d.Service.Image, "test image"},
+		{`Service.Ports`, d.Service.Ports, []string{"1234"}},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("marshalled definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestLoadChainDefinitionEmptyDefinition(t *testing.T) {
+	const (
+		name = "test"
+
+		defaultDefinition = `
+name = "` + name + `"
+chain_id = "` + name + `"
+description = "test chain"
+
+[service]
+name           = "random name"
+image          = "test image"
+data_container = true
+ports          = [ "1234" ]
+
+[dependencies]
+services = [ "keys" ]
+
+[maintainer]
+name = "Eris Industries"
+email = "support@erisindustries.com"
+`
+	)
+
+	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", defaultDefinition); err != nil {
+		t.Fatalf("cannot place a default definition file")
+	}
+	if err := tests.FakeDefinitionFile(common.ChainsPath, name, ``); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	d, err := LoadChainDefinition(name)
+	if err != nil {
+		t.Fatalf("expected to load chain definition, got %v", err)
+	}
+
+	for _, entry := range []ab{
+		{`Name`, d.Name, name},
+		{`ChainID`, d.ChainID, ""},
+		{`ContainerType`, d.Operations.ContainerType, def.TypeChain},
+		{`SrvContainerName`, d.Operations.SrvContainerName, util.ChainContainerName(name)},
+		{`DataContainerName`, d.Operations.DataContainerName, util.DataContainerName(name)},
+
+		{`Labels["ERIS"]`, d.Operations.Labels[def.LabelEris], "true"},
+		{`Labels["NAME"]`, d.Operations.Labels[def.LabelShortName], name},
+		{`Labels["TYPE"]`, d.Operations.Labels[def.LabelType], def.TypeChain},
+
+		{`Service.Name`, d.Service.Name, name},
+		// [pv]: "data_container" is not loaded from the default.toml. A bug?
+		{`Service.AutoData`, d.Service.AutoData, false},
+		{`Service.Image`, d.Service.Image, "test image"},
+		{`Service.Ports`, d.Service.Ports, []string{"1234"}},
+
+		{`Dependencies`, d.Dependencies.Services, []string{"keys"}},
+		{`Maintainer`, d.Maintainer.Email, "support@erisindustries.com"},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("marshalled definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestLoadChainDefinitionEmptyDefaultAndDefinition(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", ``); err != nil {
+		t.Fatalf("cannot place a default definition file")
+	}
+	if err := tests.FakeDefinitionFile(common.ChainsPath, name, ``); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	d, err := LoadChainDefinition(name)
+	if err != nil {
+		t.Fatalf("expected to load chain definition, got %v", err)
+	}
+
+	for _, entry := range []ab{
+		{`Name`, d.Name, name},
+		{`ChainID`, d.ChainID, ""},
+		{`ContainerType`, d.Operations.ContainerType, def.TypeChain},
+		{`SrvContainerName`, d.Operations.SrvContainerName, util.ChainContainerName(name)},
+		{`DataContainerName`, d.Operations.DataContainerName, util.DataContainerName(name)},
+
+		{`Labels["ERIS"]`, d.Operations.Labels[def.LabelEris], "true"},
+		{`Labels["NAME"]`, d.Operations.Labels[def.LabelShortName], name},
+		{`Labels["TYPE"]`, d.Operations.Labels[def.LabelType], def.TypeChain},
+
+		{`Service.Name`, d.Service.Name, name},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("marshalled definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestLoadChainDefinitionOverwrite(t *testing.T) {
+	const (
+		name = "test"
+
+		defaultDefinition = `
+[service]
+name           = "random default name"
+image          = "default image"
+data_container = true
+ports          = [ "1234" ]
+
+[dependencies]
+chains = [ "something" ]
+
+[maintainer]
+name = "Eris Industries"
+email = "support@erisindustries.com"
+`
+
+		definition = `
+name = "` + name + `"
+chain_id = "` + name + `"
+description = "test chain"
+
+[service]
+name           = "random name"
+image          = "test image"
+data_container = true
+ports          = [ "4321" ]
+`
+	)
+
+	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", defaultDefinition); err != nil {
+		t.Fatalf("cannot place a default definition file")
+	}
+	if err := tests.FakeDefinitionFile(common.ChainsPath, name, definition); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	d, err := LoadChainDefinition(name)
+	if err != nil {
+		t.Fatalf("expected to load chain definition, got %v", err)
+	}
+
+	for _, entry := range []ab{
+		{`Name`, d.Name, name},
+		{`ChainID`, d.ChainID, name},
+		{`ContainerType`, d.Operations.ContainerType, def.TypeChain},
+		{`SrvContainerName`, d.Operations.SrvContainerName, util.ChainContainerName(name)},
+		{`DataContainerName`, d.Operations.DataContainerName, util.DataContainerName(name)},
+
+		{`Labels["ERIS"]`, d.Operations.Labels[def.LabelEris], "true"},
+		{`Labels["NAME"]`, d.Operations.Labels[def.LabelShortName], name},
+		{`Labels["TYPE"]`, d.Operations.Labels[def.LabelType], def.TypeChain},
+
+		{`Service.Name`, d.Service.Name, name},
+		{`Service.AutoData`, d.Service.AutoData, true},
+		{`Service.Image`, d.Service.Image, "test image"},
+		// [pv]: ports are mixed, not overwritten! (util.Merge behaviour)
+		{`Service.Ports`, d.Service.Ports, []string{"1234", "4321"}},
+
+		{`Dependencies`, d.Dependencies.Chains, []string{"something"}},
+		{`Maintainer`, d.Maintainer.Email, "support@erisindustries.com"},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("marshalled definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestLoadChainDefinitionMissingDefault(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	os.Remove(filepath.Join(common.ChainsPath, "default.toml"))
+
+	if err := tests.FakeDefinitionFile(common.ChainsPath, name, ``); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	if _, err := LoadChainDefinition(name); err == nil {
+		t.Fatalf("expected load to fail")
+	}
+}
+
+func TestLoadChainDefinitionBadFormatDefault(t *testing.T) {
+	const (
+		name = "test"
+
+		defaultDefinition = `name = [ "keys" ]`
+	)
+
+	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", defaultDefinition); err != nil {
+		t.Fatalf("cannot place a default definition file")
+	}
+	if err := tests.FakeDefinitionFile(common.ChainsPath, name, ``); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	if _, err := LoadChainDefinition(name); err == nil {
+		t.Fatalf("expected load to fail")
+	}
+}
+
+func TestLoadChainDefinitionMissingDefinition(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	os.Remove(filepath.Join(common.ChainsPath, name+".toml"))
+
+	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", ``); err != nil {
+		t.Fatalf("cannot place a default definition file")
+	}
+
+	if _, err := LoadChainDefinition(name); err == nil {
+		t.Fatalf("expected load to fail")
+	}
+}
+
+func TestLoadChainDefinitionBadFormatDefinition(t *testing.T) {
+	const (
+		name = "test"
+
+		definition = `name = [ "keys" ]`
+	)
+
+	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", ``); err != nil {
+		t.Fatalf("cannot place a default definition file")
+	}
+	if err := tests.FakeDefinitionFile(common.ChainsPath, name, definition); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	if _, err := LoadChainDefinition(name); err == nil {
+		t.Fatalf("expected load to fail")
+	}
+}
+
+func TestChainsAsAServiceSimple(t *testing.T) {
+	const (
+		name = "test"
+
+		definition = `
+name = "` + name + `"
+chain_id = "` + name + `"
+description = "test chain"
+
+[service]
+name           = "random name"
+data_container = true
+ports          = [ "1234" ]
+image          = "test image"
+`
+	)
+
+	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", ``); err != nil {
+		t.Fatalf("cannot place a default definition file")
+	}
+	if err := tests.FakeDefinitionFile(common.ChainsPath, name, definition); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	s, err := ChainsAsAService(name)
+	if err != nil {
+		t.Fatalf("expected to load chain definition, got %v", err)
+	}
+
+	for _, entry := range []ab{
+		{`Name`, s.Name, name},
+		{`ContainerType`, s.Operations.ContainerType, def.TypeChain},
+		{`SrvContainerName`, s.Operations.SrvContainerName, util.ChainContainerName(name)},
+		{`DataContainerName`, s.Operations.DataContainerName, util.DataContainerName(name)},
+
+		{`Labels["ERIS"]`, s.Operations.Labels[def.LabelEris], "true"},
+		{`Labels["NAME"]`, s.Operations.Labels[def.LabelShortName], name},
+		{`Labels["TYPE"]`, s.Operations.Labels[def.LabelType], def.TypeChain},
+
+		{`Service.Name`, s.Service.Name, name},
+		{`Service.AutoData`, s.Service.AutoData, true},
+		// [pv]: not "test image", but erisdb image. A bug?
+		{`Service.Image`, s.Service.Image, path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_DB)},
+		{`Service.Environment`, s.Service.Environment, []string{"CHAIN_ID=" + name}},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("marshalled definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestChainsAsAServiceMissing(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	os.Remove(filepath.Join(common.ChainsPath, name+".toml"))
+
+	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", ``); err != nil {
+		t.Fatalf("cannot place a default definition file")
+	}
+
+	if _, err := ChainsAsAService(name); err == nil {
+		t.Fatalf("expected chains as a service to fail")
+	}
+}
+
+func TestMockChainDefinition(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	d := MockChainDefinition(name, "id")
+
+	for _, entry := range []ab{
+		{`Name`, d.Name, name},
+		{`ChainID`, d.ChainID, "id"},
+		{`ContainerType`, d.Operations.ContainerType, def.TypeChain},
+		{`SrvContainerName`, d.Operations.SrvContainerName, util.ChainContainerName(name)},
+		{`DataContainerName`, d.Operations.DataContainerName, util.DataContainerName(name)},
+
+		{`Labels["ERIS"]`, d.Operations.Labels[def.LabelEris], "true"},
+		{`Labels["NAME"]`, d.Operations.Labels[def.LabelShortName], name},
+		{`Labels["TYPE"]`, d.Operations.Labels[def.LabelType], def.TypeChain},
+
+		{`Service.Name`, d.Service.Name, name},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("mock definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+
+}
+
+func TestMockChainDefinitionBlankNames(t *testing.T) {
+	d := MockChainDefinition("", "")
+
+	for _, entry := range []ab{
+		{`Name`, d.Name, ""},
+		{`ChainID`, d.ChainID, ""},
+		{`ContainerType`, d.Operations.ContainerType, def.TypeChain},
+		{`SrvContainerName`, d.Operations.SrvContainerName, util.ChainContainerName("")},
+		{`DataContainerName`, d.Operations.DataContainerName, util.DataContainerName("")},
+
+		{`Labels["ERIS"]`, d.Operations.Labels[def.LabelEris], "true"},
+		{`Labels["NAME"]`, d.Operations.Labels[def.LabelShortName], ""},
+		{`Labels["TYPE"]`, d.Operations.Labels[def.LabelType], def.TypeChain},
+
+		{`Service.Name`, d.Service.Name, ""},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("mock definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestLoadDataDefinition(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	d := LoadDataDefinition(name)
+
+	for _, entry := range []ab{
+		{`ContainerType`, d.ContainerType, def.TypeData},
+		{`SrvContainerName`, d.SrvContainerName, util.DataContainerName(name)},
+		{`DataContainerName`, d.DataContainerName, util.DataContainerName(name)},
+
+		{`Labels["ERIS"]`, d.Labels[def.LabelEris], "true"},
+		{`Labels["NAME"]`, d.Labels[def.LabelShortName], name},
+		{`Labels["TYPE"]`, d.Labels[def.LabelType], def.TypeData},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestLoadPackageSimple(t *testing.T) {
+	const (
+		name = "test"
+
+		definition = `
+[eris]
+name       = "` + name + `"
+package_id = "` + name + `"
+chain_name = "test chain"
+chain_id   = "test id"
+`
+	)
+
+	if err := tests.FakeDefinitionFile(common.ErisRoot, "package", definition); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	d, err := LoadPackage(common.ErisRoot, name)
+	if err != nil {
+		t.Fatalf("expected to load definition file, got %v", err)
+	}
+
+	for _, entry := range []ab{
+		{`Name`, d.Name, name},
+		{`PackageID`, d.PackageID, name},
+		{`ChainName`, d.ChainName, "test chain"},
+		{`ChainID`, d.ChainID, "test id"},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestLoadPackageDirectoryAndSpacesInAName(t *testing.T) {
+	const (
+		name = "test test"
+
+		definition = `
+name       = "` + name + `"
+
+[eris]
+name       = "` + name + `"
+package_id = "` + name + `"
+chain_name = "test chain"
+chain_id   = "test id"
+`
+	)
+
+	if err := tests.FakeDefinitionFile(common.ErisRoot, "package", definition); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	d, err := LoadPackage(filepath.Join(common.ErisRoot, "package.toml"), name)
+	if err != nil {
+		t.Fatalf("expected to load definition file, got %v", err)
+	}
+
+	for _, entry := range []ab{
+		{`Name`, d.Name, "test_test"},
+		{`PackageID`, d.PackageID, name},
+		{`ChainName`, d.ChainName, "test chain"},
+		{`ChainID`, d.ChainID, "test id"},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestLoadPackageNotFound1(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	os.Remove(filepath.Join(common.ErisRoot, "package.toml"))
+
+	if _, err := LoadPackage("/non/existent/path", name); err == nil {
+		t.Fatalf("expected definition fail to load")
+	}
+}
+
+func TestLoadPackageNotFound2(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	os.Remove(filepath.Join(common.ErisRoot, "package.toml"))
+
+	d, err := LoadPackage(common.ErisRoot, "")
+	if err != nil {
+		t.Fatalf("expected definition to load default, got %v", err)
+	}
+
+	for _, entry := range []ab{
+		{`Name`, d.Name, "eris"},
+		{`PackageID`, d.PackageID, ""},
+		{`ChainName`, d.ChainName, ""},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestLoadPackageNotFound3(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	os.Remove(filepath.Join(common.ErisRoot, "package.toml"))
+
+	d, err := LoadPackage(common.ErisRoot, name)
+	if err != nil {
+		t.Fatalf("expected definition to load default, got %v", err)
+	}
+
+	for _, entry := range []ab{
+		{`Name`, d.Name, "eris"},
+		{`PackageID`, d.PackageID, ""},
+		{`ChainName`, d.ChainName, name},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestLoadPackageBadFormat(t *testing.T) {
+	const (
+		name = "test"
+
+		definition = `
+[eris]
+name       = [ "keys"]
+`
+	)
+
+	if err := tests.FakeDefinitionFile(common.ErisRoot, "package", definition); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	if _, err := LoadPackage(common.ErisRoot, name); err == nil {
+		t.Fatalf("expected definition fail to load")
+	}
+}
+
+func TestLoadServiceDefinitionSimple(t *testing.T) {
+	const (
+		name       = "test"
+		definition = `
+name = "` + name + `"
+description = "description"
+status = "in production"
+
+[service]
+image = "test image"
+data_container = true
+ports = [ "1234" ]
+
+[location]
+repository = "https://example.com"
+`
+	)
+
+	if err := tests.FakeDefinitionFile(common.ServicesPath, name, definition); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	d, err := LoadServiceDefinition(name)
+	if err != nil {
+		t.Fatalf("expected definition to load, got %v", err)
+	}
+
+	for _, entry := range []ab{
+		{`Name`, d.Name, name},
+
+		{`ContainerType`, d.Operations.ContainerType, def.TypeService},
+		{`SrvContainerName`, d.Operations.SrvContainerName, util.ServiceContainerName(name)},
+		{`DataContainerName`, d.Operations.DataContainerName, util.DataContainerName(name)},
+
+		{`Labels["ERIS"]`, d.Operations.Labels[def.LabelEris], "true"},
+		{`Labels["NAME"]`, d.Operations.Labels[def.LabelShortName], name},
+		{`Labels["TYPE"]`, d.Operations.Labels[def.LabelType], def.TypeService},
+
+		{`Service.Name`, d.Service.Name, name},
+		{`Service.AutoData`, d.Service.AutoData, true},
+		{`Service.Image`, d.Service.Image, "test image"},
+		{`Service.Ports`, d.Service.Ports, []string{"1234"}},
+
+		{`Location`, d.Location.Repository, "https://example.com"},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestLoadServiceDefinitionAlmostEmpty(t *testing.T) {
+	const (
+		name       = "test"
+		definition = `
+[service]
+image = "test image"
+`
+	)
+
+	if err := tests.FakeDefinitionFile(common.ServicesPath, name, definition); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	d, err := LoadServiceDefinition(name)
+	if err != nil {
+		t.Fatalf("expected definition to load, got %v", err)
+	}
+
+	for _, entry := range []ab{
+		{`Name`, d.Name, "test image"},
+
+		{`ContainerType`, d.Operations.ContainerType, def.TypeService},
+		{`SrvContainerName`, d.Operations.SrvContainerName, util.ServiceContainerName("test image")},
+		{`DataContainerName`, d.Operations.DataContainerName, util.DataContainerName("test image")},
+
+		{`Labels["ERIS"]`, d.Operations.Labels[def.LabelEris], "true"},
+		{`Labels["NAME"]`, d.Operations.Labels[def.LabelShortName], name},
+		{`Labels["TYPE"]`, d.Operations.Labels[def.LabelType], def.TypeService},
+
+		{`Service.Name`, d.Service.Name, "test image"},
+		{`Service.Image`, d.Service.Image, "test image"},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestLoadServiceDefinitionEmpty(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	if err := tests.FakeDefinitionFile(common.ServicesPath, name, ``); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	if _, err := LoadServiceDefinition(name); err == nil {
+		t.Fatalf("expected definition fail to load")
+	}
+}
+
+func TestLoadServiceDefinitionMissing(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	os.Remove(filepath.Join(common.ServicesPath, name+".toml"))
+
+	if _, err := LoadServiceDefinition(name); err == nil {
+		t.Fatalf("expected definition fail to load")
+	}
+}
+
+func TestLoadServiceDefinitionBadFormat(t *testing.T) {
+	const (
+		name = "test"
+
+		definition = `
+[service]
+image = [ "keys" ]
+`
+	)
+
+	if err := tests.FakeDefinitionFile(common.ServicesPath, name, definition); err != nil {
+		t.Fatalf("cannot place a definition file")
+	}
+
+	if _, err := LoadServiceDefinition(name); err == nil {
+		t.Fatalf("expected definition fail to load")
+	}
+}
+
+func TestMockServiceDefinition(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	d := MockServiceDefinition(name)
+
+	for _, entry := range []ab{
+		{`Name`, d.Name, name},
+
+		{`ContainerType`, d.Operations.ContainerType, def.TypeService},
+		{`SrvContainerName`, d.Operations.SrvContainerName, util.ServiceContainerName(name)},
+		{`DataContainerName`, d.Operations.DataContainerName, util.DataContainerName(name)},
+
+		{`Labels["ERIS"]`, d.Operations.Labels[def.LabelEris], "true"},
+		{`Labels["NAME"]`, d.Operations.Labels[def.LabelShortName], name},
+		{`Labels["TYPE"]`, d.Operations.Labels[def.LabelType], def.TypeService},
+
+		{`Service.Name`, d.Service.Name, name},
+		// [pv]: Mock is allowed to return an empty image while load isn't?
+		{`Service.Image`, d.Service.Image, ""},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestServiceFinalizeLoadBlankNames(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	d := def.BlankServiceDefinition()
+	d.Service.Image = name
+
+	ServiceFinalizeLoad(d)
+	for _, entry := range []ab{
+		{`Name`, d.Name, name},
+
+		{`SrvContainerName`, d.Operations.SrvContainerName, util.ServiceContainerName(name)},
+		{`DataContainerName`, d.Operations.DataContainerName, util.DataContainerName(name)},
+
+		{`Service.Name`, d.Service.Name, name},
+		{`Service.Image`, d.Service.Image, name},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestServiceFinalizeLoadBlankName(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	d := def.BlankServiceDefinition()
+	d.Service.Name = name
+
+	ServiceFinalizeLoad(d)
+	for _, entry := range []ab{
+		{`Name`, d.Name, name},
+
+		{`SrvContainerName`, d.Operations.SrvContainerName, util.ServiceContainerName(name)},
+		{`DataContainerName`, d.Operations.DataContainerName, util.DataContainerName(name)},
+
+		{`Service.Name`, d.Service.Name, name},
+		{`Service.Image`, d.Service.Image, ""},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestServiceFinalizeLoadBlankServiceName(t *testing.T) {
+	const (
+		name = "test"
+	)
+
+	d := def.BlankServiceDefinition()
+	d.Name = name
+
+	ServiceFinalizeLoad(d)
+	for _, entry := range []ab{
+		{`Name`, d.Name, name},
+
+		{`SrvContainerName`, d.Operations.SrvContainerName, util.ServiceContainerName(name)},
+		{`DataContainerName`, d.Operations.DataContainerName, util.DataContainerName(name)},
+
+		{`Service.Name`, d.Service.Name, name},
+		{`Service.Image`, d.Service.Image, ""},
+	} {
+		if !reflect.DeepEqual(entry.a, entry.b) {
+			t.Fatalf("definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)
+		}
+	}
+}
+
+func TestServiceFinalizeLoadBlankAllTheThings(t *testing.T) {
+	defer func() {
+		recover()
+	}()
+
+	d := def.BlankServiceDefinition()
+
+	ServiceFinalizeLoad(d)
+
+	t.Fatalf("expected finalize to panic")
+}

--- a/loaders/pkgs.go
+++ b/loaders/pkgs.go
@@ -9,9 +9,9 @@ import (
 	"github.com/eris-ltd/eris-cli/config"
 	"github.com/eris-ltd/eris-cli/definitions"
 
-	"github.com/spf13/viper"
-
 	log "github.com/eris-ltd/eris-logger"
+
+	"github.com/spf13/viper"
 )
 
 func LoadPackage(path, chainName string) (*definitions.Package, error) {
@@ -52,16 +52,14 @@ func LoadPackage(path, chainName string) (*definitions.Package, error) {
 		}
 	}
 
-	if err := checkName(pkg, chainName); err != nil {
-		return nil, err
-	}
+	checkName(pkg, chainName)
 
 	return pkg, nil
 }
 
 // read the config file into viper
 func loadPackage(path string) (*viper.Viper, error) {
-	return config.LoadViperConfig(path, "package", "pkg")
+	return config.LoadViperConfig(path, "package")
 }
 
 // set's the defaults
@@ -69,7 +67,7 @@ func DefaultPackage(name, chainName string) *definitions.Package {
 	pkg := definitions.BlankPackage()
 	pkg.Name = name
 	pkg.ChainName = chainName
-	pkg.PackageID = "" // TODO hash it
+	pkg.PackageID = "" // TODO hash it. [pv]: would util.UniqueName(chainName) do?
 	return pkg
 }
 
@@ -77,26 +75,25 @@ func marshalPackage(pkgConf *viper.Viper) (*definitions.Package, error) {
 	pkgDef := definitions.BlankPackageDefinition()
 	err := pkgConf.Unmarshal(pkgDef)
 	pkg := pkgDef.Package
+
 	if pkgDef.Name != "" {
 		pkg.Name = pkgDef.Name
 	}
-
 	if err != nil {
-		return nil, fmt.Errorf("%v\n\nSorry, the marmots could not figure that package.json out.\nPlease check your package.json is properly formatted.\n", err)
+		return nil, fmt.Errorf(`Sorry, the marmots could not figure that package.json out: %v
+Please check your package.json file is properly formatted`, err)
 	}
 
 	return pkg, nil
 }
 
-func checkName(pkg *definitions.Package, name string) error {
+func checkName(pkg *definitions.Package, name string) {
 	if strings.Contains(pkg.Name, " ") {
 		newName := strings.Replace(pkg.Name, " ", "_", -1)
 		log.WithFields(log.Fields{
 			"old": pkg.Name,
 			"new": newName,
-		}).Debug("Correcting package name.")
+		}).Debug("Correcting package name")
 		pkg.Name = newName
 	}
-
-	return nil
 }

--- a/loaders/pkgs.go
+++ b/loaders/pkgs.go
@@ -14,6 +14,9 @@ import (
 	"github.com/spf13/viper"
 )
 
+// LoadPackage loads a package definition specified by the directory or
+// filename path and chainName and returns a package definition structure.
+// LoadPackage can also return missing files or package loading errors.
 func LoadPackage(path, chainName string) (*definitions.Package, error) {
 	var name string
 	var dir bool
@@ -45,7 +48,7 @@ func LoadPackage(path, chainName string) (*definitions.Package, error) {
 	} else {
 		// marshal chain and always reset the operational requirements
 		// this will make sure to sync with docker so that if changes
-		// have occured in the interim they are caught.
+		// have occurred in the interim they are caught.
 		pkg, err = marshalPackage(pkgConf)
 		if err != nil {
 			return nil, err
@@ -62,7 +65,8 @@ func loadPackage(path string) (*viper.Viper, error) {
 	return config.LoadViperConfig(path, "package")
 }
 
-// set's the defaults
+// DefaultPackage creates a package definition structure
+// with some fields already filled in.
 func DefaultPackage(name, chainName string) *definitions.Package {
 	pkg := definitions.BlankPackage()
 	pkg.Name = name

--- a/loaders/services.go
+++ b/loaders/services.go
@@ -10,12 +10,17 @@ import (
 	def "github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
 
-	. "github.com/eris-ltd/common/go/common"
+	"github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-logger"
 
 	"github.com/spf13/viper"
 )
 
+// LoadServiceDefinition reads a service definition specified by a service
+// name from the common.ServicesPath directory and returns the corresponding
+// service definition file.
+// LoadServiceDefinition can return missing file or definition file bad format
+// errors.
 func LoadServiceDefinition(servName string) (*definitions.ServiceDefinition, error) {
 	log.WithField("=>", servName).Debug("Loading service definition")
 
@@ -31,10 +36,6 @@ func LoadServiceDefinition(servName string) (*definitions.ServiceDefinition, err
 		return nil, err
 	}
 
-	// if srv.Service == nil {
-	// 	return nil, fmt.Errorf("No service given.")
-	// }
-
 	if err = checkImage(srv.Service); err != nil {
 		return nil, err
 	}
@@ -45,6 +46,8 @@ func LoadServiceDefinition(servName string) (*definitions.ServiceDefinition, err
 	return srv, nil
 }
 
+// MockServiceDefinition returns a service definition structure with
+// necessary fields already filled in (with an exception of the Image field).
 func MockServiceDefinition(servName string) *definitions.ServiceDefinition {
 	srv := definitions.BlankServiceDefinition()
 	srv.Name = servName
@@ -58,6 +61,8 @@ func MockServiceDefinition(servName string) *definitions.ServiceDefinition {
 	return srv
 }
 
+// MarshalServiceDefinition converts a Viper configuration structure to a
+// service definition one; it can return marshalling errors.
 func MarshalServiceDefinition(serviceConf *viper.Viper, srv *definitions.ServiceDefinition) error {
 	err := serviceConf.Unmarshal(srv)
 	if err != nil {
@@ -73,8 +78,9 @@ func MarshalServiceDefinition(serviceConf *viper.Viper, srv *definitions.Service
 	return nil
 }
 
-// These are things we want to *always* control. Should be last
-// called before a return...
+// ServiceFinalizeLoad performs sanity checks on the most import fields of the
+// service definition structure by filling in missing ones and avoiding
+// duplication. ServiceFinalizeLoad panics if all necessary fields are empty.
 func ServiceFinalizeLoad(srv *definitions.ServiceDefinition) {
 	if srv.Name == "" && srv.Service.Name == "" && srv.Service.Image == "" { // If no name or image, panic
 		panic("Service's Image should have been set before reaching ServiceFinalizeLoad")
@@ -94,14 +100,13 @@ func ServiceFinalizeLoad(srv *definitions.ServiceDefinition) {
 	srv.Operations.DataContainerName = util.ContainerName(def.TypeData, srv.Name)
 }
 
+// ConnectToAService operates in two ways
+//  - if link is true, sets srv.Links to point to a service container specifiend by name:internalName
+//  - if mount is true, sets srv.VolumesFrom to point to a service container specified by name
 func ConnectToAService(srv *definitions.Service, ops *definitions.Operation, name, internalName string, link, mount bool) {
 	connectToAService(srv, ops, definitions.TypeService, name, internalName, link, mount)
 }
 
-// --------------------------------------------------------------------
-// helpers
-
-// links and mounts for service dependencies
 func connectToAService(srv *definitions.Service, ops *definitions.Operation, typ, name, internalName string, link, mount bool) {
 	log.WithFields(log.Fields{
 		"=>":            srv.Name,
@@ -129,11 +134,11 @@ func connectToAService(srv *definitions.Service, ops *definitions.Operation, typ
 }
 
 func loadServiceDefinition(servName string) (*viper.Viper, error) {
-	return config.LoadViperConfig(filepath.Join(ServicesPath), servName)
+	return config.LoadViperConfig(filepath.Join(common.ServicesPath), servName)
 }
 
-// Services must be given an image. Flame out if they do not.
 func checkImage(srv *definitions.Service) error {
+	// Services must be given an image. Flame out if they do not.
 	if srv.Image == "" {
 		return fmt.Errorf(`An "image" field is required in the service definition file`)
 	}

--- a/perform/perform.go
+++ b/perform/perform.go
@@ -1182,9 +1182,7 @@ func checkImageExists(image string) (bool, error) {
 	if err != nil {
 		return fail, util.DockerError(err)
 	}
-	if len(anImage) != 1 {
-		return fail, nil
-	} else {
+	if len(anImage) == 1 {
 		return true, nil
 	}
 

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"runtime"
 
 	"github.com/eris-ltd/eris-cli/config"
 	def "github.com/eris-ltd/eris-cli/definitions"
@@ -500,6 +501,12 @@ func TestExecServiceVolume(t *testing.T) {
 		name = "ipfs"
 	)
 
+	// Don't work on Windows without MSYS or Cygwin.
+	// https://github.com/docker/docker/issues/12751
+	if runtime.GOOS == "windows" {
+		return
+	}
+
 	defer tests.RemoveAllContainers()
 
 	if util.Exists(def.TypeService, name) {
@@ -529,6 +536,12 @@ func TestExecServiceMount(t *testing.T) {
 	const (
 		name = "ipfs"
 	)
+
+	// Don't work on Windows without MSYS or Cygwin.
+	// https://github.com/docker/docker/issues/12751
+	if runtime.GOOS == "windows" {
+		return
+	}
 
 	defer tests.RemoveAllContainers()
 

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -22,7 +23,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit("perform"))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
 
 	tests.RemoveAllContainers()
 
@@ -195,7 +196,7 @@ func TestRunServiceSimple(t *testing.T) {
 		t.Fatalf("expecting data container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -223,7 +224,7 @@ func TestRunServiceNoDataContainer(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -241,6 +242,63 @@ func TestRunServiceNoDataContainer(t *testing.T) {
 	}
 }
 
+func TestRunServiceAlreadyRunning(t *testing.T) {
+	const (
+		name = "ipfs"
+	)
+
+	defer tests.RemoveAllContainers()
+
+	if util.Exists(def.TypeData, name) {
+		t.Fatalf("expecting data container doesn't exist")
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if !util.Running(def.TypeService, name) {
+		t.Fatalf("1. expecting service container running")
+	}
+	if !util.Exists(def.TypeData, name) {
+		t.Fatalf("1. expecting data container existing")
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected already running service to fail with nil")
+	}
+
+	if !util.Running(def.TypeService, name) {
+		t.Fatalf("2. expecting service container running")
+	}
+	if !util.Exists(def.TypeData, name) {
+		t.Fatalf("2. expecting data container existing")
+	}
+}
+
+func TestRunServiceNonExistentImage(t *testing.T) {
+	const (
+		name = "ipfs"
+	)
+
+	defer tests.RemoveAllContainers()
+
+	srv, err := loaders.LoadServiceDefinition(name)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Service.Image = "non existent"
+	if err := DockerRunService(srv.Service, srv.Operations); err == nil {
+		t.Fatalf("expected run service to fail")
+	}
+}
+
 func TestExecServiceSimple(t *testing.T) {
 	const (
 		name = "ipfs"
@@ -252,7 +310,7 @@ func TestExecServiceSimple(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -278,7 +336,7 @@ func TestExecServiceBufferNotOverwritten(t *testing.T) {
 
 	defer tests.RemoveAllContainers()
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -307,7 +365,7 @@ func TestExecServiceAlwaysRestart(t *testing.T) {
 
 	defer tests.RemoveAllContainers()
 
-	if err := tests.FakeServiceDefinition(tests.ErisDir, name, `
+	if err := tests.FakeServiceDefinition(name, `
 name = "`+name+`"
 
 [service]
@@ -324,7 +382,7 @@ restart = "always"
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -353,7 +411,7 @@ func TestExecServiceMaxAttemptsRestart(t *testing.T) {
 
 	defer tests.RemoveAllContainers()
 
-	if err := tests.FakeServiceDefinition(tests.ErisDir, name, `
+	if err := tests.FakeServiceDefinition(name, `
 name = "`+name+`"
 
 [service]
@@ -370,7 +428,7 @@ restart = "max:99"
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -399,7 +457,7 @@ func TestExecServiceNeverRestart(t *testing.T) {
 
 	defer tests.RemoveAllContainers()
 
-	if err := tests.FakeServiceDefinition(tests.ErisDir, name, `
+	if err := tests.FakeServiceDefinition(name, `
 name = "`+name+`"
 
 [service]
@@ -415,7 +473,7 @@ exec_host = "ERIS_KEYS_HOST"
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -437,6 +495,115 @@ exec_host = "ERIS_KEYS_HOST"
 	}
 }
 
+func TestExecServiceVolume(t *testing.T) {
+	const (
+		name = "ipfs"
+	)
+
+	defer tests.RemoveAllContainers()
+
+	if util.Exists(def.TypeService, name) {
+		t.Fatalf("expecting service container doesn't exist")
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Operations.Args = strings.Fields("uptime")
+	srv.Operations.Volume = filepath.Join(config.GlobalConfig.ErisDir)
+	if _, err := DockerExecService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if util.Running(def.TypeService, name) {
+		t.Fatalf("expecting service container not running")
+	}
+	if !util.Exists(def.TypeData, name) {
+		t.Fatalf("expecting dependend data container existing")
+	}
+}
+
+func TestExecServiceMount(t *testing.T) {
+	const (
+		name = "ipfs"
+	)
+
+	defer tests.RemoveAllContainers()
+
+	if util.Exists(def.TypeService, name) {
+		t.Fatalf("expecting service container doesn't exist")
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Operations.Args = strings.Fields("uptime")
+	srv.Service.Volumes = []string{
+		config.GlobalConfig.ErisDir + ":" + "/tmp",
+		config.GlobalConfig.ErisDir + ":" + "/custom",
+	}
+	if _, err := DockerExecService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if util.Running(def.TypeService, name) {
+		t.Fatalf("expecting service container not running")
+	}
+	if !util.Exists(def.TypeData, name) {
+		t.Fatalf("expecting dependend data container existing")
+	}
+}
+
+func TestExecServiceBadMount1(t *testing.T) {
+	const (
+		name = "ipfs"
+	)
+
+	defer tests.RemoveAllContainers()
+
+	if util.Exists(def.TypeService, name) {
+		t.Fatalf("expecting service container doesn't exist")
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Operations.Args = strings.Fields("uptime")
+	srv.Service.Volumes = []string{""}
+	if _, err := DockerExecService(srv.Service, srv.Operations); err == nil {
+		t.Fatalf("expected service container creation to fail")
+	}
+}
+
+func TestExecServiceBadMount2(t *testing.T) {
+	const (
+		name = "ipfs"
+	)
+
+	defer tests.RemoveAllContainers()
+
+	if util.Exists(def.TypeService, name) {
+		t.Fatalf("expecting service container doesn't exist")
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Operations.Args = strings.Fields("uptime")
+	srv.Service.Volumes = []string{config.GlobalConfig.ErisDir + ":"}
+	if _, err := DockerExecService(srv.Service, srv.Operations); err == nil {
+		t.Fatalf("expected service container creation to fail")
+	}
+}
+
 func TestExecServiceLogOutput(t *testing.T) {
 	const (
 		name = "ipfs"
@@ -448,7 +615,7 @@ func TestExecServiceLogOutput(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -475,7 +642,7 @@ func TestExecServiceLogOutputLongRunning(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -501,7 +668,7 @@ func TestExecServiceLogOutputInteractive(t *testing.T) {
 	if util.Exists(def.TypeService, name) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -529,7 +696,7 @@ func TestExecServiceTwice(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -564,7 +731,7 @@ func TestExecServiceTwiceWithoutData(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -599,7 +766,7 @@ func TestExecServiceBadCommandLine(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -629,7 +796,7 @@ func TestExecServiceNonInteractive(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -659,7 +826,7 @@ func TestExecServiceAfterRunService(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -686,7 +853,7 @@ func TestExecServiceAfterRunServiceWithPublishedPorts1(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -721,7 +888,7 @@ func TestExecServiceAfterRunServiceWithPublishedPorts2(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -756,7 +923,7 @@ func TestContainerExistsSimple(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -786,7 +953,7 @@ func TestContainerExistsBadName(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -808,7 +975,7 @@ func TestContainerExistsAfterRemove(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -839,7 +1006,7 @@ func TestContainerRunningSimple(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -869,7 +1036,7 @@ func TestContainerRunningBadName(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -899,7 +1066,7 @@ func TestContainerRunningAfterRemove(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -930,7 +1097,7 @@ func TestRemoveWithoutData(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -980,7 +1147,7 @@ func TestRemoveWithData(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1014,6 +1181,24 @@ func TestRemoveWithData(t *testing.T) {
 	}
 }
 
+func TestRemoveNonExistent(t *testing.T) {
+	const (
+		name = "ipfs"
+	)
+
+	defer tests.RemoveAllContainers()
+
+	srv, err := loaders.LoadServiceDefinition(name)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Operations.SrvContainerName = "non existent"
+	if err := DockerRemove(srv.Service, srv.Operations, true, true, false); err != nil {
+		t.Fatalf("expected container removal will fail with nil")
+	}
+}
+
 func TestRemoveServiceWithoutStopping(t *testing.T) {
 	const (
 		name = "ipfs"
@@ -1025,7 +1210,7 @@ func TestRemoveServiceWithoutStopping(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1050,7 +1235,7 @@ func TestStopSimple(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1087,7 +1272,7 @@ func TestStopDataContainer(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1114,7 +1299,7 @@ func TestRebuildSimple(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1148,7 +1333,7 @@ func TestRebuildBadName(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1172,7 +1357,7 @@ func TestRebuildNotCreated(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1195,7 +1380,7 @@ func TestRebuildTimeout0(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1229,7 +1414,7 @@ func TestRebuildNotRunning(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1271,7 +1456,7 @@ func TestRebuildPullDisallow(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1309,7 +1494,7 @@ func TestRebuildPull(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1345,7 +1530,7 @@ func TestRebuildPullRepeat(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1382,7 +1567,7 @@ func TestPullSimple(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1417,7 +1602,7 @@ func TestPullRepeat(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1446,7 +1631,7 @@ func TestPullBadName(t *testing.T) {
 
 	defer tests.RemoveAllContainers()
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1470,7 +1655,7 @@ func TestLogsSimple(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1495,6 +1680,40 @@ func TestLogsSimple(t *testing.T) {
 	}
 }
 
+func TestLogsNilConfig(t *testing.T) {
+	const (
+		name = "ipfs"
+		tail = "1"
+	)
+
+	defer tests.RemoveAllContainers()
+
+	savedConfig := config.GlobalConfig
+	config.GlobalConfig = nil
+	defer func() { config.GlobalConfig = savedConfig }()
+
+	if util.Exists(def.TypeService, name) {
+		t.Fatalf("expecting service container doesn't exist")
+	}
+
+	srv, err := loaders.LoadServiceDefinition(name)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	if err := DockerRunService(srv.Service, srv.Operations); err != nil {
+		t.Fatalf("expected service container created, got %v", err)
+	}
+
+	if err := DockerStop(srv.Service, srv.Operations, 5); err != nil {
+		t.Fatalf("expected service container to stop, got %v", err)
+	}
+
+	if err := DockerLogs(srv.Service, srv.Operations, false, tail); err != nil {
+		t.Fatalf("expected logs pulled, got %v", err)
+	}
+}
+
 func TestLogsFollow(t *testing.T) {
 	const (
 		name = "ipfs"
@@ -1507,7 +1726,7 @@ func TestLogsFollow(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1540,7 +1759,7 @@ func TestLogsTail(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1577,7 +1796,7 @@ func TestLogsTail0(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1610,15 +1829,32 @@ func TestLogsBadName(t *testing.T) {
 
 	defer tests.RemoveAllContainers()
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
 
-	// XXX: DockerLogs bug.
 	srv.Operations.SrvContainerName = "bad name"
-	if err := DockerLogs(srv.Service, srv.Operations, false, tail); err != nil {
-		t.Fatalf("expected logs pulled, got %v", err)
+	if err := DockerLogs(srv.Service, srv.Operations, false, tail); err == nil {
+		t.Fatalf("expected logs to fail")
+	}
+}
+
+func TestLogsBadServiceName(t *testing.T) {
+	const (
+		name = "ipfs"
+		tail = "1"
+	)
+	defer tests.RemoveAllContainers()
+
+	srv, err := loaders.LoadServiceDefinition(name)
+	if err != nil {
+		t.Fatalf("could not load service definition %v", err)
+	}
+
+	srv.Operations.SrvContainerName = "bad-name"
+	if err := DockerLogs(srv.Service, srv.Operations, false, tail); err == nil {
+		t.Fatalf("expected logs to fail")
 	}
 }
 
@@ -1633,7 +1869,7 @@ func TestInspectSimple(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1665,7 +1901,7 @@ func TestInspectLine(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1691,7 +1927,7 @@ func TestInspectField(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1719,7 +1955,7 @@ func TestInspectStoppedContainer(t *testing.T) {
 
 	defer tests.RemoveAllContainers()
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1755,15 +1991,14 @@ func TestInspectBadName(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
 
-	// XXX: DockerInspect bug.
 	srv.Operations.SrvContainerName = "bad name"
-	if err := DockerInspect(srv.Service, srv.Operations, "all"); err != nil {
-		t.Fatalf("expected inspect to succeed, got %v", err)
+	if err := DockerInspect(srv.Service, srv.Operations, "all"); err == nil {
+		t.Fatalf("expected inspect to fail")
 	}
 }
 
@@ -1809,7 +2044,7 @@ func TestRenameService(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1847,7 +2082,7 @@ func TestRenameEmptyName(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1877,7 +2112,7 @@ func TestRenameServiceStopped(t *testing.T) {
 		t.Fatalf("expecting service container doesn't exist")
 	}
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1920,7 +2155,7 @@ func TestRenameBadName(t *testing.T) {
 
 	defer tests.RemoveAllContainers()
 
-	srv, err := loaders.LoadServiceDefinition(name, true)
+	srv, err := loaders.LoadServiceDefinition(name)
 	if err != nil {
 		t.Fatalf("could not load service definition %v", err)
 	}
@@ -1928,5 +2163,67 @@ func TestRenameBadName(t *testing.T) {
 	srv.Operations.SrvContainerName = "bad name"
 	if err := DockerRename(srv.Operations, newName); err == nil {
 		t.Fatalf("expected rename to fail, got nil")
+	}
+}
+
+func TestBuildSimple(t *testing.T) {
+	const (
+		image = "test-image-1"
+	)
+
+	dockerfile := `FROM ` + path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)
+
+	if err := DockerBuild(image, dockerfile); err != nil {
+		t.Fatalf("expected image to be built, got %v", err)
+	}
+
+	if err := DockerRemoveImage(image, true); err != nil {
+		t.Fatalf("expected image to be remove, got %v", err)
+	}
+}
+
+func TestBuildBad(t *testing.T) {
+	const (
+		image = "test-image-2"
+	)
+
+	defer DockerRemoveImage(image, true)
+
+	dockerfile := `@^@%^@#%^&&#@%`
+
+	if err := DockerBuild(image, dockerfile); err == nil {
+		t.Fatalf("expected image build to fail")
+	}
+}
+
+func TestBuildImage(t *testing.T) {
+	const (
+		image = "test-image-3"
+	)
+
+	defer DockerRemoveImage(image, true)
+
+	dockerfile := `FROM ###^@%^@#%^&&#@%`
+
+	if err := DockerBuild(image, dockerfile); err == nil {
+		t.Fatalf("expected image build to fail")
+	}
+}
+
+func TestBuildEmptyImage(t *testing.T) {
+	const (
+		image = "test-image-4"
+	)
+
+	defer DockerRemoveImage(image, true)
+
+	if err := DockerBuild(image, ``); err == nil {
+		t.Fatalf("expected image build to fail")
+	}
+}
+
+func TestRemoveImageBadName(t *testing.T) {
+	if err := DockerRemoveImage("bad name", true); err == nil {
+		t.Fatalf("expected remove image to fail")
 	}
 }

--- a/pkgs/packages_test.go
+++ b/pkgs/packages_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit("pkgs"))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
 
 	exitCode := m.Run()
 	killKeys()

--- a/pkgs/packages_test.go
+++ b/pkgs/packages_test.go
@@ -367,16 +367,8 @@ func TestLinkingToServicesAndChains(t *testing.T) {
 		t.Fatalf("wrong user for the containers, expected %s, got %s", "eris", do.Service.User)
 	}
 
-	for _, dep := range do.ServicesSlice {
-		match := false
-		for _, link := range do.Service.Links {
-			if strings.HasSuffix(link, ":"+dep) {
-				match = true
-			}
-		}
-		if !match {
-			t.Fatalf("chain or service not properly linked: %s", dep)
-		}
+	if err := checkLinks(do); err != nil {
+		t.Fatalf("expected links to check out, got %v", err)
 	}
 }
 
@@ -1161,6 +1153,22 @@ func writeEmptyPkgJson() error {
 		}
 	}
 	return ioutil.WriteFile(emptyPkg, []byte{}, 0644)
+}
+
+func checkLinks(do *definitions.Do) error {
+	for _, dep := range do.ServicesSlice {
+		match := false
+		for _, link := range do.Service.Links {
+			if strings.HasSuffix(link, ":"+dep) {
+				match = true
+			}
+		}
+		if !match {
+			return fmt.Errorf("chain or service not properly linked: %s", dep)
+		}
+	}
+
+	return nil
 }
 
 func exec(t *testing.T, name string, args []string) string {

--- a/remotes/manage.go
+++ b/remotes/manage.go
@@ -1,7 +1,5 @@
 package remotes
 
-import ()
-
 func Add(args []string) {
 
 }

--- a/remotes/perform.go
+++ b/remotes/perform.go
@@ -1,7 +1,5 @@
 package remotes
 
-import ()
-
 func Do(args []string) {
 
 }

--- a/services/load.go
+++ b/services/load.go
@@ -21,7 +21,7 @@ func EnsureRunning(do *definitions.Do) error {
 		return nil
 	}
 
-	srv, err := loaders.LoadServiceDefinition(do.Name, false)
+	srv, err := loaders.LoadServiceDefinition(do.Name)
 	if err != nil {
 		return err
 	}

--- a/services/manage.go
+++ b/services/manage.go
@@ -37,7 +37,7 @@ func ImportService(do *definitions.Do) error {
 		return err
 	}
 
-	_, err = loaders.LoadServiceDefinition(do.Name, false)
+	_, err = loaders.LoadServiceDefinition(do.Name)
 	if err != nil {
 		return fmt.Errorf("error loading service:\n%v", err)
 	}
@@ -94,7 +94,7 @@ func RenameService(do *definitions.Do) error {
 	transformOnly := newNameBase == do.Name
 
 	if parseKnown(do.Name) {
-		serviceDef, err := loaders.LoadServiceDefinition(do.Name, false)
+		serviceDef, err := loaders.LoadServiceDefinition(do.Name)
 		if err != nil {
 			return err
 		}
@@ -153,7 +153,7 @@ func RenameService(do *definitions.Do) error {
 }
 
 func InspectService(do *definitions.Do) error {
-	service, err := loaders.LoadServiceDefinition(do.Name, false)
+	service, err := loaders.LoadServiceDefinition(do.Name)
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func InspectService(do *definitions.Do) error {
 }
 
 func PortsService(do *definitions.Do) error {
-	service, err := loaders.LoadServiceDefinition(do.Name, false)
+	service, err := loaders.LoadServiceDefinition(do.Name)
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func PortsService(do *definitions.Do) error {
 }
 
 func LogsService(do *definitions.Do) error {
-	service, err := loaders.LoadServiceDefinition(do.Name, false)
+	service, err := loaders.LoadServiceDefinition(do.Name)
 	if err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ To find known services use [eris services ls --known]`)
 }
 
 func UpdateService(do *definitions.Do) error {
-	service, err := loaders.LoadServiceDefinition(do.Name, false)
+	service, err := loaders.LoadServiceDefinition(do.Name)
 	if err != nil {
 		return err
 	}
@@ -223,7 +223,7 @@ func UpdateService(do *definitions.Do) error {
 
 func RmService(do *definitions.Do) error {
 	for _, servName := range do.Operations.Args {
-		service, err := loaders.LoadServiceDefinition(servName, false)
+		service, err := loaders.LoadServiceDefinition(servName)
 		if err != nil {
 			return err
 		}

--- a/services/manage.go
+++ b/services/manage.go
@@ -195,7 +195,7 @@ func ExportService(do *definitions.Do) error {
 			return err
 		}
 
-		hash, err := exportFile(do.Name)
+		hash, _ := exportFile(do.Name)
 		do.Result = hash
 		log.WithField("hash", hash).Warn()
 

--- a/services/operate.go
+++ b/services/operate.go
@@ -107,7 +107,7 @@ func KillService(do *definitions.Do) (err error) {
 }
 
 func ExecService(do *definitions.Do) (buf *bytes.Buffer, err error) {
-	service, err := loaders.LoadServiceDefinition(do.Name, false)
+	service, err := loaders.LoadServiceDefinition(do.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func BuildServicesGroup(srvName string, services ...*definitions.ServiceDefiniti
 		"=>":        srvName,
 		"services#": len(services),
 	}).Debug("Building services group for")
-	srv, err := loaders.LoadServiceDefinition(srvName, false)
+	srv, err := loaders.LoadServiceDefinition(srvName)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func ConnectChainToService(chainFlag, chainNameAndOpts string, srv *definitions.
 			return nil, fmt.Errorf("Marmot disapproval face.\nYou tried to start a service which has a `$chain` variable but didn't give us a chain.\nPlease rerun the command either after [eris chains checkout CHAINNAME] *or* with a --chain flag.\n")
 		}
 	}
-	s, err := loaders.ChainsAsAService(chainName, false)
+	s, err := loaders.ChainsAsAService(chainName)
 	if err != nil {
 		return nil, err
 	}

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/eris-ltd/eris-cli/config"
 	def "github.com/eris-ltd/eris-cli/definitions"
-	"github.com/eris-ltd/eris-cli/loaders"
 	"github.com/eris-ltd/eris-cli/tests"
 	"github.com/eris-ltd/eris-cli/util"
 	ver "github.com/eris-ltd/eris-cli/version"
@@ -26,7 +25,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit("services"))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
 
 	// Prevent CLI from starting IPFS.
 	os.Setenv("ERIS_SKIP_ENSURE", "true")
@@ -35,30 +34,6 @@ func TestMain(m *testing.M) {
 	log.Info("Tearing tests down")
 	tests.IfExit(tests.TestsTearDown())
 	os.Exit(exitCode)
-}
-
-func TestLoadServiceDefinition(t *testing.T) {
-	// [pv]: this test belongs to the loaders package. [csk]: agree. #496
-	srv, err := loaders.LoadServiceDefinition(servName, true)
-	if err != nil {
-		t.Fatalf("expected definition to load, got %v", err)
-	}
-
-	if srv.Name != servName {
-		t.Fatalf("improper name on load, expected %v, got %v", servName, srv.Name)
-	}
-
-	if srv.Service.Name != servName {
-		t.Fatalf("improper service name on load, expected %v, got %v", servName, srv.Service.Name)
-	}
-
-	if !srv.Service.AutoData {
-		t.Fatal("data_container not properly read on load")
-	}
-
-	if srv.Operations.DataContainerName == "" {
-		t.Fatal("data_container_name not set")
-	}
 }
 
 func TestStartKillService(t *testing.T) {

--- a/tests/test_tool.sh
+++ b/tests/test_tool.sh
@@ -127,6 +127,8 @@ packagesToTest() {
     if [ $? -ne 0 ]; then return 1; fi
     go test ./config/... && passed Config
     if [ $? -ne 0 ]; then return 1; fi
+    go test ./loaders/... && passed Loaders
+    if [ $? -ne 0 ]; then return 1; fi
     go test ./perform/... && passed Perform
     if [ $? -ne 0 ]; then return 1; fi
     go test ./data/... && passed Data

--- a/tests/testing_utils.go
+++ b/tests/testing_utils.go
@@ -231,7 +231,7 @@ func FileContents(filename string) string {
 	return string(content)
 }
 
-// each pacakge will need its own custom stuff if need be
+// each package will need its own custom stuff if need be
 // do it through a custom pre-process ifExit in each package that
 // calls tests.IfExit()
 func TestsTearDown() error {

--- a/update/binary.go
+++ b/update/binary.go
@@ -69,7 +69,7 @@ func BuildErisBinContainer(branch, binaryPath string) error {
 	doRm.RmD = true     // remove data container
 	doRm.Volumes = true // remove volumes
 	doRm.Force = true   // remove by force (no pesky warnings)
-	doRm.File = true    // remove the service defintion file
+	doRm.File = true    // remove the service definition file
 	doRm.RmImage = true // remove the temporary image
 
 	if err := services.RmService(doRm); err != nil {

--- a/update/binary.go
+++ b/update/binary.go
@@ -14,8 +14,8 @@ import (
 	"github.com/eris-ltd/eris-cli/services"
 	ver "github.com/eris-ltd/eris-cli/version"
 
-	log "github.com/eris-ltd/eris-logger"
 	"github.com/eris-ltd/common/go/common"
+	log "github.com/eris-ltd/eris-logger"
 )
 
 // branch to update in build container

--- a/update/gitandgo.go
+++ b/update/gitandgo.go
@@ -6,8 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	log "github.com/eris-ltd/eris-logger"
 	"github.com/eris-ltd/common/go/common"
+	log "github.com/eris-ltd/eris-logger"
 )
 
 func ChangeDirectoryToCLI() error {

--- a/update/update.go
+++ b/update/update.go
@@ -11,8 +11,8 @@ import (
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
 
-	log "github.com/eris-ltd/eris-logger"
 	"github.com/eris-ltd/common/go/common"
+	log "github.com/eris-ltd/eris-logger"
 )
 
 func UpdateEris(do *definitions.Do) error {

--- a/update/update_test.go
+++ b/update/update_test.go
@@ -9,11 +9,9 @@ import (
 // such that things don't break
 
 // gitandgo.go -> everything in there is super stable
-// binary.go -> functions have too much hardcoded them to be tested...? 
+// binary.go -> functions have too much hardcoded them to be tested...?
 
 // perform/perform.go -> test for DockerBuild()
 
 // could write a test via bash script that uses `docker-machine scp/ssh` combo
 // and is run independently of unit tests, via the tests/tests_scripts.sh
-
-

--- a/util/chains_info.go
+++ b/util/chains_info.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"strings"
 
-	log "github.com/eris-ltd/eris-logger"
 	"github.com/eris-ltd/common/go/common"
+	log "github.com/eris-ltd/eris-logger"
 )
 
 // Maximum entries in the HEAD file

--- a/util/containers.go
+++ b/util/containers.go
@@ -43,7 +43,7 @@ var (
 )
 
 // UniqueName() returns a unique container name, prefixed with the short
-// container name, e.g. `ipfs-6ba7b811-9dad-11d1-80b4-00c04fd430c8`
+// entity name, e.g. `ipfs-6ba7b811-9dad-11d1-80b4-00c04fd430c8`
 //
 // [pv]: might be a good idea to truncate this long name to ~20 characters
 // without much danger of bumping into collisions, e.g. `ipfs-6ba7b811-9dad-11d1`

--- a/util/containers_test.go
+++ b/util/containers_test.go
@@ -1,8 +1,8 @@
 package util
 
 import (
-	"testing"
 	"path"
+	"testing"
 
 	def "github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/version"
@@ -308,7 +308,7 @@ func create(t, name string) error {
 	opts := docker.CreateContainerOptions{
 		Name: ContainerName(t, name),
 		Config: &docker.Config{
-			Image: keysImage,
+			Image:  keysImage,
 			Labels: labels,
 		},
 	}

--- a/util/merge.go
+++ b/util/merge.go
@@ -14,29 +14,11 @@ var (
 // Merge returns ErrMergeParameters if either base or over are not
 // pointers to structs.
 func Merge(base, over interface{}) error {
-	if base == nil || over == nil {
-		return ErrMergeParameters
+	if err := checkStructsAreMergeable(base, over); err != nil {
+		return err
 	}
 
-	// If not pointers, it won't be possible to store the result in base.
-	if reflect.ValueOf(base).Kind() != reflect.Ptr ||
-		reflect.ValueOf(over).Kind() != reflect.Ptr {
-		return ErrMergeParameters
-	}
-
-	// Not structs.
-	if reflect.ValueOf(base).Elem().Kind() != reflect.Struct ||
-		reflect.ValueOf(over).Elem().Kind() != reflect.Struct {
-		return ErrMergeParameters
-	}
-
-	// Structs, but varying number of fields.
 	baseFields := reflect.TypeOf(base).Elem().NumField()
-	overFields := reflect.TypeOf(over).Elem().NumField()
-	if baseFields != overFields {
-		return ErrMergeParameters
-	}
-
 	for i := 0; i < baseFields; i++ {
 		a := reflect.ValueOf(base).Elem().Field(i)
 		b := reflect.ValueOf(over).Elem().Field(i)
@@ -74,5 +56,30 @@ func Merge(base, over interface{}) error {
 			a.Set(b)
 		}
 	}
+	return nil
+}
+
+func checkStructsAreMergeable(base, over interface{}) error {
+	if base == nil || over == nil {
+		return ErrMergeParameters
+	}
+
+	// If not pointers, it won't be possible to store the result in base.
+	if reflect.ValueOf(base).Kind() != reflect.Ptr ||
+		reflect.ValueOf(over).Kind() != reflect.Ptr {
+		return ErrMergeParameters
+	}
+
+	// Not structs.
+	if reflect.ValueOf(base).Elem().Kind() != reflect.Struct ||
+		reflect.ValueOf(over).Elem().Kind() != reflect.Struct {
+		return ErrMergeParameters
+	}
+
+	// Structs, but varying number of fields.
+	if reflect.TypeOf(base).Elem().NumField() != reflect.TypeOf(over).Elem().NumField() {
+		return ErrMergeParameters
+	}
+
 	return nil
 }


### PR DESCRIPTION
This PR inludes
* `loaders` package (100% coverage)
* `perform` package additional tests, especially for `DockerBuild`, and `DockerRemoveImage` functions (81% coverage).
* `LoadChainDefinition`, `LoadServiceDefinition`, and `LoadViperConfig` function now have simplified signatures.
* Satisfied `go vet`, `gofmt -s -w`, `ineffassign`, `misspell` static analysis warnings (fully); and `gocyclo`, `errcheck` selectively, and `golint` partially (WIP).
* Many small deletions of dead / duplicated code.