### PR TITLE
Cm image respect

### DIFF
--- a/chains/manage.go
+++ b/chains/manage.go
@@ -16,7 +16,7 @@ import (
 	"github.com/eris-ltd/eris-cli/perform"
 	"github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/util"
-	"github.com/eris-ltd/eris-cli/version"
+	// "github.com/eris-ltd/eris-cli/version"
 
 	. "github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/common/go/ipfs"
@@ -45,7 +45,7 @@ func MakeChain(do *definitions.Do) error {
 	}
 
 	do.Service.Name = do.Name
-	do.Service.Image = path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_CM)
+	do.Service.Image = path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_CM)
 	do.Service.User = "eris"
 	do.Service.AutoData = true
 	do.Service.Links = []string{fmt.Sprintf("%s:%s", util.ServiceContainerName("keys"), "keys")}

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -8,7 +8,7 @@ import (
 	"github.com/eris-ltd/eris-cli/config"
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/util"
-	"github.com/eris-ltd/eris-cli/version"
+	// "github.com/eris-ltd/eris-cli/version"
 
 	"github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-logger"
@@ -75,7 +75,7 @@ func ChainsAsAService(chainName string) (*definitions.ServiceDefinition, error) 
 
 	setChainDefaults(chain)
 	chain.Service.Name = chain.Name
-	chain.Service.Image = path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_DB)
+	chain.Service.Image = path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_DB)
 	chain.Service.AutoData = true
 	chain.Service.Command = ErisChainStart
 

--- a/pkgs/operate.go
+++ b/pkgs/operate.go
@@ -18,7 +18,7 @@ import (
 	"github.com/eris-ltd/eris-cli/perform"
 	"github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/util"
-	"github.com/eris-ltd/eris-cli/version"
+	// "github.com/eris-ltd/eris-cli/version"
 
 	"github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-logger"
@@ -155,7 +155,7 @@ func BootServicesAndChain(do *definitions.Do, pkg *definitions.Package) error {
 //
 func DefinePkgActionService(do *definitions.Do, pkg *definitions.Package) error {
 	do.Service.Name = pkg.Name + "_tmp_" + do.Name
-	do.Service.Image = path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_PM)
+	do.Service.Image = path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_PM)
 	do.Service.AutoData = true
 	do.Service.EntryPoint = fmt.Sprintf("epm --chain chain:%s --sign keys:%s", do.ChainPort, do.KeysPort)
 	do.Service.WorkDir = path.Join(common.ErisContainerRoot, "apps", filepath.Base(do.Path))


### PR DESCRIPTION
changes the usage of images so that what is populated in eris.toml is respected for pm and cm (also defaults on chains, which are currently overwritten by default.toml in ~/.eris/chains, but @zramsay is fixing that)