### PR TITLE
Fix panic on checking current user's home directory

### DIFF
--- a/clean/clean.go
+++ b/clean/clean.go
@@ -11,7 +11,7 @@ func Clean(do *definitions.Do) error {
 		"yes":        do.Yes,
 		"all":        do.All,
 		"containers": do.Containers,
-		"chn-dirs":   do.ChnDirs,
+		"chains":     do.ChnDirs,
 		"scratch":    do.Scratch,
 		"root":       do.RmD,
 		"images":     do.Images,

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -29,7 +29,7 @@ func addCleanFlags() {
 	Clean.Flags().BoolVarP(&do.Yes, "yes", "y", false, "overrides prompts prior to removing things")
 	Clean.Flags().BoolVarP(&do.All, "all", "a", false, "removes everything, stopping short of uninstalling eris")
 	Clean.Flags().BoolVarP(&do.Containers, "containers", "c", true, "remove all eris containers")
-	Clean.Flags().BoolVarP(&do.ChnDirs, "chn-dirs", "", true, "remove latent chain datas in $HOME/.eris/chains")
+	Clean.Flags().BoolVarP(&do.ChnDirs, "chains", "", true, "remove latent chain data in $HOME/.eris/chains")
 	Clean.Flags().BoolVarP(&do.Scratch, "scratch", "s", true, "remove contents of: $HOME/.eris/scratch")
 	Clean.Flags().BoolVarP(&do.RmD, "dir", "", false, "remove the eris home directory: $HOME/.eris")
 	Clean.Flags().BoolVarP(&do.Images, "images", "i", false, "remove all eris docker images")

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -224,7 +224,7 @@ func drops(files []string, typ, dir, from string) error {
 		}
 	} else if from == "rawgit" {
 		for _, file := range files {
-			log.WithField(file, dir).Debug("Getting file from GitHub, dropping into:")
+			log.WithField(file, dir).Debug("Getting file from GitHub, dropping into")
 			if err := util.GetFromGithub("eris-ltd", repo, "master", archPrefix+file, dir, file); err != nil {
 				return err
 			}

--- a/pkgs/operate.go
+++ b/pkgs/operate.go
@@ -493,10 +493,9 @@ func getDataContainerSorted(do *definitions.Do, inbound bool) error {
 		log.WithField("=>", do.ABIPath).Debug("Setting do.ABIPath")
 	}
 
-	// when running eris pkgs do from a home directory there is a problem on the exports. this ensures that the export
-	// runs properly.
-	user, _ := user.Current()
-	if user.HomeDir == do.ABIPath {
+	// If the ABI path specified is a home directory,
+	// append the "abi" subdirectory to it.
+	if user, err := user.Current(); err == nil && user.HomeDir == do.ABIPath {
 		do.ABIPath = filepath.Join(do.ABIPath, "abi")
 	}
 

--- a/util/clean.go
+++ b/util/clean.go
@@ -39,15 +39,15 @@ func cleanHandler(toClean map[string]bool) error {
 		}
 	}
 
-	if toClean["chn-dirs"] {
-		log.Debug("Removing latent chains data in ChainsPath")
+	if toClean["chains"] {
+		log.Debug("Removing latent chains data directories")
 		if err := cleanLatentChainData(); err != nil {
 			return err
 		}
 	}
 
 	if toClean["scratch"] {
-		log.Debug("Removing contents of DataContainersPath")
+		log.Debug("Removing containers' scratch data")
 		if err := cleanScratchData(); err != nil {
 			return err
 		}
@@ -172,7 +172,7 @@ func RemoveErisImages() error {
 func canWeRemove(toClean map[string]bool) bool {
 	var toWarn = map[string]string{
 		"containers": "all",
-		"chn-dirs":   "latent files & dirs from ~/.eris/chains",
+		"chains":     fmt.Sprintf("%s/.eris/chains", common.HomeDir()),
 		"scratch":    fmt.Sprintf("%s/.eris/scratch/data", common.HomeDir()),
 		"root":       fmt.Sprintf("%s/.eris", common.HomeDir()),
 		"images":     "all",
@@ -181,24 +181,24 @@ func canWeRemove(toClean map[string]bool) bool {
 	if toClean["all"] != true {
 		log.Warn("The marmots are about to remove the following")
 		if toClean["containers"] {
-			log.WithField("containers", toWarn["containers"]).Warn("")
+			log.WithField("containers", toWarn["containers"]).Warn()
 		}
-		if toClean["chn-dirs"] {
-			log.WithField("chn-dirs", toWarn["chn-dirs"]).Warn("")
+		if toClean["chains"] {
+			log.WithField("chains", toWarn["chains"]).Warn()
 		}
 		if toClean["scratch"] {
-			log.WithField("scratch", toWarn["scratch"]).Warn("")
+			log.WithField("scratch", toWarn["scratch"]).Warn()
 		}
 		if toClean["root"] {
-			log.WithField("root", toWarn["root"]).Warn("")
+			log.WithField("root", toWarn["root"]).Warn()
 		}
 		if toClean["images"] {
-			log.WithField("images", toWarn["images"]).Warn("")
+			log.WithField("images", toWarn["images"]).Warn()
 		}
 	} else {
 		log.WithFields(log.Fields{
 			"containers": toWarn["containers"],
-			"chn-dirs":   toWarn["chn-dirs"],
+			"chains":     toWarn["chains"],
 			"scratch":    toWarn["scratch"],
 			"root":       toWarn["root"],
 			"images":     toWarn["images"],

--- a/vendor/github.com/eris-ltd/common/go/ipfs/readers.go
+++ b/vendor/github.com/eris-ltd/common/go/ipfs/readers.go
@@ -117,7 +117,7 @@ func DownloadFromUrlToFile(url, fileName, dirName string) error {
 		log.WithFields(log.Fields{
 			"from": url,
 			"to":   endPath,
-		}).Warn("Downloading")
+		}).Info("Downloading")
 		checkDir, err := os.Stat(dirName)
 		if err != nil {
 			log.Warn("Directory does not exist, creating it")

--- a/vendor/github.com/eris-ltd/eris-logger/doc.go
+++ b/vendor/github.com/eris-ltd/eris-logger/doc.go
@@ -1,5 +1,5 @@
 /*
-Package eris-logger is a logrus fork for Eris Industries, Ltd.
+Package logger is a logrus fork for Eris Industries, Ltd.
 
   package main
 

--- a/vendor/github.com/eris-ltd/eris-logger/eris.go
+++ b/vendor/github.com/eris-ltd/eris-logger/eris.go
@@ -53,7 +53,7 @@ func ParseLevel(lvl string) (Level, error) {
 	return l, fmt.Errorf("not a valid logrus Level: %q", lvl)
 }
 
-// A constant exposing all logging levels
+// AllLevels is a constant exposing all logging levels.
 var AllLevels = []Level{
 	PanicLevel,
 	FatalLevel,

--- a/vendor/github.com/eris-ltd/eris-logger/eris_formatter.go
+++ b/vendor/github.com/eris-ltd/eris-logger/eris_formatter.go
@@ -2,14 +2,12 @@ package logger
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"runtime"
 	"sort"
-
-	"github.com/docker/docker/pkg/term"
 )
 
+// ErisFormatter is a custom logger implementation.
 type ErisFormatter struct {
 	// Set to true to ignore TTY checks for color highlights.
 	Color bool
@@ -46,7 +44,7 @@ func (f ErisFormatter) Format(entry *Entry) (out []byte, err error) {
 
 	// Sort tag names in alphabetical order.
 	var keys []string
-	for key, _ := range entry.Data {
+	for key := range entry.Data {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
@@ -91,16 +89,15 @@ func (f ErisFormatter) Highlight(tag, comment string) (adjustedOffset int, text 
 	commentDecorated := comment
 
 	// Use color formatting if specified and if connected to the terminal.
-	if f.Color && term.IsTerminal(os.Stdout.Fd()) && term.IsTerminal(os.Stderr.Fd()) {
+	if f.Color && IsTerminal() {
 		tagDecorated = fmt.Sprintf("%s%s%s", escTag, tag, escReset)
 		commentDecorated = fmt.Sprintf("%s%s%s", escBold, comment, escReset)
 	}
 
 	if tag == arrowTag {
 		return offset + 2, fmt.Sprintf("%s", commentDecorated)
-	} else {
-		return offset - len(tag) + 1, fmt.Sprintf("%s=%s", tagDecorated, commentDecorated)
 	}
+	return offset - len(tag) + 1, fmt.Sprintf("%s=%s", tagDecorated, commentDecorated)
 }
 
 // tput asks the terminfo database for a particular escape sequence.

--- a/vendor/github.com/eris-ltd/eris-logger/eris_test.go
+++ b/vendor/github.com/eris-ltd/eris-logger/eris_test.go
@@ -305,7 +305,7 @@ func TestParseLevel(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, DebugLevel, l)
 
-	l, err = ParseLevel("invalid")
+	_, err = ParseLevel("invalid")
 	assert.Equal(t, "not a valid logrus Level: \"invalid\"", err.Error())
 }
 

--- a/vendor/github.com/eris-ltd/eris-logger/exported.go
+++ b/vendor/github.com/eris-ltd/eris-logger/exported.go
@@ -9,6 +9,7 @@ var (
 	std = New()
 )
 
+// StandardLogger returns a default logger instance.
 func StandardLogger() *Logger {
 	return std
 }

--- a/vendor/github.com/eris-ltd/eris-logger/formatter.go
+++ b/vendor/github.com/eris-ltd/eris-logger/formatter.go
@@ -2,6 +2,7 @@ package logger
 
 import "time"
 
+// DefaultTimestampFormat is a timestamp format used for the standard logger.
 const DefaultTimestampFormat = time.RFC3339
 
 // The Formatter interface is used to implement a custom Formatter. It takes an

--- a/vendor/github.com/eris-ltd/eris-logger/hooks.go
+++ b/vendor/github.com/eris-ltd/eris-logger/hooks.go
@@ -1,6 +1,6 @@
 package logger
 
-// A hook to be fired when logging on the logging levels returned from
+// Hook to be fired when logging on the logging levels returned from
 // `Levels()` on your implementation of the interface. Note that this is not
 // fired in a goroutine or a channel with workers, you should handle such
 // functionality yourself if your call is non-blocking and you don't wish for
@@ -10,7 +10,7 @@ type Hook interface {
 	Fire(*Entry) error
 }
 
-// Internal type for storing the hooks on a logger instance.
+// LevelHooks internal type for storing the hooks on a logger instance.
 type LevelHooks map[Level][]Hook
 
 // Add a hook to an instance of logger. This is called with

--- a/vendor/github.com/eris-ltd/eris-logger/hooks_bugsnag.go
+++ b/vendor/github.com/eris-ltd/eris-logger/hooks_bugsnag.go
@@ -9,7 +9,7 @@ import (
 	bugsnag "github.com/bugsnag/bugsnag-go"
 )
 
-// Default API Key. Can be overridden with the ERIS_BUGSNAG_TOKEN
+// APIKey can be overridden with the ERIS_BUGSNAG_TOKEN
 // environment variable.
 var APIKey = "1b9565bb7a4f8fd6dc446f2efd238fa3"
 
@@ -52,10 +52,12 @@ func NewBugsnagReporter(config map[string]string) Bugsnag {
 	}
 }
 
+// Hook is an implementation of the logger Hook method.
 func (b Bugsnag) Hook() Hook {
 	return b
 }
 
+// Levels is an implementation of the logger Levels method.
 func (b Bugsnag) Levels() []Level {
 	// Collecting messages on all levels.
 	return []Level{
@@ -68,6 +70,7 @@ func (b Bugsnag) Levels() []Level {
 	}
 }
 
+// Fire is an implementation of the logger Fire method.
 func (b Bugsnag) Fire(e *Entry) error {
 	out, err := b.remoteLogger.Formatter.Format(e)
 	if err != nil {
@@ -80,6 +83,8 @@ func (b Bugsnag) Fire(e *Entry) error {
 	return nil
 }
 
+// SendReport method connects to the Bugsnag server and
+// sends out collected debugging an stack trace info.
 func (b Bugsnag) SendReport(message interface{}) error {
 	debug.PrintStack()
 
@@ -98,5 +103,4 @@ func (b Bugsnag) SendReport(message interface{}) error {
 			},
 		},
 	)
-	return nil
 }

--- a/vendor/github.com/eris-ltd/eris-logger/hooks_stub.go
+++ b/vendor/github.com/eris-ltd/eris-logger/hooks_stub.go
@@ -7,22 +7,28 @@ import (
 // Stub is a void implementation of the CrashReporter and Eris logger Hook interfaces.
 type Stub struct{}
 
+// NewStubReporter returns a new Stub implementation.
 func NewStubReporter(c map[string]string) Stub {
 	return Stub{}
 }
 
+// Levels is an implementation of the logger Levels method.
 func (s Stub) Levels() []Level {
 	return []Level{}
 }
 
+// Fire is an implementation of the logger Fire method.
 func (s Stub) Fire(e *Entry) error {
 	return nil
 }
 
+// Hook is an implementation of the logger Hook method.
 func (s Stub) Hook() Hook {
 	return s
 }
 
+// SendReport prints a stack trace to the console
+// to make sure stub actually is used as an implementation.
 func (s Stub) SendReport(message interface{}) error {
 	debug.PrintStack()
 

--- a/vendor/github.com/eris-ltd/eris-logger/json_formatter.go
+++ b/vendor/github.com/eris-ltd/eris-logger/json_formatter.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 )
 
+// JSONFormatter is a custom logger implementation.
 type JSONFormatter struct {
 	// TimestampFormat sets the format used for marshaling timestamps.
 	TimestampFormat string
 }
 
+// Format returns a JSON formatted logging entry.
 func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	data := make(Fields, len(entry.Data)+3)
 	for k, v := range entry.Data {

--- a/vendor/github.com/eris-ltd/eris-logger/terminal_bsd.go
+++ b/vendor/github.com/eris-ltd/eris-logger/terminal_bsd.go
@@ -6,4 +6,5 @@ import "syscall"
 
 const ioctlReadTermios = syscall.TIOCGETA
 
+// Termios is an exposed syscall structure.
 type Termios syscall.Termios

--- a/vendor/github.com/eris-ltd/eris-logger/writer.go
+++ b/vendor/github.com/eris-ltd/eris-logger/writer.go
@@ -6,10 +6,13 @@ import (
 	"runtime"
 )
 
+// Writer is an implementation of io.PipeWriter interface.
 func (logger *Logger) Writer() *io.PipeWriter {
-	return logger.WriterLevel(InfoLevel)
+	return logger.WriterLevel(WarnLevel)
 }
 
+// WriterLevel is an in implementation io.PipeWriter interface
+// logging at a specifi level.
 func (logger *Logger) WriterLevel(level Level) *io.PipeWriter {
 	reader, writer := io.Pipe()
 


### PR DESCRIPTION
* Check the failure on `user.Current()` error when Go can't retrieve current user entry from the password file; fixes #830.
* Update outdated /vendor `eris-logger`.
* Remove noisy `common/go/ipfs` client fetch files messages for `eris init`.
* Rename `chn-dirs` to `chains` in `eris clean` command.  