### PR TITLE
Expose `chains cat` commands and fix on Mac

### DIFF
--- a/chains/manage.go
+++ b/chains/manage.go
@@ -283,11 +283,9 @@ func CatChain(do *definitions.Do) error {
 	case "config":
 		do.Operations.Args = []string{"cat", path.Join(rootDir, "config.toml")}
 	case "status":
-		// [pv]: can't have 0.0.0.0 on OSX or Windows.
-		do.Operations.Args = []string{"mintinfo", "--node-addr", "http://0.0.0.0:46657", "status"}
+		do.Operations.Args = []string{"mintinfo", "--node-addr", "http://chain:46657", "status"}
 	case "validators":
-		// [pv]: can't have 0.0.0.0 on OSX or Windows.
-		do.Operations.Args = []string{"mintinfo", "--node-addr", "http://0.0.0.0:46657", "validators"}
+		do.Operations.Args = []string{"mintinfo", "--node-addr", "http://chain:46657", "validators"}
 	case "toml":
 		cat, err := ioutil.ReadFile(filepath.Join(ChainsPath, do.Name+".toml"))
 		if err != nil {

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -368,13 +368,15 @@ var chainsRestart = &cobra.Command{
 }
 
 var chainsCat = &cobra.Command{
-	Use:     "cat NAME [config|genesis]",
+	Use:     "cat NAME [config|genesis|status|validators]",
 	Short:   "display chain information",
 	Long:    `display chain information`,
 	Aliases: []string{"plop"},
-	Example: `$ eris chains cat simplechain -- will display the chain definition file
-$ eris chains cat simplechain config -- will display the config.toml file from inside the container
-$ eris chains cat simplechain genesis -- will display the genesis.json file from the container`,
+	Example: `$ eris chains cat simplechain -- display the chain definition file
+$ eris chains cat simplechain config -- display the config.toml file from inside the container
+$ eris chains cat simplechain genesis -- display the genesis.json file from the container
+$ eris chains cat simplechain status -- display chain status
+$ eris chains cat simplechain validators -- display chain validators`,
 	Run: CatChain,
 }
 


### PR DESCRIPTION
* Fix `chains cat CHAIN_NAME status` and `chains cat CHAIN_NAME validators` command on Mac and expose them in `eris chains cat --help`.
* Fixes #820.