### PR TITLE
Fix linked Docker container `/etc/hosts` entry

### DIFF
--- a/perform/perform.go
+++ b/perform/perform.go
@@ -983,7 +983,6 @@ func configureInteractiveContainer(srv *def.Service, ops *def.Operation) docker.
 }
 
 func configureServiceContainer(srv *def.Service, ops *def.Operation) docker.CreateContainerOptions {
-
 	opts := docker.CreateContainerOptions{
 		Name: ops.SrvContainerName,
 		Config: &docker.Config{
@@ -1014,7 +1013,6 @@ func configureServiceContainer(srv *def.Service, ops *def.Operation) docker.Crea
 			CapAdd:          ops.CapAdd,
 			CapDrop:         ops.CapDrop,
 			RestartPolicy:   docker.NeverRestart(), //default. overide below
-			NetworkMode:     "bridge",
 		},
 	}
 


### PR DESCRIPTION
* Fix by removing the default `NetworkMode: bridge` default. Needs a Docker issue for head-up / info.
* Closes #780.