### PR TITLE
Pull selected services definitions for testing

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -44,7 +44,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull, "keys"))
 
 	exitCode := m.Run()
 	tests.IfExit(tests.TestsTearDown())

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull, "keys", "ipfs"))
 
 	exitCode := m.Run()
 	tests.IfExit(tests.TestsTearDown())

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
+	tests.IfExit(tests.TestsInit(tests.DontPull))
 
 	exitCode := m.Run()
 	tests.IfExit(tests.TestsTearDown())

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 		port_to_use = port
 	}
 
-	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull, "ipfs"))
 	exitCode := m.Run()
 	tests.IfExit(tests.TestsTearDown())
 	os.Exit(exitCode)

--- a/initialize/init.go
+++ b/initialize/init.go
@@ -15,7 +15,6 @@ import (
 )
 
 func Initialize(do *definitions.Do) error {
-
 	newDir, err := checkThenInitErisRoot(do.Quiet)
 	if err != nil {
 		return err
@@ -105,7 +104,13 @@ func InitDefaults(do *definitions.Do, newDir bool) error {
 
 	tsErrorFix := "toadserver may be down: re-run with `--source=rawgit`"
 
-	if err := dropServiceDefaults(srvPath, do.Source); err != nil {
+	// Default or custom service definition files list.
+	services := ver.SERVICE_DEFINITIONS
+	if len(do.ServicesSlice) != 0 {
+		services = do.ServicesSlice
+	}
+
+	if err := dropServiceDefaults(srvPath, do.Source, services); err != nil {
 		return fmt.Errorf("%v\n%s\n", err, tsErrorFix)
 	}
 

--- a/initialize/initialize_test.go
+++ b/initialize/initialize_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/eris-ltd/eris-cli/config"
 	"github.com/eris-ltd/eris-cli/util"
+	ver "github.com/eris-ltd/eris-cli/version"
 
 	"github.com/eris-ltd/common/go/common"
 	"github.com/eris-ltd/common/go/ipfs"
@@ -97,12 +98,12 @@ func testDrops(dir, kind string) error {
 	case "services":
 		//pull from toadserver
 		if toadUp {
-			if err := dropServiceDefaults(dirToad, "toadserver"); err != nil {
+			if err := dropServiceDefaults(dirToad, "toadserver", ver.SERVICE_DEFINITIONS); err != nil {
 				ifExit(err)
 			}
 		}
 		//pull from rawgit
-		if err := dropServiceDefaults(dirGit, "rawgit"); err != nil {
+		if err := dropServiceDefaults(dirGit, "rawgit", ver.SERVICE_DEFINITIONS); err != nil {
 			ifExit(err)
 		}
 	case "actions":

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull, "keys"))
 
 	exitCode := m.Run()
 	tests.IfExit(tests.TestsTearDown())

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -23,7 +23,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull, "keys", "ipfs"))
 
 	tests.RemoveAllContainers()
 

--- a/pkgs/packages_test.go
+++ b/pkgs/packages_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull, "compilers", "keys", "ipfs"))
 
 	exitCode := m.Run()
 	killKeys()

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 	// log.SetLevel(log.InfoLevel)
 	// log.SetLevel(log.DebugLevel)
 
-	tests.IfExit(tests.TestsInit(tests.ConnectAndPull))
+	tests.IfExit(tests.TestsInit(tests.ConnectAndPull, "do_not_use", "keys", "ipfs"))
 
 	// Prevent CLI from starting IPFS.
 	os.Setenv("ERIS_SKIP_ENSURE", "true")

--- a/tests/testing_utils.go
+++ b/tests/testing_utils.go
@@ -31,7 +31,7 @@ const (
 	Quick
 )
 
-func TestsInit(steps int) (err error) {
+func TestsInit(steps int, services ...string) (err error) {
 	// TODO: make a reader/pipe so we can see what is written from tests.
 	config.GlobalConfig, err = config.SetGlobalObject(os.Stdout, os.Stderr)
 	if err != nil {
@@ -62,6 +62,7 @@ func TestsInit(steps int) (err error) {
 	do.Yes = true   //over-ride command-line prompts
 	do.Quiet = true
 	do.Source = "rawgit" //use "rawgit" if ts down
+	do.ServicesSlice = services
 	if err := ini.Initialize(do); err != nil {
 		IfExit(fmt.Errorf("TRAGIC. Could not initialize the eris dir: %s.\n", err))
 	}

--- a/util/readers.go
+++ b/util/readers.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
-	"strings"
 
 	ipfs "github.com/eris-ltd/common/go/ipfs"
 	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive"
@@ -61,7 +61,7 @@ func UnpackTarball(tarBallPath, installPath string) error {
 	return UntarForDocker(reader, "", installPath)
 }
 
-func GetFromGithub(org, repo, branch, path, directory, fileName string) error {
-	url := "https://raw.githubusercontent.com/" + strings.Join([]string{org, repo, branch, path}, "/")
+func GetFromGithub(org, repo, branch, p, directory, fileName string) error {
+	url := "https://" + path.Join("raw.githubusercontent.com", org, repo, branch, p)
 	return ipfs.DownloadFromUrlToFile(url, fileName, directory)
 }

--- a/version/files.go
+++ b/version/files.go
@@ -7,35 +7,35 @@ package version
 // service definition files which can then be imported.
 var (
 	SERVICE_DEFINITIONS = []string{
-		"bigchaindb.toml",
-		"btcd.toml",
-		"bitcoincore.toml",
-		"bitcoinclassic.toml",
-		"compilers.toml",
-		"geth.toml",
-		//"ipfs.toml",
-		//"keys.toml", now in eris-cli binary so we can version
-		"logspout.toml",
-		"logrotate.toml",
-		"mindy.toml",
-		"openbazaar.toml",
-		"rethinkdb.toml",
-		"toadserver.toml",
-		"tinydns.toml",
-		"tor.toml",
-		"watchtower.toml",
-		"do_not_use.toml",
+		"bigchaindb",
+		"btcd",
+		"bitcoincore",
+		"bitcoinclassic",
+		"compilers",
+		"geth",
+		"ipfs",
+		"keys",
+		"logspout",
+		"logrotate",
+		"mindy",
+		"openbazaar",
+		"rethinkdb",
+		"toadserver",
+		"tinydns",
+		"tor",
+		"watchtower",
+		"do_not_use",
 	}
 
 	ACTION_DEFINITIONS = []string{
-		"chain_info.toml",
-		"dns_register.toml",
-		"keys_list.toml",
+		"chain_info",
+		"dns_register",
+		"keys_list",
 	}
 
 	CHAIN_DEFINITIONS = []string{
-		"default.toml",
-		"config.toml",
-		"server_conf.toml",
+		"default",
+		"config",
+		"server_conf",
 	}
 )

--- a/version/files_arm.go
+++ b/version/files_arm.go
@@ -2,19 +2,19 @@ package version
 
 var (
 	SERVICE_DEFINITIONS = []string{
-	//"ipfs.toml",
-	//"keys.toml",
+		"ipfs",
+		"keys",
 	}
 
 	ACTION_DEFINITIONS = []string{
-		"chain_info.toml",
-		"dns_register.toml",
-		"keys_list.toml",
+		"chain_info",
+		"dns_register",
+		"keys_list",
 	}
 
 	CHAIN_DEFINITIONS = []string{
-		"default.toml",
-		"config.toml",
-		"server_conf.toml",
+		"default",
+		"config",
+		"server_conf",
 	}
 )


### PR DESCRIPTION
* `tests.TestsInit()` takes additional arguments to pull selected services:
  
  ```
  ...
  tests.TestsInit(ConnectAndPull, "keys", "ipfs", "do_not_use")
  ...
  ``` 
* Renames `files.go` and `files_arm.go` definitions not to include the `.toml` suffix (looks better/dries out both `tests.TestsInit()` function and the definitions list).
* Includes "ipfs" and "keys" back into `SERVICE_DEFINITION` to optimize pulling of the custom list.
* Partially resolves #867.