### PR TITLE
chains tests: add -timeout

### DIFF
--- a/tests/test_tool.sh
+++ b/tests/test_tool.sh
@@ -135,7 +135,7 @@ packagesToTest() {
     if [ $? -ne 0 ]; then return 1; fi
     go test ./services/... && passed Services
     if [ $? -ne 0 ]; then return 1; fi
-    go test ./chains/... && passed Chains
+    go test -timeout=900s ./chains/... && passed Chains
     if [ $? -ne 0 ]; then return 1; fi
     go test ./keys/... && passed Keys
     if [ $? -ne 0 ]; then return 1; fi


### PR DESCRIPTION
- added temporarily because of #884 and the chains test refactor which, as a by-product of cleaner separation, runs twice as long => `chains.MakeChain` is called for every test.
- this will be fixed by #892
