### PR TITLE
Implements one click eris startup and shutdown of services (Issue #766)

### DIFF
--- a/cmd/eris.go
+++ b/cmd/eris.go
@@ -144,6 +144,8 @@ func AddCommands() {
 	ErisCmd.AddCommand(Update)
 	buildVerSionCommand()
 	ErisCmd.AddCommand(VerSion)
+	buildStartCommand()
+	ErisCmd.AddCommand(Start)
 
 	if runtime.GOOS != "windows" {
 		buildManCommand()

--- a/cmd/eris.go
+++ b/cmd/eris.go
@@ -146,6 +146,8 @@ func AddCommands() {
 	ErisCmd.AddCommand(VerSion)
 	buildStartCommand()
 	ErisCmd.AddCommand(Start)
+	buildStartCommand()
+	ErisCmd.AddCommand(Stop)
 
 	if runtime.GOOS != "windows" {
 		buildManCommand()

--- a/cmd/eris.go
+++ b/cmd/eris.go
@@ -146,7 +146,7 @@ func AddCommands() {
 	ErisCmd.AddCommand(VerSion)
 	buildStartCommand()
 	ErisCmd.AddCommand(Start)
-	buildStartCommand()
+	buildStopCommand()
 	ErisCmd.AddCommand(Stop)
 
 	if runtime.GOOS != "windows" {

--- a/cmd/start_stop.go
+++ b/cmd/start_stop.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	//"github.com/eris-ltd/eris-cli/definitions"
+	"github.com/eris-ltd/eris-cli/kaihei"
+
+	"github.com/spf13/cobra"
+
+	. "github.com/eris-ltd/common/go/common"
+)
+
+var Start = &cobra.Command{}
+
+var Stop = &cobra.Command{}
+
+func buildStartCommand() {
+	addStartFlags()
+}
+
+func addStartFlags() {
+}
+
+func buildStopCommand() {
+	addStopFlags()
+}
+
+func addStopFlags() {
+}
+
+func StartEris(cmd *cobra.Command, args []string) {
+	IfExit(kaihei.StartUpEris(do))
+}
+
+func StopEris(cmd *cobra.Command, args []string) {
+	IfExit(kaihei.ShutUpEris(do))
+}

--- a/cmd/start_stop.go
+++ b/cmd/start_stop.go
@@ -9,9 +9,31 @@ import (
 	. "github.com/eris-ltd/common/go/common"
 )
 
-var Start = &cobra.Command{}
+var Start = &cobra.Command{
+	Use:   "startup",
+	Short: "start up your Eris dev environment for the day",
+	Long: `start up your Eris dev environment for the day
 
-var Stop = &cobra.Command{}
+The startup command starts the services for which you have started
+in the past. The startup command also requires a '--chain' 
+flag that specifies the chain you would like to start with the
+services.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		StartEris(cmd, args)
+	},
+}
+
+var Stop = &cobra.Command{	
+	Use:   "shutdown",
+	Short: "shutdown your Eris dev environment for the day",
+	Long: `shutdown your Eris dev environment for the day
+
+The shutdown command finds all of the services and chains that 
+are currently running and shuts them down for the day. In effect,
+this command wraps:
+[eris services stop $(eris services ls -q)] and
+[eris chains stop $(eris chains ls -q)]`,
+}
 
 func buildStartCommand() {
 	addStartFlags()

--- a/cmd/start_stop.go
+++ b/cmd/start_stop.go
@@ -15,12 +15,10 @@ var Start = &cobra.Command{
 	Long: `start up your Eris dev environment for the day
 
 The startup command starts the services for which you have started
-in the past. The startup command also requires a '--chain' 
-flag that specifies the chain you would like to start with the
-services.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		StartEris(cmd, args)
-	},
+in the past. The startup command also gives you the option to 
+specify a '--chain' flag that specifies the chain you would 
+like to start with the services.`,
+	Run: StartEris,
 }
 
 var Stop = &cobra.Command{	
@@ -33,6 +31,7 @@ are currently running and shuts them down for the day. In effect,
 this command wraps:
 [eris services stop $(eris services ls -q)] and
 [eris chains stop $(eris chains ls -q)]`,
+	Run: StopEris,
 }
 
 func buildStartCommand() {
@@ -40,6 +39,7 @@ func buildStartCommand() {
 }
 
 func addStartFlags() {
+	Start.PersistentFlags().StringVarP(&do.ChainName, "chain", "c", "", "specify a chain to start")
 }
 
 func buildStopCommand() {

--- a/definitions/chains.go
+++ b/definitions/chains.go
@@ -7,6 +7,7 @@ type Chain struct {
 	ChainID string `mapstructure:"chain_id" json:"chain_id" yaml:"chain_id" toml:"chain_id"`
 	// type of the chain
 	ChainType string `mapstructure:"chain_type" json:"chain_type" yaml:"chain_type" toml:"chain_type"`
+	Chain string `json:"chain,omitempty" yaml:"chain,omitempty" toml:"chain,omitempty"`
 
 	// same fields as in the Service Struct/Service Specification
 	Service      *Service      `json:"service,omitempty" yaml:"service,omitempty" toml:"service,omitempty"`

--- a/kaihei/start.go
+++ b/kaihei/start.go
@@ -3,16 +3,33 @@ package kaihei
 import (
 	"fmt"
 
+//	"github.com/eris-ltd/eris-cli/chains"
+	"github.com/eris-ltd/eris-cli/util"
+	"github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/definitions"
 )
 
 func StartUpEris(do *definitions.Do) error {
-	// list of services
-	// list of chains
-	fmt.Println("todo: start:")
 
 	// start services
+	listofServices := util.ErisContainersByType(definitions.TypeService, true)
+	names := make([]string, len(listofServices))
+	for i, serviceName := range listofServices {
+		names[i] = serviceName.ShortName
+	}
+
+	fmt.Println(names)
+
+	doStart := definitions.NowDo()
+	doStart.ServicesSlice = names
+	if err := services.StartService(doStart); err != nil {
+		return err
+	}	
 	// start chains
+	// 	IfExit(ArgCheck(1, "ge", cmd, args))
+	// do.Name = args[0]
+	// do.Run = true
+	// IfExit(chns.StartChain(do))
 	return nil
 }
 

--- a/kaihei/start.go
+++ b/kaihei/start.go
@@ -1,0 +1,22 @@
+package kaihei
+
+import (
+	"fmt"
+
+	"github.com/eris-ltd/eris-cli/definitions"
+)
+
+func StartUpEris(do *definitions.Do) error {
+	// list of services
+	// list of chains
+	fmt.Println("todo: start:")
+
+	// start services
+	// start chains
+	return nil
+}
+
+func ShutUpEris(do *definitions.Do) error {
+	fmt.Println("todo: stop:")
+	return nil
+}

--- a/kaihei/start.go
+++ b/kaihei/start.go
@@ -3,18 +3,25 @@ package kaihei
 import (
 	"fmt"
 
-//	"github.com/eris-ltd/eris-cli/chains"
+	"github.com/eris-ltd/eris-cli/chains"
 	"github.com/eris-ltd/eris-cli/util"
-	"github.com/eris-ltd/eris-cli/services"
+	srv "github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/definitions"
 )
 
 func StartUpEris(do *definitions.Do) error {
 
+	fmt.Println("starting up your services...")
+
 	// start services
-	listofServices := util.ErisContainersByType(definitions.TypeService, true)
-	names := make([]string, len(listofServices))
-	for i, serviceName := range listofServices {
+	listOfServices := util.ErisContainersByType(definitions.TypeService, false)
+
+	if len(listOfServices) == 0 {
+		return fmt.Errorf("no existing services to start")
+	}
+
+	names := make([]string, len(listOfServices))
+	for i, serviceName := range listOfServices {
 		names[i] = serviceName.ShortName
 	}
 
@@ -22,18 +29,54 @@ func StartUpEris(do *definitions.Do) error {
 
 	doStart := definitions.NowDo()
 	doStart.ServicesSlice = names
-	if err := services.StartService(doStart); err != nil {
+	if err := srv.StartService(doStart); err != nil {
 		return err
-	}	
+	}
+	
 	// start chains
-	// 	IfExit(ArgCheck(1, "ge", cmd, args))
-	// do.Name = args[0]
-	// do.Run = true
-	// IfExit(chns.StartChain(do))
+	// do.Name    - name of the chain (required)
+
+	doChain := definitions.NowDo()
+	doChain.Name = do.ChainName
+
+	if doChain == nil {
+		return nil
+	}
+
+	fmt.Println("starting up your chain...")
+	if err := chains.StartChain(doChain); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func ShutUpEris(do *definitions.Do) error {
-	fmt.Println("todo: stop:")
+
+	fmt.Println("shutting down your services...")
+
+	// start services
+	listOfServices := util.ErisContainersByType(definitions.TypeService, false)
+
+	if len(listOfServices) == 0 {
+		return fmt.Errorf("no existing services to stop")
+	}
+
+	names := make([]string, len(listOfServices))
+	for i, serviceName := range listOfServices {
+		names[i] = serviceName.ShortName
+	}
+
+	fmt.Println(names)
+
+	doStop := definitions.NowDo()
+	doStop.Operations.Args = names
+	doStop.Timeout = 10
+	if err := srv.KillService(doStop); err != nil {
+		return err
+	}
+
+	// shutdown all chains
+
 	return nil
 }

--- a/kaihei/start.go
+++ b/kaihei/start.go
@@ -32,22 +32,19 @@ func StartUpEris(do *definitions.Do) error {
 	if err := srv.StartService(doStart); err != nil {
 		return err
 	}
+
+	// start chain
+	// doChain.Name    - name of the chain (optional)
+	if do.ChainName != ""{
+		doChain := definitions.NowDo()
+		doChain.Name = do.ChainName
+
+		fmt.Println("starting up your chain...")
+		if err := chains.StartChain(doChain); err != nil {
+			return err
+		}
+	}
 	
-	// start chains
-	// do.Name    - name of the chain (required)
-
-	doChain := definitions.NowDo()
-	doChain.Name = do.ChainName
-
-	if doChain == nil {
-		return nil
-	}
-
-	fmt.Println("starting up your chain...")
-	if err := chains.StartChain(doChain); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -77,6 +74,26 @@ func ShutUpEris(do *definitions.Do) error {
 	}
 
 	// shutdown all chains
+	listOfChains := util.ErisContainersByType(definitions.TypeChain, false)
+
+	if len(listOfChains) == 0 {
+		return fmt.Errorf("no existing chains to stop")
+	}
+
+	namez := make([]string, len(listOfChains))
+	for i, chainName := range listOfChains {
+		namez[i] = chainName.ShortName
+	}
+
+	fmt.Println(namez)
+
+	doStopChain := definitions.NowDo()
+	doStopChain.Operations.Args = namez
+	doStopChain.Timeout = 10
+	if err := chains.KillChain(doStopChain); err != nil {
+		return err
+	}
+
 
 	return nil
 }

--- a/kaihei/start.go
+++ b/kaihei/start.go
@@ -11,6 +11,18 @@ import (
 
 func StartUpEris(do *definitions.Do) error {
 
+	// start chain
+	// doChain.Name - name of the chain (optional)
+	if do.ChainName != ""{
+		doChain := definitions.NowDo()
+		doChain.Name = do.ChainName
+
+		fmt.Println("starting up your chain...")
+		if err := chains.StartChain(doChain); err != nil {
+			return err
+		}
+	}
+	
 	fmt.Println("starting up your services...")
 
 	// start services
@@ -33,18 +45,6 @@ func StartUpEris(do *definitions.Do) error {
 		return err
 	}
 
-	// start chain
-	// doChain.Name    - name of the chain (optional)
-	if do.ChainName != ""{
-		doChain := definitions.NowDo()
-		doChain.Name = do.ChainName
-
-		fmt.Println("starting up your chain...")
-		if err := chains.StartChain(doChain); err != nil {
-			return err
-		}
-	}
-	
 	return nil
 }
 
@@ -52,7 +52,7 @@ func ShutUpEris(do *definitions.Do) error {
 
 	fmt.Println("shutting down your services...")
 
-	// start services
+	// shutdown all services
 	listOfServices := util.ErisContainersByType(definitions.TypeService, false)
 
 	if len(listOfServices) == 0 {
@@ -90,10 +90,9 @@ func ShutUpEris(do *definitions.Do) error {
 	doStopChain := definitions.NowDo()
 	doStopChain.Operations.Args = namez
 	doStopChain.Timeout = 10
-	if err := chains.KillChain(doStopChain); err != nil {
+	if err := chains.KillChains(doStopChain); err != nil {
 		return err
 	}
-
 
 	return nil
 }

--- a/services/operate.go
+++ b/services/operate.go
@@ -79,7 +79,7 @@ func KillService(do *definitions.Do) (err error) {
 		}
 		services = append(services, s...)
 	}
-
+	
 	// if force flag given, this will override any timeout flag
 	if do.Force {
 		do.Timeout = 0


### PR DESCRIPTION
When submitting a pull request (branched from develop):

- [ check ] `gofmt -s` your code
- [ check ] `git rebase develop` while on your feature/fix branch
- [ check ] use a descriptive title
- [ closes #766 ] in the comments section, include the issue # (i.e., closes #577)
- [ Adds the ability to `eris startup` which starts up all existing services that you have. `startup` also takes a `--chain` flag to simultaneously startup a chain if you like. Adds ability to `eris shutdown` which gracefully shuts down all chains and services currently running. Adds function to `KillChains` which is the same functionality as the `KillChain` command except it takes an array of chain container names in case multiple chains are running. This is similar to the behaviour of `KillServices`. ] provide a significant summary of the important changes the PR yields. Describe under-the-hood behaviour of code changes and/or modifications to the user experience
- [ ] await a thumbs up (:+1:) from the maintainers of the repository
