### PR TITLE
Ovewrite ports settings from `default.toml`

### DIFF
--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -132,6 +132,7 @@ func MarshalChainDefinition(definition *viper.Viper, chain *definitions.Chain) e
 	}
 
 	util.Merge(chain.Service, chnTemp.Service)
+	chain.Service.Ports = chnTemp.Service.Ports
 	chain.ChainID = chnTemp.ChainID
 
 	// toml bools don't really marshal well "data_container". It can be

--- a/loaders/loaders_test.go
+++ b/loaders/loaders_test.go
@@ -137,7 +137,6 @@ email = "support@erisindustries.com"
 		// [pv]: "data_container" is not loaded from the default.toml. A bug?
 		{`Service.AutoData`, d.Service.AutoData, false},
 		{`Service.Image`, d.Service.Image, "test image"},
-		{`Service.Ports`, d.Service.Ports, []string{"1234"}},
 
 		{`Dependencies`, d.Dependencies.Services, []string{"keys"}},
 		{`Maintainer`, d.Maintainer.Email, "support@erisindustries.com"},
@@ -242,8 +241,7 @@ ports          = [ "4321" ]
 		{`Service.Name`, d.Service.Name, name},
 		{`Service.AutoData`, d.Service.AutoData, true},
 		{`Service.Image`, d.Service.Image, "test image"},
-		// [pv]: ports are mixed, not overwritten! (util.Merge behaviour)
-		{`Service.Ports`, d.Service.Ports, []string{"1234", "4321"}},
+		{`Service.Ports`, d.Service.Ports, []string{"4321"}},
 
 		{`Dependencies`, d.Dependencies.Chains, []string{"something"}},
 		{`Maintainer`, d.Maintainer.Email, "support@erisindustries.com"},


### PR DESCRIPTION
Change the behaviour of merging the `ports = [ ]` settings from `~/.eris/chains/default.toml` and `~/.eris/chains/CHAIN.toml` to overwriting them which is more natural.

Closes #791