### PR TITLE
Use standard error stream for logging and `IfExit` messages

### DIFF
--- a/cmd/eris.go
+++ b/cmd/eris.go
@@ -35,10 +35,6 @@ Made with <3 by Eris Industries.
 Complete documentation is available at https://docs.erisindustries.com
 ` + "\nVersion:\n  " + VERSION,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// Using stdout for less fuss with redirecting the log messages
-		// into a file (`eris > out`) or a viewer (`eris|more`).
-		log.SetOutput(os.Stdout)
-
 		log.SetLevel(log.WarnLevel)
 		if do.Verbose {
 			log.SetLevel(log.InfoLevel)

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/viper"
-	"github.com/tcnksm/go-gitconfig"
+	gitconfig "github.com/tcnksm/go-gitconfig"
 )
 
 // Properly scope the globalConfig.
@@ -74,24 +74,29 @@ func SetGlobalObject(writer, errorWriter io.Writer) (*ErisCli, error) {
 }
 
 func LoadViperConfig(configPath, configName string) (*viper.Viper, error) {
-	var conf = viper.New()
+	var errKnown string
+	switch configPath {
+	case dir.ChainsPath, dir.ServicesPath, dir.ActionsPath:
+		errKnown = fmt.Sprintf(`
 
+List available definitions with the [eris %s ls --known] command`, filepath.Base(configPath))
+	}
+
+	// Don't use ReadInConfig() for checking file existence because
+	// is error is too murky (e.g.:it doesn't say "file not found").
+	//
+	// Don't use os.Stat() for checking file existence because there might
+	// be a selection of supported definition files, e.g.: keys.toml,
+	// keys.json, keys.yaml, etc.
+	if matches, _ := filepath.Glob(filepath.Join(configPath, configName+".*")); len(matches) == 0 {
+		return nil, fmt.Errorf("Unable to find the %q definition: %v%s", configName, os.ErrNotExist, errKnown)
+	}
+
+	conf := viper.New()
 	conf.AddConfigPath(configPath)
 	conf.SetConfigName(configName)
-	err := conf.ReadInConfig()
-	if err != nil {
-		errmsg := fmt.Sprintf(`Unable to load the %q config. Check the file name existence and formatting: %v
-`, configName, err)
-
-		switch configPath {
-		case dir.ChainsPath, dir.ServicesPath, dir.ActionsPath:
-			errknown := fmt.Sprintf(`
-List available definitions with the [eris %s ls --known] command
-`, filepath.Base(configPath))
-			return nil, fmt.Errorf("%s%s", errmsg, errknown)
-		}
-
-		return nil, fmt.Errorf(errmsg)
+	if err := conf.ReadInConfig(); err != nil {
+		return nil, fmt.Errorf("Unable to load the %q definition: %v%s", configName, err, errKnown)
 	}
 
 	return conf, nil

--- a/vendor/github.com/eris-ltd/common/go/common/dirs_and_files.go
+++ b/vendor/github.com/eris-ltd/common/go/common/dirs_and_files.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -79,7 +78,7 @@ var MajorDirs = []string{
 	PersonalServicesPath,
 }
 
-// These should only be used by specific tooling rather than eris-cli level
+// ChainsDirs to be used by specific tooling rather than eris-cli level.
 var ChainsDirs = []string{
 	ChainsPath,
 	DefaultChainPath,
@@ -87,20 +86,20 @@ var ChainsDirs = []string{
 	ChainTypePath,
 }
 
-// These should only be used by specific tooling rather than eris-cli level
+// KeysDirs to be used by specific tooling rather than eris-cli level.
 var KeysDirs = []string{
 	KeysPath,
 	KeysDataPath,
 	KeyNamesPath,
 }
 
-// These should only be used by specific tooling rather than eris-cli level
+// ServicesDirs to be used by specific tooling rather than eris-cli level.
 var ServicesDirs = []string{
 	ServicesPath,
 	PersonalServicesPath,
 }
 
-// These should only be used by specific tooling rather than eris-cli level
+// ScratchDirs to be used by specific tooling rather than eris-cli level.
 var ScratchDirs = []string{
 	ScratchPath,
 	DataContainersPath,
@@ -110,15 +109,13 @@ var ScratchDirs = []string{
 	SerpScratchPath,
 }
 
-//eris update checks if old dirs exist & migrates them
+// DirsToMigrate is used by the `eris update` command to check
+// if old dirs exist to migrate them.
 var DirsToMigrate = map[string]string{
 	BlockchainsPath: ChainsPath,
 	DappsPath:       AppsPath,
 	LanguagesPath:   LanguagesScratchPath,
 }
-
-//---------------------------------------------
-// user and process
 
 func HomeDir() string {
 	if runtime.GOOS == "windows" {
@@ -132,26 +129,6 @@ func HomeDir() string {
 		return os.Getenv("HOME")
 	}
 }
-
-func Exit(err error) {
-	status := 0
-	if err != nil {
-		fmt.Println(err)
-		status = 1
-	}
-	os.Exit(status)
-}
-
-func IfExit(err error) {
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-}
-
-// user and process
-//---------------------------------------------------------------------------
-// filesystem
 
 func AbsolutePath(Datadir string, filename string) string {
 	if filepath.IsAbs(filename) {
@@ -305,10 +282,6 @@ func WriteFile(data, path string) error {
 	writer.Write([]byte(data))
 	return nil
 }
-
-// filesystem
-//-------------------------------------------------------
-// open text editors
 
 func Editor(file string) error {
 	editr := os.Getenv("EDITOR")

--- a/vendor/github.com/eris-ltd/common/go/common/exit.go
+++ b/vendor/github.com/eris-ltd/common/go/common/exit.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"fmt"
+	"os"
+)
+
+func Exit(err error) {
+	status := 0
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		status = 1
+	}
+	os.Exit(status)
+}
+
+func IfExit(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
* Update `common`'s `Exit()` and `IfExit()` functions to use `os.Stderr` for messages.
* Don't change the default `os.Stderr` for eris logger.
* Handle the missing service definition files more gracefully.