### PR TITLE
cleanup the `chains` command

### DIFF
--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/eris-ltd/eris-cli/config"
 	def "github.com/eris-ltd/eris-cli/definitions"
-	//ini "github.com/eris-ltd/eris-cli/initialize"
 	"github.com/eris-ltd/eris-cli/loaders"
 	"github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/tests"
@@ -32,7 +31,6 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.DebugLevel)
 
 	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
-	//mockChainDefinitionFile(chainName)
 
 	exitCode := m.Run()
 

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -290,64 +290,6 @@ func TestInspectChain(t *testing.T) {
 	}
 }
 
-// deprecate this command
-func _TestRenameChain(t *testing.T) {
-	defer tests.RemoveAllContainers()
-
-	const (
-		chain   = "hichain"
-		rename1 = "niahctset"
-	)
-	create(t, chain)
-
-	if !util.Running(def.TypeChain, chain) {
-		t.Fatalf("expecting chain running")
-	}
-	if !util.Exists(def.TypeData, chain) {
-		t.Fatalf("expecting data container exists")
-	}
-
-	do := def.NowDo()
-	do.Name = chain
-	do.NewName = rename1
-	if err := RenameChain(do); err != nil {
-		t.Fatalf("expected chain to be renamed #1, got %v", err)
-	}
-
-	if util.Running(def.TypeChain, chain) {
-		t.Fatalf("expecting old chain running")
-	}
-	if util.Exists(def.TypeData, chain) {
-		t.Fatalf("expecting old data container exists")
-	}
-	if !util.Running(def.TypeChain, rename1) {
-		t.Fatalf("expecting renamed chain running")
-	}
-	if !util.Exists(def.TypeData, rename1) {
-		t.Fatalf("expecting renamed data container exists")
-	}
-
-	do = def.NowDo()
-	do.Name = rename1
-	do.NewName = chainName
-	if err := RenameChain(do); err != nil {
-		t.Fatalf("expected chain to be renamed #2, got %v", err)
-	}
-
-	if util.Running(def.TypeChain, rename1) {
-		t.Fatalf("expecting renamed chain not running")
-	}
-	if util.Exists(def.TypeData, rename1) {
-		t.Fatalf("expecting renamed data container doesn't exist")
-	}
-	if !util.Running(def.TypeChain, chainName) {
-		t.Fatalf("expecting renamed again chain running")
-	}
-	if !util.Exists(def.TypeData, chainName) {
-		t.Fatalf("expecting renamed again data container exists")
-	}
-}
-
 func TestRmChain(t *testing.T) {
 	defer tests.RemoveAllContainers()
 

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -273,79 +273,10 @@ func PortsChain(do *definitions.Do) error {
 	return nil
 }
 
-// XXX: What's going on here? => [csk]: magic
+// command no longer exposed
+// [todo] re-implement with state dump + restore
+// if ever desired by users
 func RenameChain(do *definitions.Do) error {
-	if do.Name == do.NewName {
-		return fmt.Errorf("Cannot rename to same name")
-	}
-
-	newNameBase := strings.Replace(do.NewName, filepath.Ext(do.NewName), "", 1)
-	transformOnly := newNameBase == do.Name
-
-	if util.IsKnownChain(do.Name) {
-		log.WithFields(log.Fields{
-			"from": do.Name,
-			"to":   do.NewName,
-		}).Info("Renaming chain")
-
-		log.WithField("=>", do.Name).Debug("Loading chain definition file")
-		chainDef, err := loaders.LoadChainDefinition(do.Name)
-		if err != nil {
-			return err
-		}
-
-		if !transformOnly {
-			log.Debug("Renaming chain container")
-			err = perform.DockerRename(chainDef.Operations, do.NewName)
-			if err != nil {
-				return err
-			}
-		}
-
-		oldFile := util.GetFileByNameAndType("chains", do.Name)
-		if err != nil {
-			return err
-		}
-
-		if filepath.Base(oldFile) == do.NewName {
-			log.Info("Those are the same file. Not renaming")
-			return nil
-		}
-
-		log.Debug("Renaming chain definition file")
-		var newFile string
-		if filepath.Ext(do.NewName) == "" {
-			newFile = strings.Replace(oldFile, do.Name, do.NewName, 1)
-		} else {
-			newFile = filepath.Join(ChainsPath, do.NewName)
-		}
-
-		chainDef.Name = newNameBase
-		// Generally we won't want to use Service.Name
-		// as it will be confused with the Name.
-		chainDef.Service.Name = ""
-		// Service.Image should be taken from the default.toml.
-		chainDef.Service.Image = ""
-		err = WriteChainDefinitionFile(chainDef, newFile)
-		if err != nil {
-			return err
-		}
-
-		if !transformOnly {
-			log.WithFields(log.Fields{
-				"from": do.Name,
-				"to":   do.NewName,
-			}).Info("Renaming chain data container")
-			err = data.RenameData(do)
-			if err != nil {
-				return err
-			}
-		}
-
-		os.Remove(oldFile)
-	} else {
-		return fmt.Errorf("I cannot find that chain. Please check the chain name you sent me.")
-	}
 	return nil
 }
 

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -384,17 +384,6 @@ func RemoveChain(do *definitions.Do) error {
 		log.Info("Chain container does not exist")
 	}
 
-	if do.File {
-		oldFile := util.GetFileByNameAndType("chains", do.Name)
-		if err != nil {
-			return err
-		}
-		log.WithField("file", oldFile).Warn("Removing file")
-		if err := os.Remove(oldFile); err != nil {
-			return err
-		}
-	}
-
 	if do.RmHF {
 		dirPath := filepath.Join(ChainsPath, do.Name) // the dir
 

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -273,13 +273,6 @@ func PortsChain(do *definitions.Do) error {
 	return nil
 }
 
-// command no longer exposed
-// [todo] re-implement with state dump + restore
-// if ever desired by users
-func RenameChain(do *definitions.Do) error {
-	return nil
-}
-
 func UpdateChain(do *definitions.Do) error {
 	chain, err := loaders.LoadChainDefinition(do.Name)
 	if err != nil {

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -233,7 +233,7 @@ func CatChain(do *definitions.Do) error {
 	case "validators":
 		do.Operations.Args = []string{"mintinfo", "--node-addr", "http://chain:46657", "validators"}
 	case "toml":
-		cat, err := ioutil.ReadFile(filepath.Join(ChainsPath, do.Name+".toml"))
+		cat, err := ioutil.ReadFile(filepath.Join(ChainsPath, do.Name, do.Name+".toml"))
 		if err != nil {
 			return err
 		}

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -273,20 +273,6 @@ func PortsChain(do *definitions.Do) error {
 	return nil
 }
 
-// EditChain is an easy way to edit a chain definition file
-// it uses eris-ltd/common/go/common/dirs_and_files.go 's editor
-// function to determine the editor for the current shell and
-// to utilize that (or VIM by default) (sorry emacs folks).
-//
-//  do.Name - name of the chain to edit its chain definition files (required)
-//
-func EditChain(do *definitions.Do) error {
-	chainDefFile := util.GetFileByNameAndType("chains", do.Name)
-	log.WithField("file", chainDefFile).Info("Editing chain definition")
-	do.Result = "success"
-	return Editor(chainDefFile)
-}
-
 // XXX: What's going on here? => [csk]: magic
 func RenameChain(do *definitions.Do) error {
 	if do.Name == do.NewName {

--- a/chains/operate.go
+++ b/chains/operate.go
@@ -36,7 +36,7 @@ func NewChain(do *definitions.Do) error {
 	// for now we just let setupChain force do.ChainID = do.Name
 	// and we overwrite using jq in the container
 	log.WithField("=>", do.Name).Debug("Setting up chain")
-	return setupChain(do, loaders.ErisChainNew)
+	return setupChain(do, "new") // move away from loaders
 }
 
 func InstallChain(do *definitions.Do) error {
@@ -319,7 +319,8 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 	}
 
 	// Write the chain definition file.
-	fileName := filepath.Join(ChainsPath, do.Name) + ".toml"
+	// write in chains/chainName dir!
+	fileName := filepath.Join(ChainsPath, do.Name, do.Name) + ".toml"
 	if _, err = os.Stat(fileName); err != nil {
 		if err = WriteChainDefinitionFile(chain, fileName); err != nil {
 			return fmt.Errorf("error writing chain definition to file: %v", err)
@@ -335,6 +336,7 @@ func setupChain(do *definitions.Do, cmd string) (err error) {
 	chain.Operations.Ports = do.Operations.Ports
 
 	// Cmd should be "new" or "install".
+	// [zr] install is basically deprecated. Can remove L20-26 in loaders/chains.go
 	chain.Service.Command = cmd
 
 	// Write the list of <key>:<value> config options as flags.

--- a/chains/writers.go
+++ b/chains/writers.go
@@ -30,7 +30,7 @@ func WriteChainDefinitionFile(chainDef *def.Chain, fileName string) error {
 	writer, err := os.Create(fileName)
 	defer writer.Close()
 	if err != nil {
-		return fmt.Errorf("wtf: %v", err)
+		return err
 	}
 
 	switch filepath.Ext(fileName) {

--- a/chains/writers.go
+++ b/chains/writers.go
@@ -30,7 +30,7 @@ func WriteChainDefinitionFile(chainDef *def.Chain, fileName string) error {
 	writer, err := os.Create(fileName)
 	defer writer.Close()
 	if err != nil {
-		return err
+		return fmt.Errorf("wtf: %v", err)
 	}
 
 	switch filepath.Ext(fileName) {

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -105,7 +105,6 @@ func TestCleanLatentChainDatas(t *testing.T) {
 func testCheckChainDirsExist(chains []string, yes bool, t *testing.T) {
 	if yes { // fail if dirs/files don't exist
 		for _, chn := range chains {
-			// this should be !util.DoesDirExist() but that fails ... ?
 			if !util.DoesDirExist(filepath.Join(common.ChainsPath, chn)) {
 				t.Fatalf("chain directory does not exist when it should")
 			}

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -106,7 +106,7 @@ func testCheckChainDirsExist(chains []string, yes bool, t *testing.T) {
 	if yes { // fail if dirs/files don't exist
 		for _, chn := range chains {
 			// this should be !util.DoesDirExist() but that fails ... ?
-			if util.DoesDirExist(filepath.Join(common.ChainsPath, chn)) {
+			if !util.DoesDirExist(filepath.Join(common.ChainsPath, chn)) {
 				t.Fatalf("chain directory does not exist when it should")
 			}
 			_, err := loaders.LoadChainDefinition(chn) // list.Known only Prints to stdout
@@ -212,8 +212,16 @@ func testStartService(serviceName string, t *testing.T) {
 }
 
 func testStartChain(chainName string, t *testing.T) {
+	doMake := definitions.NowDo()
+	doMake.Name = chainName
+	doMake.ChainType = "simplechain"
+	if err := chains.MakeChain(doMake); err != nil {
+		t.Fatalf("expected a chain to be made, got %v", err)
+	}
+
 	do := definitions.NowDo()
 	do.Name = chainName
+	do.ConfigFile = filepath.Join(common.ChainsPath, "default", "config.toml")
 	do.Operations.PublishAllPorts = true
 	if err := chains.NewChain(do); err != nil {
 		t.Fatalf("starting chain %v failed: %v", chainName, err)

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -369,7 +369,6 @@ func addChainsFlags() {
 	chainsExec.Flags().StringVarP(&do.Image, "image", "", "", "docker image")
 
 	buildFlag(chainsRemove, do, "force", "chain")
-	buildFlag(chainsRemove, do, "file", "chain")
 	buildFlag(chainsRemove, do, "data", "chain")
 	buildFlag(chainsRemove, do, "rm-volumes", "chain")
 	chainsRemove.Flags().BoolVarP(&do.RmHF, "dir", "", false, "remove the chain directory in ~/.eris/chains")

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -49,7 +49,7 @@ func buildChainsCommand() {
 	Chains.AddCommand(chainsStop)
 	Chains.AddCommand(chainsExec)
 	Chains.AddCommand(chainsCat)
-	Chains.AddCommand(chainsRename)
+	//Chains.AddCommand(chainsRename)
 	Chains.AddCommand(chainsUpdate)
 	Chains.AddCommand(chainsRestart)
 	Chains.AddCommand(chainsRemove)
@@ -279,10 +279,11 @@ $ eris chains inspect 2gather host_config.binds -- will display only that value`
 	Run: InspectChain,
 }
 
+// not currently used
 var chainsRename = &cobra.Command{
 	Use:   "rename OLD_NAME NEW_NAME",
-	Short: "rename a blockchain",
-	Long:  `rename a blockchain`,
+	Short: "rename a chain",
+	Long:  `rename a chain`,
 	Run:   RenameChain,
 }
 
@@ -540,6 +541,7 @@ func ListChains(cmd *cobra.Command, args []string) {
 	IfExit(list.Containers(def.TypeChain, do.Format, do.Running))
 }
 
+// not currently used
 func RenameChain(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(2, "eq", cmd, args))
 	do.Name = args[0]

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -49,7 +49,6 @@ func buildChainsCommand() {
 	Chains.AddCommand(chainsStop)
 	Chains.AddCommand(chainsExec)
 	Chains.AddCommand(chainsCat)
-	//Chains.AddCommand(chainsRename)
 	Chains.AddCommand(chainsUpdate)
 	Chains.AddCommand(chainsRestart)
 	Chains.AddCommand(chainsRemove)
@@ -277,14 +276,6 @@ see: https://github.com/fsouza/go-dockerclient/blob/master/container.go#L235`,
 $ eris chains inspect 2gather name -- will display the name in machine readable format
 $ eris chains inspect 2gather host_config.binds -- will display only that value`,
 	Run: InspectChain,
-}
-
-// not currently used
-var chainsRename = &cobra.Command{
-	Use:   "rename OLD_NAME NEW_NAME",
-	Short: "rename a chain",
-	Long:  `rename a chain`,
-	Run:   RenameChain,
 }
 
 var chainsRemove = &cobra.Command{
@@ -539,14 +530,6 @@ func ListChains(cmd *cobra.Command, args []string) {
 		do.Format = "json"
 	}
 	IfExit(list.Containers(def.TypeChain, do.Format, do.Running))
-}
-
-// not currently used
-func RenameChain(cmd *cobra.Command, args []string) {
-	IfExit(ArgCheck(2, "eq", cmd, args))
-	do.Name = args[0]
-	do.NewName = args[1]
-	IfExit(chns.RenameChain(do))
 }
 
 func UpdateChain(cmd *cobra.Command, args []string) {

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -174,15 +174,7 @@ The -q flag is equivalent to the '{{.ShortName}}' format.
 
 The -f flag specifies an alternate format for the list, using the syntax
 of Go text templates. See the more detailed description in the help
-output for the [eris ls] command. The struct passed to the Go template
-for the -k flag is this
-
-  type Definition struct {
-    Name       string       // chain name
-    Definition string       // definition file name
-  }
-
-The -k flag displays the known definition files. `,
+output for the [eris ls] command.`,
 
 	Run: ListChains,
 	Example: `$ eris chains ls -f '{{.ShortName}}\t{{.Info.Config.Image}}\t{{ports .Info}}'
@@ -407,7 +399,6 @@ func addChainsFlags() {
 	buildFlag(chainsStop, do, "timeout", "chain")
 	buildFlag(chainsStop, do, "volumes", "chain")
 
-	buildFlag(chainsList, do, "known", "chain")
 	chainsList.Flags().BoolVarP(&do.JSON, "json", "", false, "machine readable output")
 	chainsList.Flags().BoolVarP(&do.All, "all", "a", false, "show extended output")
 	chainsList.Flags().BoolVarP(&do.Quiet, "quiet", "q", false, "show a list of chain names")
@@ -573,11 +564,7 @@ func ListChains(cmd *cobra.Command, args []string) {
 	if do.JSON {
 		do.Format = "json"
 	}
-	if do.Known {
-		IfExit(list.Known("chains", do.Format))
-	} else {
-		IfExit(list.Containers(def.TypeChain, do.Format, do.Running))
-	}
+	IfExit(list.Containers(def.TypeChain, do.Format, do.Running))
 }
 
 func RenameChain(cmd *cobra.Command, args []string) {

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -43,7 +43,6 @@ func buildChainsCommand() {
 	Chains.AddCommand(chainsCheckout)
 	Chains.AddCommand(chainsHead)
 	Chains.AddCommand(chainsPorts)
-	Chains.AddCommand(chainsEdit)
 	Chains.AddCommand(chainsStart)
 	Chains.AddCommand(chainsLogs)
 	Chains.AddCommand(chainsInspect)
@@ -225,19 +224,6 @@ To checkout a new chain use [eris chains checkout NAME].
 
 To "uncheckout" a chain use [eris chains checkout] without arguments.`,
 	Run: CurrentChain,
-}
-
-var chainsEdit = &cobra.Command{
-	Use:   "edit NAME",
-	Short: "edit a blockchain",
-	Long: `edit a blockchain definition file
-
-Edit will utilize the default editor set for your current shell
-or if none is set, it will use *vim*. Sorry for the bias Emacs
-users, but we had to pick one and more marmots are known vim
-users. Emacs users can set their EDITOR variable and eris
-will default to that if you wise.`,
-	Run: EditChain,
 }
 
 var chainsStart = &cobra.Command{
@@ -526,18 +512,6 @@ func PortsChain(cmd *cobra.Command, args []string) {
 	do.Name = args[0]
 	do.Operations.Args = args[1:]
 	IfExit(chns.PortsChain(do))
-}
-
-func EditChain(cmd *cobra.Command, args []string) {
-	// [csk]: if no args should we just start the checkedout chain?
-	IfExit(ArgCheck(1, "ge", cmd, args))
-	var configVals []string
-	if len(args) > 1 {
-		configVals = args[1:]
-	}
-	do.Name = args[0]
-	do.Operations.Args = configVals
-	IfExit(chns.EditChain(do))
 }
 
 func InspectChain(cmd *cobra.Command, args []string) {

--- a/list/definitions.go
+++ b/list/definitions.go
@@ -24,8 +24,8 @@ type Definition struct {
 	Definition string
 }
 
-// Known list definition files for a given type t ("chains", "services",
-// or "actions") from the Eris root directory in one of the 3 formats,
+// Known list definition files for a given type t ("services",
+// or "actions") from the Eris root directory in one of the 2 formats,
 // specified by the format parameter. Default is `ls(1)` multicolumn format,
 // `json` dumps the JSON document onto the console. A custom format can
 // be specified using the `text/template` Go package syntax, e.g.:

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -38,7 +38,8 @@ func LoadChainDefinition(chainName string) (*definitions.Chain, error) {
 		return nil, err
 	}
 
-	definition, err := config.LoadViperConfig(filepath.Join(common.ChainsPath), chainName)
+	//definition, err := config.LoadViperConfig(filepath.Join(common.ChainsPath), chainName)
+	definition, err := config.LoadViperConfig(filepath.Join(common.ChainsPath, chainName), chainName)
 	if err != nil {
 		return nil, err
 	}

--- a/loaders/loaders_test.go
+++ b/loaders/loaders_test.go
@@ -55,7 +55,7 @@ ports          = [ "1234" ]
 	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", ``); err != nil {
 		t.Fatalf("cannot place a default definition file")
 	}
-	if err := tests.FakeDefinitionFile(common.ChainsPath, name, definition); err != nil {
+	if err := tests.FakeDefinitionFile(filepath.Join(common.ChainsPath, name), name, definition); err != nil {
 		t.Fatalf("cannot place a definition file")
 	}
 
@@ -113,7 +113,7 @@ email = "support@erisindustries.com"
 	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", defaultDefinition); err != nil {
 		t.Fatalf("cannot place a default definition file")
 	}
-	if err := tests.FakeDefinitionFile(common.ChainsPath, name, ``); err != nil {
+	if err := tests.FakeDefinitionFile(filepath.Join(common.ChainsPath, name), name, ``); err != nil {
 		t.Fatalf("cannot place a definition file")
 	}
 
@@ -155,7 +155,7 @@ func TestLoadChainDefinitionEmptyDefaultAndDefinition(t *testing.T) {
 	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", ``); err != nil {
 		t.Fatalf("cannot place a default definition file")
 	}
-	if err := tests.FakeDefinitionFile(common.ChainsPath, name, ``); err != nil {
+	if err := tests.FakeDefinitionFile(filepath.Join(common.ChainsPath, name), name, ``); err != nil {
 		t.Fatalf("cannot place a definition file")
 	}
 
@@ -218,7 +218,7 @@ ports          = [ "4321" ]
 	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", defaultDefinition); err != nil {
 		t.Fatalf("cannot place a default definition file")
 	}
-	if err := tests.FakeDefinitionFile(common.ChainsPath, name, definition); err != nil {
+	if err := tests.FakeDefinitionFile(filepath.Join(common.ChainsPath, name), name, definition); err != nil {
 		t.Fatalf("cannot place a definition file")
 	}
 
@@ -292,7 +292,7 @@ func TestLoadChainDefinitionMissingDefinition(t *testing.T) {
 		name = "test"
 	)
 
-	os.Remove(filepath.Join(common.ChainsPath, name+".toml"))
+	os.Remove(filepath.Join(common.ChainsPath, name, name+".toml"))
 
 	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", ``); err != nil {
 		t.Fatalf("cannot place a default definition file")
@@ -342,7 +342,7 @@ image          = "test image"
 	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", ``); err != nil {
 		t.Fatalf("cannot place a default definition file")
 	}
-	if err := tests.FakeDefinitionFile(common.ChainsPath, name, definition); err != nil {
+	if err := tests.FakeDefinitionFile(filepath.Join(common.ChainsPath, name), name, definition); err != nil {
 		t.Fatalf("cannot place a definition file")
 	}
 
@@ -378,7 +378,7 @@ func TestChainsAsAServiceMissing(t *testing.T) {
 		name = "test"
 	)
 
-	os.Remove(filepath.Join(common.ChainsPath, name+".toml"))
+	os.Remove(filepath.Join(common.ChainsPath, name, name+".toml"))
 
 	if err := tests.FakeDefinitionFile(common.ChainsPath, "default", ``); err != nil {
 		t.Fatalf("cannot place a default definition file")


### PR DESCRIPTION
- closes #878 and #882, reducing cognitive overhead of flag/command bloat
- the chain definition file is dropped at `~/.eris/chains/chainName/chainName.toml` and is more or less abstracted from the user. Arguably, it should be removed entirely as it longer really serves a purpose.
- prepares for/unblocks progress on #651 
- refactors chains & pkgs tests for cleaner separation
- amends loaders tests for changes in chain definitions file handling

**Deprecation Notices:**
- the `eris chains edit` command is removed completely
- the `eris chains rename` command is removed completely
- the `--file` flag for `eris chains rm` is removed
- the `--known` flag for `eris chains ls` is removed
