### PR TITLE
add a local compilers flag for easy usage of local compilers image

### DIFF
--- a/cmd/pkgs.go
+++ b/cmd/pkgs.go
@@ -59,6 +59,7 @@ func addPackagesFlags() {
 	packagesDo.Flags().StringVarP(&do.ChainPort, "chain-port", "", "46657", "chain rpc port")
 	packagesDo.Flags().StringVarP(&do.KeysPort, "keys-port", "", "4767", "port for keys server")
 	packagesDo.Flags().BoolVarP(&do.Overwrite, "overwrite", "t", true, "overwrite jobs of the same name")
+	packagesDo.Flags().BoolVarP(&do.LocalCompiler, "local-compiler", "z", false, "use a local compiler service; overwrites anything added to compilers flag")
 }
 
 func PackagesDo(cmd *cobra.Command, args []string) {
@@ -71,7 +72,7 @@ func PackagesDo(cmd *cobra.Command, args []string) {
 	if do.ChainName == "" {
 		IfExit(fmt.Errorf("please provide the name of a running chain with --chain"))
 	}
-	if do.DefaultAddr == "" {
+	if do.DefaultAddr == "" { // note that this is not strictly necessary since the addr can be set in the epm.yaml.
 		IfExit(fmt.Errorf("please provide the address to deploy from with --address"))
 	}
 	IfExit(pkgs.RunPackage(do))

--- a/config/config.go
+++ b/config/config.go
@@ -6,14 +6,16 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	ver "github.com/eris-ltd/eris-cli/version"
 
 	dir "github.com/eris-ltd/common/go/common"
-	"github.com/tcnksm/go-gitconfig"
 
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/viper"
+	"github.com/tcnksm/go-gitconfig"
 )
 
 // Properly scope the globalConfig.
@@ -30,7 +32,8 @@ type ErisCli struct {
 
 type ErisConfig struct {
 	IpfsHost       string `json:"IpfsHost,omitempty" yaml:"IpfsHost,omitempty" toml:"IpfsHost,omitempty"`
-	CompilersHost  string `json:"CompilersHost,omitempty" yaml:"CompilersHost,omitempty" toml:"CompilersHost,omitempty"`
+	CompilersHost  string `json:"CompilersHost,omitempty" yaml:"CompilersHost,omitempty" toml:"CompilersHost,omitempty"` // currently unused
+	CompilersPort  string `json:"CompilersPort,omitempty" yaml:"CompilersPort,omitempty" toml:"CompilersPort,omitempty"` // currently unused
 	DockerHost     string `json:"DockerHost,omitempty" yaml:"DockerHost,omitempty" toml:"DockerHost,omitempty"`
 	DockerCertPath string `json:"DockerCertPath,omitempty" yaml:"DockerCertPath,omitempty" toml:"DockerCertPath,omitempty"`
 	CrashReport    string `json:"CrashReport,omitempty" yaml:"CrashReport,omitempty" toml:"CrashReport,omitempty"`
@@ -111,10 +114,21 @@ func LoadGlobalConfig() (*viper.Viper, error) {
 
 func SetDefaults() (*viper.Viper, error) {
 	var globalConfig = viper.New()
-	globalConfig.SetDefault("IpfsHost", "http://0.0.0.0")
-	globalConfig.SetDefault("CompilersHost", "https://compilers.eris.industries")
+
+	// assorted defaults
+	globalConfig.SetDefault("IpfsHost", "http://0.0.0.0") // [csk] TODO: be less opinionated here...
 	globalConfig.SetDefault("CrashReport", "bugsnag")
-	// image defaults...
+
+	// compilers defaults
+	globalConfig.SetDefault("CompilersHost", "https://compilers.eris.industries")
+	verSplit := strings.Split(ver.VERSION, "-")
+	verSplit = strings.Split(verSplit[0], ".")
+	maj, _ := strconv.Atoi(verSplit[0])
+	min, _ := strconv.Atoi(verSplit[1])
+	pat, _ := strconv.Atoi(verSplit[2])
+	globalConfig.SetDefault("CompilersPort", fmt.Sprintf("1%01d%02d%01d", maj, min, pat))
+
+	// image defaults
 	globalConfig.SetDefault("ERIS_REG_DEF", ver.ERIS_REG_DEF)
 	globalConfig.SetDefault("ERIS_REG_BAK", ver.ERIS_REG_BAK)
 	globalConfig.SetDefault("ERIS_IMG_DATA", ver.ERIS_IMG_DATA)
@@ -122,7 +136,9 @@ func SetDefaults() (*viper.Viper, error) {
 	globalConfig.SetDefault("ERIS_IMG_DB", ver.ERIS_IMG_DB)
 	globalConfig.SetDefault("ERIS_IMG_PM", ver.ERIS_IMG_PM)
 	globalConfig.SetDefault("ERIS_IMG_CM", ver.ERIS_IMG_CM)
+	globalConfig.SetDefault("ERIS_IMG_COMP", ver.ERIS_IMG_COMP)
 	globalConfig.SetDefault("ERIS_IMG_IPFS", ver.ERIS_IMG_IPFS)
+
 	return globalConfig, nil
 }
 

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -27,6 +27,7 @@ type Do struct {
 	OutputTable   bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Overwrite     bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Dump          bool     `mapstructure:"," json:"," yaml:"," toml:","`
+	LocalCompiler bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Lines         int      `mapstructure:"," json:"," yaml:"," toml:","` // XXX: for tail and logs
 	Timeout       uint     `mapstructure:"," json:"," yaml:"," toml:","`
 	N             uint     `mapstructure:"," json:"," yaml:"," toml:","`

--- a/version/images.go
+++ b/version/images.go
@@ -15,5 +15,6 @@ var (
 	ERIS_IMG_DB   = fmt.Sprintf("eris/erisdb:%s", VERSION)
 	ERIS_IMG_PM   = fmt.Sprintf("eris/epm:%s", VERSION)
 	ERIS_IMG_CM   = fmt.Sprintf("eris/eris-cm:%s", VERSION)
+	ERIS_IMG_COMP = fmt.Sprintf("eris/compilers:%s", VERSION)
 	ERIS_IMG_IPFS = "eris/ipfs"
 )

--- a/version/images_arm.go
+++ b/version/images_arm.go
@@ -15,5 +15,6 @@ var (
 	ERIS_IMG_DB   = fmt.Sprintf("eris/erisdb:%s-%s", ARCH, VERSION)
 	ERIS_IMG_PM   = fmt.Sprintf("eris/epm:%s-%s", ARCH, VERSION)
 	ERIS_IMG_CM   = fmt.Sprintf("eris/eris-cm:%s-%s", ARCH, VERSION)
+	ERIS_IMG_COMP = fmt.Sprintf("eris/compilers:%s-%s", ARCH, VERSION)
 	ERIS_IMG_IPFS = fmt.Sprintf("eris/ipfs:%s", ARCH)
 )


### PR DESCRIPTION
Changes:

* CompilersPort added to global config (note, both it an CompilersHost currently unused but good for future work)
* Placeholder for compilers image added to globalConfig
* When `-z` or `--local-compilers` given to `eris pkgs do` the compilers service will be started (currently using the compilers service definition file, which utilizes the `:latest` image), linked to, and removed during cleanup
* added appropriate tests for this functionality

closes #837

