### PR TITLE
overwrite default image versions in eris.toml on init

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ type ErisConfig struct {
 	DockerHost     string `json:"DockerHost,omitempty" yaml:"DockerHost,omitempty" toml:"DockerHost,omitempty"`
 	DockerCertPath string `json:"DockerCertPath,omitempty" yaml:"DockerCertPath,omitempty" toml:"DockerCertPath,omitempty"`
 	CrashReport    string `json:"CrashReport,omitempty" yaml:"CrashReport,omitempty" toml:"CrashReport,omitempty"`
-	Verbose bool
+	Verbose        bool
 
 	//image defaults
 	ERIS_REG_DEF string `json:"ERIS_REG_DEF,omitempty" yaml:"ERIS_REG_DEF,omitempty" toml:"ERIS_REG_DEF,omitempty"`
@@ -42,9 +42,9 @@ type ErisConfig struct {
 
 	ERIS_IMG_DATA string `json:"ERIS_IMG_DATA,omitempty" yaml:"ERIS_IMG_DATA,omitempty" toml:"ERIS_IMG_DATA,omitempty"`
 	ERIS_IMG_KEYS string `json:"ERIS_IMG_KEYS,omitempty" yaml:"ERIS_IMG_KEYS,omitempty" toml:"ERIS_IMG_KEYS,omitempty"`
-	ERIS_IMG_DB string `json:"ERIS_IMG_DB,omitempty" yaml:"ERIS_IMG_DB,omitempty" toml:"ERIS_IMG_DB,omitempty"`
-	ERIS_IMG_PM string `json:"ERIS_IMG_PM,omitempty" yaml:"ERIS_IMG_PM,omitempty" toml:"ERIS_IMG_PM,omitempty"`
-	ERIS_IMG_CM string `json:"ERIS_IMG_CM,omitempty" yaml:"ERIS_IMG_CM,omitempty" toml:"ERIS_IMG_CM,omitempty"`
+	ERIS_IMG_DB   string `json:"ERIS_IMG_DB,omitempty" yaml:"ERIS_IMG_DB,omitempty" toml:"ERIS_IMG_DB,omitempty"`
+	ERIS_IMG_PM   string `json:"ERIS_IMG_PM,omitempty" yaml:"ERIS_IMG_PM,omitempty" toml:"ERIS_IMG_PM,omitempty"`
+	ERIS_IMG_CM   string `json:"ERIS_IMG_CM,omitempty" yaml:"ERIS_IMG_CM,omitempty" toml:"ERIS_IMG_CM,omitempty"`
 	ERIS_IMG_IPFS string `json:"ERIS_IMG_IPFS,omitempty" yaml:"ERIS_IMG_IPFS,omitempty" toml:"ERIS_IMG_IPFS,omitempty"`
 }
 
@@ -135,8 +135,7 @@ func SaveGlobalConfig(config *ErisConfig) error {
 
 	enc := toml.NewEncoder(writer)
 	enc.Indent = ""
-	err = enc.Encode(config)
-	if err != nil {
+	if err := enc.Encode(config); err != nil {
 		return err
 	}
 	return nil

--- a/initialize/init.go
+++ b/initialize/init.go
@@ -5,20 +5,26 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/eris-ltd/eris-cli/config"
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
+	ver "github.com/eris-ltd/eris-cli/version"
 
 	"github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-logger"
 )
 
 func Initialize(do *definitions.Do) error {
+
 	newDir, err := checkThenInitErisRoot(do.Quiet)
 	if err != nil {
 		return err
 	}
 
 	if !newDir { //new ErisRoot won't have either...can skip
+		if err := overwriteImageConfigs(); err != nil {
+			return err
+		}
 		if err := checkIfCanOverwrite(do.Yes); err != nil {
 			return nil
 		}
@@ -188,6 +194,22 @@ on local host machines. If you already have the images, they'll be updated.
 			}
 			log.Warn("Successfully pulled default images")
 		}
+	}
+	return nil
+}
+
+func overwriteImageConfigs() error {
+	config.GlobalConfig.Config.ERIS_REG_DEF = ver.ERIS_REG_DEF
+	config.GlobalConfig.Config.ERIS_REG_BAK = ver.ERIS_REG_BAK
+	config.GlobalConfig.Config.ERIS_IMG_DATA = ver.ERIS_IMG_DATA
+	config.GlobalConfig.Config.ERIS_IMG_KEYS = ver.ERIS_IMG_KEYS
+	config.GlobalConfig.Config.ERIS_IMG_DB = ver.ERIS_IMG_DB
+	config.GlobalConfig.Config.ERIS_IMG_PM = ver.ERIS_IMG_PM
+	config.GlobalConfig.Config.ERIS_IMG_CM = ver.ERIS_IMG_CM
+	config.GlobalConfig.Config.ERIS_IMG_IPFS = ver.ERIS_IMG_IPFS
+
+	if err := config.SaveGlobalConfig(config.GlobalConfig.Config); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
fixes #779 