### PR TITLE
Proper error message if there's no link to chain or the chain isn't running

### DIFF
--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -132,7 +132,9 @@ func MarshalChainDefinition(definition *viper.Viper, chain *definitions.Chain) e
 	}
 
 	util.Merge(chain.Service, chnTemp.Service)
-	chain.Service.Ports = chnTemp.Service.Ports
+	if len(chnTemp.Service.Ports) != 0 {
+		chain.Service.Ports = chnTemp.Service.Ports
+	}
 	chain.ChainID = chnTemp.ChainID
 
 	// toml bools don't really marshal well "data_container". It can be


### PR DESCRIPTION
* Check if the chain is running before setting a link to it in an interactive container and remove deferred errors.
* Output the error of a missing `--dir` parameter of the first attempt (absolute path), not the second (`~/.eris/chains` + absolute path), because 2 concatenated Eris home directories look very ugly: (`stat /Users/peter/.eris/chains/Users/peter/.eris/simplechain: no such file or directory`).
* Fix an error of overwriting with empty ports.
* Closes #797