### PR TITLE
Use logging for IPFS client instead of `io` writers

### DIFF
--- a/actions/manage.go
+++ b/actions/manage.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,16 +54,7 @@ func ImportAction(do *definitions.Do) error {
 			return err
 		}
 
-		if log.GetLevel() > 0 {
-			err = ipfs.GetFromIPFS(s[1], fileName, "", os.Stdout)
-		} else {
-			err = ipfs.GetFromIPFS(s[1], fileName, "", bytes.NewBuffer([]byte{}))
-		}
-
-		if err != nil {
-			return err
-		}
-		return nil
+		return ipfs.GetFromIPFS(s[1], fileName, "")
 	}
 
 	if strings.Contains(s[0], "github") {
@@ -178,22 +168,10 @@ func RmAction(do *definitions.Do) error {
 }
 
 func exportFile(actionName string) (string, error) {
-	var err error
 	fileName := util.GetFileByNameAndType("actions", actionName)
 	if fileName == "" {
 		return "", fmt.Errorf("no file to export")
 	}
 
-	var hash string
-	if log.GetLevel() > 0 {
-		hash, err = ipfs.SendToIPFS(fileName, "", os.Stdout)
-	} else {
-		hash, err = ipfs.SendToIPFS(fileName, "", bytes.NewBuffer([]byte{}))
-	}
-
-	if err != nil {
-		return "", err
-	}
-
-	return hash, nil
+	return ipfs.SendToIPFS(fileName, "")
 }

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -1,7 +1,6 @@
 package chains
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -147,17 +146,7 @@ func ImportChain(do *definitions.Do) error {
 
 	s := strings.Split(do.Path, ":")
 	if s[0] == "ipfs" {
-		var err error
-		if log.GetLevel() > 0 {
-			err = ipfs.GetFromIPFS(s[1], fileName, "", os.Stdout)
-		} else {
-			err = ipfs.GetFromIPFS(s[1], fileName, "", bytes.NewBuffer([]byte{}))
-		}
-
-		if err != nil {
-			return err
-		}
-		return nil
+		return ipfs.GetFromIPFS(s[1], fileName, "")
 	}
 
 	if strings.Contains(s[0], "github") {
@@ -491,19 +480,7 @@ func RemoveChain(do *definitions.Do) error {
 func exportFile(chainName string) (string, error) {
 	fileName := util.GetFileByNameAndType("chains", chainName)
 
-	var hash string
-	var err error
-	if log.GetLevel() > 0 {
-		hash, err = ipfs.SendToIPFS(fileName, "", os.Stdout)
-	} else {
-		hash, err = ipfs.SendToIPFS(fileName, "", bytes.NewBuffer([]byte{}))
-	}
-
-	if err != nil {
-		return "", err
-	}
-
-	return hash, nil
+	return ipfs.SendToIPFS(fileName, "")
 }
 
 // TODO: remove

--- a/files/handle.go
+++ b/files/handle.go
@@ -246,82 +246,34 @@ func ManagePinned(do *definitions.Do) error {
 }
 
 func importFile(hash, fileName string) error {
-	var err error
-
 	log.WithFields(log.Fields{
 		"from hash": hash,
 		"to path":   fileName,
 	}).Debug("Importing a file")
 
-	if log.GetLevel() > 0 {
-		err = ipfs.GetFromIPFS(hash, fileName, "", os.Stdout)
-	} else {
-		err = ipfs.GetFromIPFS(hash, fileName, "", bytes.NewBuffer([]byte{}))
-	}
-	if err != nil {
-		return err
-	}
-	return nil
+	return ipfs.GetFromIPFS(hash, fileName, "")
 }
 
 func exportFile(fileName, gateway string) (string, error) {
-	var hash string
-	var err error
-
 	log.WithFields(log.Fields{
 		"file":    fileName,
 		"gateway": gateway,
 	}).Debug("Adding a file")
 
-	if log.GetLevel() > 0 {
-		hash, err = ipfs.SendToIPFS(fileName, gateway, os.Stdout)
-	} else {
-		hash, err = ipfs.SendToIPFS(fileName, gateway, bytes.NewBuffer([]byte{}))
-	}
-	if err != nil {
-		return "", err
-	}
-
-	return hash, nil
+	return ipfs.SendToIPFS(fileName, gateway)
 }
 
 func pinFile(fileHash string) (string, error) {
-	var hash string
-	var err error
-
-	if log.GetLevel() > 0 {
-		hash, err = ipfs.PinToIPFS(fileHash, os.Stdout)
-	} else {
-		hash, err = ipfs.PinToIPFS(fileHash, bytes.NewBuffer([]byte{}))
-	}
-	if err != nil {
-		return "", err
-	}
-	return hash, nil
+	return ipfs.PinToIPFS(fileHash)
 }
 
 func catFile(fileHash string) (string, error) {
-	var hash string
-	var err error
-	if log.GetLevel() > 0 {
-		hash, err = ipfs.CatFromIPFS(fileHash, os.Stdout)
-	} else {
-		hash, err = ipfs.CatFromIPFS(fileHash, bytes.NewBuffer([]byte{}))
-	}
-	if err != nil {
-		return "", err
-	}
-	return hash, nil
+	return ipfs.CatFromIPFS(fileHash)
 }
 
 func listFile(objectHash string) (string, error) {
-	var hash string
-	var err error
-	if log.GetLevel() > 0 {
-		hash, err = ipfs.ListFromIPFS(objectHash, os.Stdout)
-	} else {
-		hash, err = ipfs.ListFromIPFS(objectHash, bytes.NewBuffer([]byte{}))
-	}
+	hash, err := ipfs.ListFromIPFS(objectHash)
+
 	if err != nil {
 		if fmt.Sprintf("%v", err) != "EOF" {
 			return "", err
@@ -333,17 +285,7 @@ func listFile(objectHash string) (string, error) {
 }
 
 func listPinned() (string, error) {
-	var hash string
-	var err error
-	if log.GetLevel() > 0 {
-		hash, err = ipfs.ListPinnedFromIPFS(os.Stdout)
-	} else {
-		hash, err = ipfs.ListPinnedFromIPFS(bytes.NewBuffer([]byte{}))
-	}
-	if err != nil {
-		return "", err
-	}
-	return hash, nil
+	return ipfs.ListPinnedFromIPFS()
 }
 
 func rmAllPinned() (string, error) {
@@ -365,16 +307,7 @@ func rmAllPinned() (string, error) {
 }
 
 func rmPinnedByHash(hash string) (string, error) {
-	var err error
-	if log.GetLevel() > 0 {
-		hash, err = ipfs.RemovePinnedFromIPFS(hash, os.Stdout)
-	} else {
-		hash, err = ipfs.RemovePinnedFromIPFS(hash, bytes.NewBuffer([]byte{}))
-	}
-	if err != nil {
-		return "", err
-	}
-	return hash, nil
+	return ipfs.RemovePinnedFromIPFS(hash)
 }
 
 //---------------------------------------------------------

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -1,7 +1,6 @@
 package initialize
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -211,20 +210,22 @@ func drops(files []string, typ, dir, from string) error {
 		}
 	}
 
-	buf := new(bytes.Buffer)
 	if from == "toadserver" {
 		for _, file := range files {
 			url := fmt.Sprintf("%s:11113/getfile/%s", ipfs.SexyUrl(), file)
-			log.WithField(file, url).Debug("Getting file from url")
-			log.WithField(file, dir).Debug("Dropping file to")
-			if err := ipfs.DownloadFromUrlToFile(url, file, dir, buf); err != nil {
+			log.WithFields(log.Fields{
+				"=>":   file,
+				"from": url,
+				"to":   dir,
+			}).Debug("Moving file")
+			if err := ipfs.DownloadFromUrlToFile(url, file, dir); err != nil {
 				return err
 			}
 		}
 	} else if from == "rawgit" {
 		for _, file := range files {
 			log.WithField(file, dir).Debug("Getting file from GitHub, dropping into:")
-			if err := util.GetFromGithub("eris-ltd", repo, "master", archPrefix+file, dir, file, buf); err != nil {
+			if err := util.GetFromGithub("eris-ltd", repo, "master", archPrefix+file, dir, file); err != nil {
 				return err
 			}
 		}

--- a/services/load.go
+++ b/services/load.go
@@ -27,7 +27,7 @@ func EnsureRunning(do *definitions.Do) error {
 	}
 
 	if !util.IsService(srv.Service.Name, true) {
-		e := fmt.Sprintf("The requested service is not running, start it with [eris services start %s]", do.Name)
+		e := fmt.Sprintf("the requested service is not running, start it with [eris services start %s]", do.Name)
 		return errors.New(e)
 	} else {
 		log.WithField("=>", do.Name).Info("Service is running")

--- a/services/manage.go
+++ b/services/manage.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -26,18 +25,11 @@ func ImportService(do *definitions.Do) error {
 		fileName = fileName + ".toml"
 	}
 
-	var err error
-	if log.GetLevel() > 0 {
-		err = ipfs.GetFromIPFS(do.Hash, fileName, "", os.Stdout)
-	} else {
-		err = ipfs.GetFromIPFS(do.Hash, fileName, "", bytes.NewBuffer([]byte{}))
-	}
-
-	if err != nil {
+	if err := ipfs.GetFromIPFS(do.Hash, fileName, ""); err != nil {
 		return err
 	}
 
-	_, err = loaders.LoadServiceDefinition(do.Name)
+	_, err := loaders.LoadServiceDefinition(do.Name)
 	if err != nil {
 		return fmt.Errorf("error loading service:\n%v", err)
 	}
@@ -281,20 +273,5 @@ func InspectServiceByService(srv *definitions.Service, ops *definitions.Operatio
 }
 
 func exportFile(servName string) (string, error) {
-	fileName := FindServiceDefinitionFile(servName)
-
-	var hash string
-	var err error
-
-	if log.GetLevel() > 0 {
-		hash, err = ipfs.SendToIPFS(fileName, "", os.Stdout)
-	} else {
-		hash, err = ipfs.SendToIPFS(fileName, "", bytes.NewBuffer([]byte{}))
-	}
-
-	if err != nil {
-		return "", err
-	}
-
-	return hash, nil
+	return ipfs.SendToIPFS(FindServiceDefinitionFile(servName), "")
 }

--- a/util/readers.go
+++ b/util/readers.go
@@ -61,8 +61,7 @@ func UnpackTarball(tarBallPath, installPath string) error {
 	return UntarForDocker(reader, "", installPath)
 }
 
-func GetFromGithub(org, repo, branch, path, directory, fileName string, w io.Writer) error {
+func GetFromGithub(org, repo, branch, path, directory, fileName string) error {
 	url := "https://raw.githubusercontent.com/" + strings.Join([]string{org, repo, branch, path}, "/")
-	w.Write([]byte("Will download from url -> " + url))
-	return ipfs.DownloadFromUrlToFile(url, fileName, directory, w)
+	return ipfs.DownloadFromUrlToFile(url, fileName, directory)
 }

--- a/vendor/github.com/eris-ltd/common/go/ipfs/api_handler.go
+++ b/vendor/github.com/eris-ltd/common/go/ipfs/api_handler.go
@@ -3,14 +3,13 @@ package ipfs
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 )
 
 //returns []byte to let each command make its own struct for the response
 //but handles the errs in here
-func PostAPICall(url, fileHash string, w io.Writer) ([]byte, error) {
+func PostAPICall(url, fileHash string) ([]byte, error) {
 	request, err := http.NewRequest("POST", url, nil)
 	if err != nil {
 		return []byte(""), err
@@ -49,7 +48,7 @@ func PostAPICall(url, fileHash string, w io.Writer) ([]byte, error) {
 	}
 	//XXX hacky: would need to fix ipfs error msgs
 	if string(body) == "Path Resolve error: context deadline exceeded" && string(body) == "context deadline exceeded" {
-		return []byte(""), fmt.Errorf("A timeout occured while trying to reach IPFS. Run `eris files cache [hash], wait 5-10 seconds, then run `eris files [cmd] [hash]`")
+		return []byte(""), fmt.Errorf("A timeout occured while trying to reach IPFS. Run `[eris files cache HASH]`, wait 5-10 seconds, then run `[eris files COMMAND HASH]`")
 	}
 	return body, nil
 }


### PR DESCRIPTION
* Signatures of most ipfs client calls have changed to not accept writers (to be replaced with `ipfs.SetLogLevel()`.
* Closes #726