### PR TITLE
Clean images

### DIFF
--- a/clean/clean.go
+++ b/clean/clean.go
@@ -12,7 +12,7 @@ func Clean(do *definitions.Do) error {
 		"all":        do.All,
 		"containers": do.Containers,
 		"scratch":    do.Scratch,
-		"rmd":        do.RmD,
+		"root":       do.RmD,
 		"images":     do.Images,
 	}
 	if err := util.Clean(toClean); err != nil {

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -1,23 +1,27 @@
 package clean
 
 import (
-	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
 	"github.com/eris-ltd/eris-cli/chains"
 	"github.com/eris-ltd/eris-cli/data"
 	"github.com/eris-ltd/eris-cli/definitions"
+	"github.com/eris-ltd/eris-cli/perform"
 	srv "github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/tests"
 	"github.com/eris-ltd/eris-cli/util"
+	ver "github.com/eris-ltd/eris-cli/version"
 
 	"github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-logger"
 
 	docker "github.com/fsouza/go-dockerclient"
 )
+
+const customImage = "sample"
 
 func TestMain(m *testing.M) {
 	log.SetLevel(log.ErrorLevel)
@@ -32,11 +36,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestRemoveAllErisContainers(t *testing.T) {
-	testFailIfAnyContainers(t)
+	defer util.RemoveAllErisContainers()
 
-	// start a bunch of eris containers
+	// Start a bunch of eris containers.
 	testStartService("ipfs", t)
-	testStartService("tor", t)
 	testStartService("keys", t)
 
 	testStartChain("dirty-chain0", t)
@@ -45,48 +48,33 @@ func TestRemoveAllErisContainers(t *testing.T) {
 	testCreateDataContainer("filthy-data0", t)
 	testCreateDataContainer("filthy-data1", t)
 
-	// start some not eris containers (using busybox)
+	// Start some non-Eris containers.
 	notEris0 := testCreateNotEris("not_eris0", t)
 	notEris1 := testCreateNotEris("not_eris1", t)
 
-	// run the command
 	tests.IfExit(util.RemoveAllErisContainers())
 
-	// check that both not_eris still exist
-	// and no Eris containers exist
+	// Check that both not_eris still exist and no Eris containers exist.
 	testCheckSimple(notEris0, t)
 	testCheckSimple(notEris1, t)
 
-	// remove what's left
+	// Remove what's left.
 	testRemoveNotEris(notEris0, t)
 	testRemoveNotEris(notEris1, t)
 
-	// fail is anything remains
-	testFailIfAnyContainers(t)
-
-}
-
-func testFailIfAnyContainers(t *testing.T) {
-	contns, err := util.DockerClient.ListContainers(docker.ListContainersOptions{All: true})
-	if err != nil {
-		t.Fatalf("error listing containers: %v", err)
-	}
-
-	if len(contns) != 0 {
-		t.Fatalf("found (%v) remaining containers, something went wrong\n", len(contns))
-	}
-}
-
-// it works...any working test
-// will take too long IMO [zr]
-func TestRemoveErisImages(t *testing.T) {
+	// Remove custom built image.
+	testRemoveNotErisImage(t)
 }
 
 func testCreateNotEris(name string, t *testing.T) string {
+	if err := perform.DockerBuild(customImage, "FROM "+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)); err != nil {
+		t.Fatalf("expected to build a custom image, got %v", err)
+	}
+
 	opts := docker.CreateContainerOptions{
 		Name: name,
 		Config: &docker.Config{
-			Image:           "busybox",
+			Image:           customImage,
 			AttachStdin:     false,
 			AttachStdout:    false,
 			AttachStderr:    false,
@@ -117,21 +105,25 @@ func testRemoveNotEris(contID string, t *testing.T) {
 	}
 }
 
+func testRemoveNotErisImage(t *testing.T) {
+	if err := perform.DockerRemoveImage(customImage, true); err != nil {
+		t.Fatalf("expected custom image to be removed, got %v", err)
+	}
+}
+
 func testCheckSimple(newContID string, t *testing.T) {
 	contns, err := util.DockerClient.ListContainers(docker.ListContainersOptions{All: true})
 	if err != nil {
 		t.Fatalf("error listing containers: %v", err)
 	}
 
-	//if any Eris, fail
-	for _, container := range contns {
-		if container.Labels["eris:ERIS"] == "true" {
-			t.Fatalf("Eris container detected. Clean did not do its job\n")
-		}
-	}
+	// If any Eris containers exist, fail.
+	util.ErisContainers(func(name string, details *util.Details) bool {
+		t.Fatalf("expected no Eris containers running")
+		return true
+	}, false)
 
 	var notEris bool
-	//make sure "not_eris" still exists
 	for _, container := range contns {
 		if container.ID == newContID {
 			notEris = true
@@ -142,18 +134,16 @@ func testCheckSimple(newContID string, t *testing.T) {
 	}
 
 	if !notEris {
-		t.Fatalf("Expected running container, did not find %s\n", newContID)
+		t.Fatalf("expected running container, did not find %s", newContID)
 	}
 }
 
-//from /services/services_test.go
 func testStartService(serviceName string, t *testing.T) {
 	do := definitions.NowDo()
 	do.Operations.Args = []string{serviceName}
 	do.Operations.PublishAllPorts = true
-	log.WithField("=>", fmt.Sprintf("%s:%d", serviceName, 1)).Debug("Starting service (from tests)")
 	if err := srv.StartService(do); err != nil {
-		t.Fatalf("Error starting service: %v", err)
+		t.Fatalf("error starting service: %v", err)
 	}
 
 	tests.IfExit(tests.TestExistAndRun(serviceName, "service", true, true))
@@ -172,12 +162,12 @@ func testStartChain(chainName string, t *testing.T) {
 func testCreateDataContainer(dataName string, t *testing.T) {
 	newDataDir := filepath.Join(common.DataContainersPath, dataName)
 	if err := os.MkdirAll(newDataDir, 0777); err != nil {
-		t.Fatalf("err mkdir: %v\n", err)
+		t.Fatalf("error mkdir: %v\n", err)
 	}
 
 	f, err := os.Create(filepath.Join(newDataDir, "test"))
 	if err != nil {
-		t.Fatalf("err creating file: %v\n", err)
+		t.Fatalf("error creating file: %v", err)
 	}
 	defer f.Close()
 
@@ -185,13 +175,12 @@ func testCreateDataContainer(dataName string, t *testing.T) {
 	do.Name = dataName
 	do.Source = filepath.Join(common.DataContainersPath, do.Name)
 	do.Destination = common.ErisContainerRoot
-	log.WithField("=>", do.Name).Info("Importing data (from tests)")
 	if err := data.ImportData(do); err != nil {
-		t.Fatalf("error importing data: %v\n", err)
+		t.Fatalf("error importing data: %v", err)
 	}
 
 	if err := tests.TestExistAndRun(dataName, "data", true, false); err != nil {
-		t.Fatalf("error creating data cont: %v\n", err)
+		t.Fatalf("error creating data cont: %v", err)
 	}
 
 }

--- a/tests/test_tool.sh
+++ b/tests/test_tool.sh
@@ -78,7 +78,6 @@ setup() {
 
   echo "Checking the Host <-> Docker Connection"
   # Used by clean/clean_test.go.
-  docker pull busybox &>/dev/null
   if [ $? -ne 0 ] && [ -z $1 ]
   then
     echo "Could not connect to Docker backend. Attempting to regenerate certificates."

--- a/util/clean.go
+++ b/util/clean.go
@@ -122,6 +122,9 @@ func RemoveErisImages() error {
 		if !strings.Contains(i.RepoTags[0], "eris/") {
 			continue
 		}
+		log.WithFields(log.Fields{
+			"image": i.RepoTags[0],
+		}).Debug("Removing image")
 		if err := DockerClient.RemoveImageExtended(i.ID, docker.RemoveImageOptions{Force: true, NoPrune: true}); err != nil {
 			return DockerError(err)
 		}

--- a/util/clean.go
+++ b/util/clean.go
@@ -3,7 +3,6 @@ package util
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/eris-ltd/common/go/common"
@@ -45,7 +44,7 @@ func cleanHandler(toClean map[string]bool) error {
 		}
 	}
 
-	if toClean["rmd"] {
+	if toClean["root"] {
 		log.Debug("Removing Eris root directory")
 		if err := os.RemoveAll(common.ErisRoot); err != nil {
 			return err
@@ -114,51 +113,20 @@ func cleanScratchData() error {
 }
 
 func RemoveErisImages() error {
-	opts := docker.ListImagesOptions{
-		All:     true,
-		Filters: nil,
-		Digests: false,
-	}
-	allTheImages, err := DockerClient.ListImages(opts)
+	images, err := DockerClient.ListImages(docker.ListImagesOptions{All: true})
 	if err != nil {
 		return DockerError(err)
 	}
 
-	//get all repo tags & IDs
-	repoTags := make(map[int][]string)
-	imageIDs := make(map[int]string)
-	for i, image := range allTheImages {
-		repoTags[i] = image.RepoTags
-		imageIDs[i] = image.ID
-	}
-
-	erisImages := []string{}
-	erisImageIDs := []string{}
-
-	//searches through repo tags for eris images & "maps" to ID
-	for i, repoTag := range repoTags {
-		for _, rt := range repoTag {
-			r, err := regexp.Compile(`eris`)
-			if err != nil {
-				log.Errorf("Regexp error: %v", err)
-			}
-
-			if r.MatchString(rt) == true {
-				erisImages = append(erisImages, rt)
-				erisImageIDs = append(erisImageIDs, imageIDs[i])
-			}
+	for _, i := range images {
+		if !strings.Contains(i.RepoTags[0], "eris/") {
+			continue
 		}
-	}
-
-	for i, imageID := range erisImageIDs {
-		log.WithFields(log.Fields{
-			"=>": erisImages[i],
-			"id": imageID,
-		}).Debug("Removing image")
-		if err := DockerClient.RemoveImage(imageID); err != nil {
+		if err := DockerClient.RemoveImageExtended(i.ID, docker.RemoveImageOptions{Force: true, NoPrune: true}); err != nil {
 			return DockerError(err)
 		}
 	}
+
 	return nil
 }
 
@@ -167,7 +135,7 @@ func canWeRemove(toClean map[string]bool) bool {
 	var toWarn = map[string]string{
 		"containers": "all",
 		"scratch":    fmt.Sprintf("%s/.eris/scratch/data", home),
-		"rmd":        fmt.Sprintf("%s/.eris", home),
+		"root":       fmt.Sprintf("%s/.eris", home),
 		"images":     "all",
 	}
 
@@ -179,8 +147,8 @@ func canWeRemove(toClean map[string]bool) bool {
 		if toClean["scratch"] {
 			log.WithField("scratch", toWarn["scratch"]).Warn("")
 		}
-		if toClean["rmd"] {
-			log.WithField("rmd", toWarn["rmd"]).Warn("")
+		if toClean["root"] {
+			log.WithField("root", toWarn["root"]).Warn("")
 		}
 		if toClean["images"] {
 			log.WithField("images", toWarn["images"]).Warn("")
@@ -189,7 +157,7 @@ func canWeRemove(toClean map[string]bool) bool {
 		log.WithFields(log.Fields{
 			"containers": toWarn["containers"],
 			"scratch":    toWarn["scratch"],
-			"rmd":        toWarn["rmd"],
+			"root":       toWarn["root"],
 			"images":     toWarn["images"],
 		}).Warn("The marmots are about to remove the following")
 	}


### PR DESCRIPTION
* Use `force` and `no prune` image removal options to avoid removal of untagged image dependencies, which produce errors, closes #715.
* Don't pull neither `busybox` nor `tor` images for `clean` package tests; use custom built images (`perform.DockerBuild`); also don't expect no containers to be running after `clean` package tests — some containers may be user containers running an Ubuntu session, for example, closes #754.
* Use `root` instead of `rmd` to indicate the Eris root directory to be removed in the `eris clean --all` command:

  ```
The marmots are about to remove the following
                                   containers=all
                                       images=all
                                         root=/Users/peter/.eris
                                      scratch=/Users/peter/.eris/scratch/data
Please confirm (y/n):
  ```