### PR TITLE
move image versioning to eris.toml (global config) rather than in binary

### DIFF
--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/tests"
 	"github.com/eris-ltd/eris-cli/util"
-	ver "github.com/eris-ltd/eris-cli/version"
 
 	"github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-logger"
@@ -405,7 +404,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
+image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_IPFS)+`"
 data_container = true
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
@@ -426,7 +425,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
+image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_IPFS)+`"
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
 	}
@@ -447,7 +446,7 @@ func TestServiceLinkBadChainWithoutChainInDefinition(t *testing.T) {
 	if err := tests.FakeServiceDefinition("fake", `
 [service]
 name = "fake"
-image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
+image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_IPFS)+`"
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
 	}
@@ -486,7 +485,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)+`"
+image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)+`"
 data_container = false
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
@@ -538,7 +537,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
+image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_IPFS)+`"
 data_container = true
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
@@ -590,7 +589,7 @@ chain = "`+chain+`:fake"
 
 [service]
 name = "fake"
-image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)+`"
+image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)+`"
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
 	}
@@ -641,7 +640,7 @@ chain = "blah-blah:blah"
 
 [service]
 name = "fake"
-image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_IPFS)+`"
+image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_IPFS)+`"
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
 	}
@@ -675,7 +674,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)+`"
+image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)+`"
 
 [dependencies]
 services = [ "sham" ]
@@ -688,7 +687,7 @@ chain = "$chain:sham"
 
 [service]
 name = "sham"
-image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)+`"
+image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)+`"
 data_container = true
 `); err != nil {
 		t.Fatalf("can't create a sham service definition: %v", err)

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -7,13 +7,13 @@ import (
 	"testing"
 
 	"github.com/eris-ltd/eris-cli/chains"
+	"github.com/eris-ltd/eris-cli/config"
 	"github.com/eris-ltd/eris-cli/data"
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/perform"
 	srv "github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/tests"
 	"github.com/eris-ltd/eris-cli/util"
-	ver "github.com/eris-ltd/eris-cli/version"
 
 	"github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-logger"
@@ -67,7 +67,7 @@ func TestRemoveAllErisContainers(t *testing.T) {
 }
 
 func testCreateNotEris(name string, t *testing.T) string {
-	if err := perform.DockerBuild(customImage, "FROM "+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)); err != nil {
+	if err := perform.DockerBuild(customImage, "FROM "+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)); err != nil {
 		t.Fatalf("expected to build a custom image, got %v", err)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
+	ver "github.com/eris-ltd/eris-cli/version"
+
 	dir "github.com/eris-ltd/common/go/common"
 	"github.com/tcnksm/go-gitconfig"
 
@@ -32,8 +34,18 @@ type ErisConfig struct {
 	DockerHost     string `json:"DockerHost,omitempty" yaml:"DockerHost,omitempty" toml:"DockerHost,omitempty"`
 	DockerCertPath string `json:"DockerCertPath,omitempty" yaml:"DockerCertPath,omitempty" toml:"DockerCertPath,omitempty"`
 	CrashReport    string `json:"CrashReport,omitempty" yaml:"CrashReport,omitempty" toml:"CrashReport,omitempty"`
-
 	Verbose bool
+
+	//image defaults
+	ERIS_REG_DEF string `json:"ERIS_REG_DEF,omitempty" yaml:"ERIS_REG_DEF,omitempty" toml:"ERIS_REG_DEF,omitempty"`
+	ERIS_REG_BAK string `json:"ERIS_REG_BAK,omitempty" yaml:"ERIS_REG_BAK,omitempty" toml:"ERIS_REG_BAK,omitempty"`
+
+	ERIS_IMG_DATA string `json:"ERIS_IMG_DATA,omitempty" yaml:"ERIS_IMG_DATA,omitempty" toml:"ERIS_IMG_DATA,omitempty"`
+	ERIS_IMG_KEYS string `json:"ERIS_IMG_KEYS,omitempty" yaml:"ERIS_IMG_KEYS,omitempty" toml:"ERIS_IMG_KEYS,omitempty"`
+	ERIS_IMG_DB string `json:"ERIS_IMG_DB,omitempty" yaml:"ERIS_IMG_DB,omitempty" toml:"ERIS_IMG_DB,omitempty"`
+	ERIS_IMG_PM string `json:"ERIS_IMG_PM,omitempty" yaml:"ERIS_IMG_PM,omitempty" toml:"ERIS_IMG_PM,omitempty"`
+	ERIS_IMG_CM string `json:"ERIS_IMG_CM,omitempty" yaml:"ERIS_IMG_CM,omitempty" toml:"ERIS_IMG_CM,omitempty"`
+	ERIS_IMG_IPFS string `json:"ERIS_IMG_IPFS,omitempty" yaml:"ERIS_IMG_IPFS,omitempty" toml:"ERIS_IMG_IPFS,omitempty"`
 }
 
 func SetGlobalObject(writer, errorWriter io.Writer) (*ErisCli, error) {
@@ -102,6 +114,15 @@ func SetDefaults() (*viper.Viper, error) {
 	globalConfig.SetDefault("IpfsHost", "http://0.0.0.0")
 	globalConfig.SetDefault("CompilersHost", "https://compilers.eris.industries")
 	globalConfig.SetDefault("CrashReport", "bugsnag")
+	// image defaults...
+	globalConfig.SetDefault("ERIS_REG_DEF", ver.ERIS_REG_DEF)
+	globalConfig.SetDefault("ERIS_REG_BAK", ver.ERIS_REG_BAK)
+	globalConfig.SetDefault("ERIS_IMG_DATA", ver.ERIS_IMG_DATA)
+	globalConfig.SetDefault("ERIS_IMG_KEYS", ver.ERIS_IMG_KEYS)
+	globalConfig.SetDefault("ERIS_IMG_DB", ver.ERIS_IMG_DB)
+	globalConfig.SetDefault("ERIS_IMG_PM", ver.ERIS_IMG_PM)
+	globalConfig.SetDefault("ERIS_IMG_CM", ver.ERIS_IMG_CM)
+	globalConfig.SetDefault("ERIS_IMG_IPFS", ver.ERIS_IMG_IPFS)
 	return globalConfig, nil
 }
 
@@ -138,6 +159,23 @@ func GetConfigValue(key string) string {
 		return GlobalConfig.Config.DockerCertPath
 	case "CrashReport":
 		return GlobalConfig.Config.CrashReport
+	//image defaults
+	case "ERIS_REG_DEF":
+		return GlobalConfig.Config.ERIS_REG_DEF
+	case "ERIS_REG_BAK":
+		return GlobalConfig.Config.ERIS_REG_BAK
+	case "ERIS_IMG_DATA":
+		return GlobalConfig.Config.ERIS_IMG_DATA
+	case "ERIS_IMG_KEYS":
+		return GlobalConfig.Config.ERIS_IMG_KEYS
+	case "ERIS_IMG_DB":
+		return GlobalConfig.Config.ERIS_IMG_DB
+	case "ERIS_IMG_PM":
+		return GlobalConfig.Config.ERIS_IMG_PM
+	case "ERIS_IMG_CM":
+		return GlobalConfig.Config.ERIS_IMG_CM
+	case "ERIS_IMG_IPFS":
+		return GlobalConfig.Config.ERIS_IMG_IPFS
 	default:
 		return ""
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 
+	ver "github.com/eris-ltd/eris-cli/version"
+
 	log "github.com/eris-ltd/eris-logger"
 )
 
@@ -97,6 +99,10 @@ func TestSetGlobalObjectDefaultConfig(t *testing.T) {
 		t.Fatalf("expected default %q, got %q", returned, def)
 	}
 
+	if def, returned := defaults.Get("ERIS_IMG_KEYS"), cli.Config.ERIS_IMG_KEYS; reflect.DeepEqual(returned, def) != true {
+		t.Fatalf("expected default %q, got %q", returned, def)
+	}
+
 	log.WithFields(log.Fields{
 		"ipfshost":       cli.Config.IpfsHost,
 		"compilers host": cli.Config.CompilersHost,
@@ -104,6 +110,7 @@ func TestSetGlobalObjectDefaultConfig(t *testing.T) {
 		"cert path":      cli.Config.DockerCertPath,
 		"crash report":   cli.Config.CrashReport,
 		"verbose":        cli.Config.Verbose,
+		"eris_img_keys":  cli.Config.ERIS_IMG_KEYS,
 	}).Info("Checking defaults")
 }
 
@@ -115,6 +122,8 @@ DockerHost = "baz"
 DockerCertPath = "qux"
 CrashReport = "quux"
 Verbose = true
+ERIS_IMG_KEYS = "crypto"
+ERIS_IMG_DB = "erisdb"
 `)
 	defer removeErisDir()
 
@@ -145,6 +154,12 @@ Verbose = true
 	if custom, returned := true, cli.Config.Verbose; custom != returned {
 		t.Fatalf("expected %v, got %v", custom, returned)
 	}
+	if custom, returned := "crypto", cli.Config.ERIS_IMG_KEYS; custom != returned {
+		t.Fatalf("expected %q, got %q", custom, returned)
+	}
+	if custom, returned := "erisdb", cli.Config.ERIS_IMG_DB; custom != returned {
+		t.Fatalf("expected %q, got %q", custom, returned)
+	}
 }
 
 func TestSetGlobalObjectCustomEmptyConfig(t *testing.T) {
@@ -170,6 +185,8 @@ func TestSetGlobalObjectCustomEmptyConfig(t *testing.T) {
 		"cert path":      cli.Config.DockerCertPath,
 		"crash report":   cli.Config.CrashReport,
 		"verbose":        cli.Config.Verbose,
+		"eris_img_keys":  cli.Config.ERIS_IMG_KEYS,
+		"eris_img_db":    cli.Config.ERIS_IMG_DB,
 	}).Info("Checking empty values")
 
 	// With an empty config, the values are used are defaults.
@@ -193,6 +210,12 @@ func TestSetGlobalObjectCustomEmptyConfig(t *testing.T) {
 	if custom, returned := false, cli.Config.Verbose; custom != returned {
 		t.Fatalf("expected %v, got %v", custom, returned)
 	}
+	if custom, returned := ver.ERIS_IMG_KEYS, cli.Config.ERIS_IMG_KEYS; custom != returned {
+		t.Fatalf("expected %v, got %v", custom, returned)
+	}
+	if custom, returned := ver.ERIS_IMG_DB, cli.Config.ERIS_IMG_DB; custom != returned {
+		t.Fatalf("expected %v, got %v", custom, returned)
+	}
 }
 
 func TestSetGlobalObjectCustomBadConfig(t *testing.T) {
@@ -213,6 +236,8 @@ func TestSetGlobalObjectCustomBadConfig(t *testing.T) {
 		"cert path":      cli.Config.DockerCertPath,
 		"crash report":   cli.Config.CrashReport,
 		"verbose":        cli.Config.Verbose,
+		"eris_img_keys":  cli.Config.ERIS_IMG_KEYS,
+		"eris_img_db":    cli.Config.ERIS_IMG_DB,
 	}).Info("Checking empty values")
 
 	// With an empty config, the values are used are defaults.
@@ -241,6 +266,12 @@ func TestSetGlobalObjectCustomBadConfig(t *testing.T) {
 	if custom, returned := false, cli.Config.Verbose; custom != returned {
 		t.Fatalf("expected %v, got %v", custom, returned)
 	}
+	if def, returned := defaults.Get("ERIS_IMG_KEYS"), cli.Config.ERIS_IMG_KEYS; reflect.DeepEqual(returned, def) != true {
+		t.Fatalf("expected default %q, got %q", returned, def)
+	}
+	if def, returned := defaults.Get("ERIS_IMG_DB"), cli.Config.ERIS_IMG_DB; reflect.DeepEqual(returned, def) != true {
+		t.Fatalf("expected default %q, got %q", returned, def)
+	}
 }
 
 func TestSetDefaults(t *testing.T) {
@@ -256,6 +287,10 @@ func TestSetDefaults(t *testing.T) {
 	if _, ok := defaults.Get("CompilersHost").(string); !ok {
 		t.Fatalf("expected CompilersHost values set")
 	}
+
+	if _, ok := defaults.Get("ERIS_IMG_KEYS").(string); !ok {
+		t.Fatalf("expected ERIS_IMG_KEYS value set")
+	}
 }
 
 func TestLoadGlobalConfig(t *testing.T) {
@@ -266,6 +301,8 @@ DockerHost = "baz"
 DockerCertPath = "qux"
 CrashReport = "quux"
 Verbose = true
+ERIS_IMG_KEYS = "crypto"
+ERIS_IMG_DB = "erisdb"
 `)
 	defer removeErisDir()
 
@@ -290,6 +327,12 @@ Verbose = true
 		t.Fatalf("expected %q, got %q", expected, returned)
 	}
 	if expected, returned := true, config.Get("Verbose"); reflect.DeepEqual(expected, returned) != true {
+		t.Fatalf("expected %v, got %v", expected, returned)
+	}
+	if expected, returned := "crypto", config.Get("ERIS_IMG_KEYS"); reflect.DeepEqual(expected, returned) != true {
+		t.Fatalf("expected %v, got %v", expected, returned)
+	}
+	if expected, returned := "erisdb", config.Get("ERIS_IMG_DB"); reflect.DeepEqual(expected, returned) != true {
 		t.Fatalf("expected %v, got %v", expected, returned)
 	}
 }
@@ -326,6 +369,12 @@ func TestLoadGlobalConfigEmpty(t *testing.T) {
 	if returned := config.Get("Verbose"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
 	}
+	if def, returned := defaults.Get("ERIS_IMG_KEYS"), config.Get("ERIS_IMG_KEYS"); reflect.DeepEqual(returned, def) != true {
+		t.Fatalf("expected default %q, got %q", returned, def)
+	}
+	if def, returned := defaults.Get("ERIS_IMG_DB"), config.Get("ERIS_IMG_DB"); reflect.DeepEqual(returned, def) != true {
+		t.Fatalf("expected default %q, got %q", returned, def)
+	}
 }
 
 func TestLoadGlobalConfigBad(t *testing.T) {
@@ -361,6 +410,12 @@ func TestLoadGlobalConfigBad(t *testing.T) {
 	if returned := config.Get("Verbose"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
 	}
+	if def, returned := defaults.Get("ERIS_IMG_KEYS"), config.Get("ERIS_IMG_KEYS"); reflect.DeepEqual(returned, def) != true {
+		t.Fatalf("expected default %q, got %q", returned, def)
+	}
+	if def, returned := defaults.Get("ERIS_IMG_DB"), config.Get("ERIS_IMG_DB"); reflect.DeepEqual(returned, def) != true {
+		t.Fatalf("expected default %q, got %q", returned, def)
+	}
 }
 
 func TestLoadViperConfig(t *testing.T) {
@@ -371,6 +426,8 @@ DockerHost = "baz"
 DockerCertPath = "qux"
 CrashReport = "quux"
 Verbose = true
+ERIS_IMG_KEYS = "crypto"
+ERIS_IMG_DB = "erisdb"
 `)
 	defer removeErisDir()
 
@@ -395,6 +452,12 @@ Verbose = true
 		t.Fatalf("expected %q, got %q", expected, returned)
 	}
 	if expected, returned := true, config.Get("Verbose"); reflect.DeepEqual(expected, returned) != true {
+		t.Fatalf("expected %v, got %v", expected, returned)
+	}
+	if expected, returned := "crypto", config.Get("ERIS_IMG_KEYS"); reflect.DeepEqual(expected, returned) != true {
+		t.Fatalf("expected %v, got %v", expected, returned)
+	}
+	if expected, returned := "erisdb", config.Get("ERIS_IMG_DB"); reflect.DeepEqual(expected, returned) != true {
 		t.Fatalf("expected %v, got %v", expected, returned)
 	}
 }
@@ -424,6 +487,12 @@ func TestLoadViperConfigEmpty(t *testing.T) {
 		t.Fatalf("expected nil, got %q", returned)
 	}
 	if returned := config.Get("Verbose"); returned != nil {
+		t.Fatalf("expected nil, got %q", returned)
+	}
+	if returned := config.Get("ERIS_IMG_KEYS"); returned != nil {
+		t.Fatalf("expected nil, got %q", returned)
+	}
+	if returned := config.Get("ERIS_IMG_DB"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
 	}
 }
@@ -487,6 +556,9 @@ func TestGetConfigValue(t *testing.T) {
 	}
 	if returned := GetConfigValue("DockerCertPath"); returned != "" {
 		t.Fatalf("expected empty string returned, got %v", returned)
+	}
+	if returned := GetConfigValue("ERIS_IMG_KEYS"); returned == "" {
+		t.Fatal("expected value returned, got empty string")
 	}
 }
 
@@ -555,6 +627,8 @@ func TestSaveGlobalConfigNotExistentDir(t *testing.T) {
 		DockerHost:     "baz",
 		DockerCertPath: "qux",
 		Verbose:        true,
+		ERIS_IMG_KEYS:  "crypto",
+		ERIS_IMG_DB:    "erisdb",
 	}
 	if err := SaveGlobalConfig(config); err == nil {
 		t.Fatal("expected failure, got nil")

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/eris-ltd/eris-cli/config"
 	"github.com/eris-ltd/eris-cli/util"
 
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -81,9 +82,9 @@ func dropChainDefaults(dir, from string) error {
 	}
 
 	//move things to where they ought to be
-	config := filepath.Join(dir, "config.toml")
+	confiG := filepath.Join(dir, "config.toml")
 	configDef := filepath.Join(chnDir, "config.toml")
-	if err := os.Rename(config, configDef); err != nil {
+	if err := os.Rename(confiG, configDef); err != nil {
 		return err
 	}
 
@@ -97,13 +98,12 @@ func dropChainDefaults(dir, from string) error {
 
 func pullDefaultImages() error {
 	images := []string{
-		//ver.ERIS_IMG_BASE,
-		ver.ERIS_IMG_DATA,
-		ver.ERIS_IMG_KEYS,
-		ver.ERIS_IMG_IPFS,
-		ver.ERIS_IMG_DB,
-		ver.ERIS_IMG_PM,
-		ver.ERIS_IMG_CM,
+		config.GlobalConfig.Config.ERIS_IMG_DATA,
+		config.GlobalConfig.Config.ERIS_IMG_KEYS,
+		config.GlobalConfig.Config.ERIS_IMG_IPFS,
+		config.GlobalConfig.Config.ERIS_IMG_DB,
+		config.GlobalConfig.Config.ERIS_IMG_PM,
+		config.GlobalConfig.Config.ERIS_IMG_CM,
 	}
 
 	// Spacer.
@@ -127,12 +127,12 @@ func pullDefaultImages() error {
 			tag = nameSplit[2]
 		}
 		image = nameSplit[0]
-		img := path.Join(ver.ERIS_REG_DEF, image)
+		img := path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, image)
 
 		r, w := io.Pipe()
 		opts := docker.PullImageOptions{
 			Repository:    img,
-			Registry:      ver.ERIS_REG_DEF,
+			Registry:      config.GlobalConfig.Config.ERIS_REG_DEF,
 			Tag:           tag,
 			OutputStream:  w,
 			RawJSONStream: true,
@@ -151,7 +151,7 @@ func pullDefaultImages() error {
 
 			if err := util.DockerClient.PullImage(opts, auth); err != nil {
 				opts.Repository = image
-				opts.Registry = ver.ERIS_REG_BAK
+				opts.Registry = ver.ERIS_REG_BAK //not in global config...(also, won't even work unless we build & push updated images to dockerhub in addition to quay (which we should do)
 				if err := util.DockerClient.PullImage(opts, auth); err != nil {
 					ch <- util.DockerError(err)
 				}

--- a/loaders/loaders_test.go
+++ b/loaders/loaders_test.go
@@ -7,12 +7,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/eris-ltd/common/go/common"
+	"github.com/eris-ltd/eris-cli/config"
 	def "github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/tests"
 	"github.com/eris-ltd/eris-cli/util"
-	ver "github.com/eris-ltd/eris-cli/version"
 
+	"github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-logger"
 )
 
@@ -366,7 +366,7 @@ image          = "test image"
 		{`Service.Name`, s.Service.Name, name},
 		{`Service.AutoData`, s.Service.AutoData, true},
 		// [pv]: not "test image", but erisdb image. A bug?
-		{`Service.Image`, s.Service.Image, path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_DB)},
+		{`Service.Image`, s.Service.Image, path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_DB)},
 		{`Service.Environment`, s.Service.Environment, []string{"CHAIN_ID=" + name}},
 	} {
 		if !reflect.DeepEqual(entry.a, entry.b) {

--- a/perform/perform.go
+++ b/perform/perform.go
@@ -18,7 +18,7 @@ import (
 	"github.com/eris-ltd/eris-cli/config"
 	def "github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
-	ver "github.com/eris-ltd/eris-cli/version"
+	//ver "github.com/eris-ltd/eris-cli/version"
 
 	dirs "github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-logger"
@@ -1079,7 +1079,7 @@ func configureVolumesFromContainer(ops *def.Operation, service *def.Service) doc
 	opts := docker.CreateContainerOptions{
 		Name: util.UniqueName("interactive"),
 		Config: &docker.Config{
-			Image:           path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_DATA),
+			Image:           path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_DATA),
 			User:            "root",
 			WorkingDir:      dirs.ErisContainerRoot,
 			AttachStdout:    true,
@@ -1125,7 +1125,7 @@ func configureDataContainer(srv *def.Service, ops *def.Operation, mainContOpts *
 	//   that base image will not be present. in such cases use
 	//   the base eris data container.
 	if srv.Image == "" {
-		srv.Image = path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_DATA)
+		srv.Image = path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_DATA)
 	}
 
 	// Manipulate labels locally.

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -14,15 +14,14 @@ import (
 	"github.com/eris-ltd/eris-cli/loaders"
 	"github.com/eris-ltd/eris-cli/tests"
 	"github.com/eris-ltd/eris-cli/util"
-	ver "github.com/eris-ltd/eris-cli/version"
 
 	log "github.com/eris-ltd/eris-logger"
 )
 
 func TestMain(m *testing.M) {
-	log.SetLevel(log.ErrorLevel)
+	// log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)
-	// log.SetLevel(log.DebugLevel)
+	log.SetLevel(log.DebugLevel)
 
 	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
 
@@ -371,7 +370,7 @@ name = "`+name+`"
 
 [service]
 name = "`+name+`"
-image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)+`"
+image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)+`"
 data_container = true
 exec_host = "ERIS_KEYS_HOST"
 restart = "always"
@@ -417,7 +416,7 @@ name = "`+name+`"
 
 [service]
 name = "`+name+`"
-image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)+`"
+image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)+`"
 data_container = true
 exec_host = "ERIS_KEYS_HOST"
 restart = "max:99"
@@ -463,7 +462,7 @@ name = "`+name+`"
 
 [service]
 name = "`+name+`"
-image = "`+path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)+`"
+image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)+`"
 data_container = true
 exec_host = "ERIS_KEYS_HOST"
 `); err != nil {
@@ -2184,14 +2183,14 @@ func TestBuildSimple(t *testing.T) {
 		image = "test-image-1"
 	)
 
-	dockerfile := `FROM ` + path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)
+	dockerfile := `FROM ` + path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)
 
 	if err := DockerBuild(image, dockerfile); err != nil {
 		t.Fatalf("expected image to be built, got %v", err)
 	}
 
 	if err := DockerRemoveImage(image, true); err != nil {
-		t.Fatalf("expected image to be remove, got %v", err)
+		t.Fatalf("expected image to be removed, got %v", err)
 	}
 }
 

--- a/update/binary.go
+++ b/update/binary.go
@@ -12,7 +12,7 @@ import (
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/perform"
 	"github.com/eris-ltd/eris-cli/services"
-	ver "github.com/eris-ltd/eris-cli/version"
+	"github.com/eris-ltd/eris-cli/config"
 
 	"github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-logger"
@@ -120,7 +120,7 @@ func MakeDockerfile(branch string) string {
 	var dockerfile string
 
 	// baseImage is `quay.io/eris/data` // because the user already has it
-	baseImage := path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_DATA)
+	baseImage := path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_DATA)
 	// todo: clean up Dockerfile as much as possible
 
 	baseDockerfile := fmt.Sprintf(`

--- a/version/images.go
+++ b/version/images.go
@@ -10,7 +10,6 @@ var (
 	ERIS_REG_DEF = "quay.io"
 	ERIS_REG_BAK = "" //dockerhub
 
-	//ERIS_IMG_BASE = "eris/base" // only needed for [eris update]
 	ERIS_IMG_DATA = fmt.Sprintf("eris/data:%s", VERSION)
 	ERIS_IMG_KEYS = fmt.Sprintf("eris/keys:%s", VERSION)
 	ERIS_IMG_DB   = fmt.Sprintf("eris/erisdb:%s", VERSION)


### PR DESCRIPTION
- provides much needed flexibility for using feature/bugBranches for the other repos
- closes #515 

