### PR TITLE
keys: sort import/export

### DIFF
--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"path/filepath"
 	"strings"
 
 	"github.com/eris-ltd/eris-cli/keys"
@@ -9,8 +8,6 @@ import (
 	. "github.com/eris-ltd/common/go/common"
 	"github.com/spf13/cobra"
 )
-
-var DefKeysPathHost = filepath.Join(KeysPath, "data")
 
 var Keys = &cobra.Command{
 	Use:   "keys",
@@ -103,11 +100,9 @@ Latter flag is equivalent to:
 }
 
 func addKeysFlags() {
-	keysExport.Flags().StringVarP(&do.Destination, "dest", "", DefKeysPathHost, "destination for export on host")
 	keysExport.Flags().StringVarP(&do.Address, "addr", "", "", "address of key to export")
 	keysExport.Flags().BoolVarP(&do.All, "all", "", false, "export all keys. do not provide any arguments")
 
-	keysImport.Flags().StringVarP(&do.Source, "src", "", DefKeysPathHost, "source on host to import from")
 	keysImport.Flags().StringVarP(&do.Address, "addr", "", "", "address of key to import")
 	keysImport.Flags().BoolVarP(&do.All, "all", "", false, "import all keys. do not provide any arguments")
 

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -202,7 +202,6 @@ func TestImportKeySingle(t *testing.T) {
 	//export it
 	doExp := def.NowDo()
 	doExp.Address = address
-	doExp.Destination = filepath.Join(KeysPath, "data") //is default set by flag
 
 	if err := ExportKey(doExp); err != nil {
 		t.Fatalf("error exporting key: %v", err)
@@ -224,8 +223,6 @@ func TestImportKeySingle(t *testing.T) {
 
 	doImp := def.NowDo()
 	doImp.Address = address
-	//doImp.Destination // set in function
-	doImp.Source = filepath.Join(KeysPath, "data")
 
 	if err := ImportKey(doImp); err != nil {
 		t.Fatalf("error importing key: %v", err)
@@ -284,14 +281,8 @@ func TestListKeyHost(t *testing.T) {
 	addrs[addr1] = true
 
 	doExp := def.NowDo()
-	doExp.Address = addr0
-	doExp.Destination = filepath.Join(KeysPath, "data") //is default
+	doExp.All = true
 
-	if err := ExportKey(doExp); err != nil {
-		t.Fatalf("error exporting key: %v", err)
-	}
-
-	doExp.Address = addr1
 	if err := ExportKey(doExp); err != nil {
 		t.Fatalf("error exporting key: %v", err)
 	}

--- a/keys/writers.go
+++ b/keys/writers.go
@@ -53,7 +53,6 @@ func ExportKey(do *definitions.Do) error {
 		return err
 	}
 
-	do.Destination = common.KeysDataPath
 	if do.All && do.Address == "" {
 		doLs := definitions.NowDo()
 		doLs.Container = true
@@ -65,13 +64,15 @@ func ExportKey(do *definitions.Do) error {
 		keyArray := strings.Split(do.Result, ",")
 
 		for _, addr := range keyArray {
-			do.Source = path.Join(common.ErisContainerRoot, "keys", "data", addr)
+			do.Destination = common.KeysPath
+			do.Source = path.Join(common.KeysContainerPath, addr)
 			if err := data.ExportData(do); err != nil {
 				return err
 			}
 		}
 	} else {
-		do.Source = path.Join(common.ErisContainerRoot, "keys", "data", do.Address)
+		do.Destination = common.KeysDataPath
+		do.Source = path.Join(common.KeysContainerPath, do.Address)
 		if err := data.ExportData(do); err != nil {
 			return err
 		}
@@ -85,7 +86,6 @@ func ImportKey(do *definitions.Do) error {
 		return err
 	}
 
-	do.Destination = path.Join(common.KeysContainerPath, do.Address)
 	if do.All && do.Address == "" {
 		doLs := definitions.NowDo()
 		doLs.Container = false
@@ -97,14 +97,15 @@ func ImportKey(do *definitions.Do) error {
 		keyArray := strings.Split(do.Result, ",")
 
 		for _, addr := range keyArray {
-			do.Source = filepath.Join(common.KeysPath, "data", addr)
-			do.Destination = path.Join(common.ErisContainerRoot, "keys", "data", addr)
+			do.Source = filepath.Join(common.KeysDataPath, addr)
+			do.Destination = path.Join(common.KeysContainerPath, addr)
 			if err := data.ImportData(do); err != nil {
 				return err
 			}
 		}
 	} else {
 		do.Source = filepath.Join(common.KeysDataPath, do.Address)
+		do.Destination = path.Join(common.KeysContainerPath, do.Address)
 		if err := data.ImportData(do); err != nil {
 			return err
 		}

--- a/keys/writers.go
+++ b/keys/writers.go
@@ -2,7 +2,6 @@ package keys
 
 import (
 	"io"
-	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -54,7 +53,7 @@ func ExportKey(do *definitions.Do) error {
 		return err
 	}
 
-	// do.Destination = given by flag default or overriden
+	do.Destination = common.KeysDataPath
 	if do.All && do.Address == "" {
 		doLs := definitions.NowDo()
 		doLs.Container = true
@@ -66,7 +65,6 @@ func ExportKey(do *definitions.Do) error {
 		keyArray := strings.Split(do.Result, ",")
 
 		for _, addr := range keyArray {
-			do.Destination = common.KeysPath
 			do.Source = path.Join(common.ErisContainerRoot, "keys", "data", addr)
 			if err := data.ExportData(do); err != nil {
 				return err
@@ -87,11 +85,7 @@ func ImportKey(do *definitions.Do) error {
 		return err
 	}
 
-	//src on host
-	//if default given (from flag), join addrs
-	//dest in container
-	do.Destination = path.Join(common.ErisContainerRoot, "keys", "data", do.Address)
-
+	do.Destination = path.Join(common.KeysContainerPath, do.Address)
 	if do.All && do.Address == "" {
 		doLs := definitions.NowDo()
 		doLs.Container = false
@@ -109,19 +103,8 @@ func ImportKey(do *definitions.Do) error {
 				return err
 			}
 		}
-		//list keys
-		//for each, import data
-
 	} else {
-		if do.Source == filepath.Join(common.KeysPath, "data") {
-			do.Source = filepath.Join(common.KeysPath, "data", do.Address, do.Address)
-		} else { // either relative or absolute path given. get absolute
-			wd, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-			do.Source = common.AbsolutePath(wd, do.Source)
-		}
+		do.Source = filepath.Join(common.KeysDataPath, do.Address)
 		if err := data.ImportData(do); err != nil {
 			return err
 		}

--- a/vendor/github.com/eris-ltd/common/go/common/dirs_and_files.go
+++ b/vendor/github.com/eris-ltd/common/go/common/dirs_and_files.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -35,8 +36,9 @@ var (
 	ChainTypePath    = filepath.Join(ChainsPath, "chain-types")
 
 	// Keys Directories
-	KeysDataPath = filepath.Join(KeysPath, "data")
-	KeyNamesPath = filepath.Join(KeysPath, "names")
+	KeysDataPath      = filepath.Join(KeysPath, "data")
+	KeysNamesPath     = filepath.Join(KeysPath, "names")
+	KeysContainerPath = path.Join(ErisContainerRoot, "keys", "data")
 
 	// Scratch Directories (basically eris' cache) (globally coordinated)
 	DataContainersPath   = filepath.Join(ScratchPath, "data")
@@ -64,7 +66,7 @@ var MajorDirs = []string{
 	ChainTypePath,
 	KeysPath,
 	KeysDataPath,
-	KeyNamesPath,
+	KeysNamesPath,
 	RemotesPath,
 	ScratchPath,
 	DataContainersPath,
@@ -88,7 +90,7 @@ var ChainsDirs = []string{
 var KeysDirs = []string{
 	KeysPath,
 	KeysDataPath,
-	KeyNamesPath,
+	KeysNamesPath,
 }
 
 // ServicesDirs to be used by specific tooling rather than eris-cli level.

--- a/vendor/github.com/eris-ltd/common/go/common/dirs_and_files.go
+++ b/vendor/github.com/eris-ltd/common/go/common/dirs_and_files.go
@@ -154,7 +154,7 @@ func ChangeErisRoot(erisDir string) {
 
 	// Keys Directories
 	KeysDataPath = filepath.Join(KeysPath, "data")
-	KeyNamesPath = filepath.Join(KeysPath, "names")
+	KeysNamesPath = filepath.Join(KeysPath, "names")
 
 	// Scratch Directories (basically eris' cache) (globally coordinated)
 	DataContainersPath = filepath.Join(ScratchPath, "data")


### PR DESCRIPTION
- fixes `eris keys import ADDR` which was not working
- closes #697 