### PR TITLE
Allow less restrictive mounting of host directories

### DIFF
--- a/cmd/services.go
+++ b/cmd/services.go
@@ -240,7 +240,7 @@ func addServicesFlags() {
 
 	buildFlag(servicesExec, do, "env", "service")
 	buildFlag(servicesExec, do, "links", "service")
-	servicesExec.Flags().StringVarP(&do.Operations.Volume, "volume", "", "", fmt.Sprintf("mount a volume %v/VOLUME on a host machine to a %v/VOLUME on a container", ErisRoot, ErisContainerRoot))
+	servicesExec.Flags().StringVarP(&do.Operations.Volume, "volume", "", "", fmt.Sprintf("mount a DIR or a VOLUME to a %v/DIR inside a container", ErisRoot))
 	buildFlag(servicesExec, do, "publish", "service")
 	buildFlag(servicesExec, do, "ports", "service")
 	buildFlag(servicesExec, do, "interactive", "service")

--- a/perform/perform.go
+++ b/perform/perform.go
@@ -963,8 +963,8 @@ func configureInteractiveContainer(srv *def.Service, ops *def.Operation) docker.
 
 	// Mount a volume.
 	if ops.Volume != "" {
-		bind := filepath.Join(dirs.ErisRoot, ops.Volume) + ":" +
-			filepath.Join(dirs.ErisContainerRoot, ops.Volume)
+		bind := filepath.Join(ops.Volume) + ":" +
+			filepath.Join(dirs.ErisContainerRoot, filepath.Base(ops.Volume))
 
 		if opts.HostConfig.Binds == nil {
 			opts.HostConfig.Binds = []string{bind}


### PR DESCRIPTION
Remove restriction of mounting volumes only from within the `~/.eris/` directory on the host machine; as a side effect this will also allow mounting volumes inside containers.

```
eris services exec -i <service> --volume /path/to/dir 
eris services exec -i <service> --volume volume_name
```

Closes #799