### PR TITLE
Refactor `config` package

### DIFF
--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -145,7 +145,7 @@ func TestCatChainLocalConfig(t *testing.T) {
 	defer tests.RemoveAllContainers()
 
 	buf := new(bytes.Buffer)
-	config.GlobalConfig.Writer = buf
+	config.Global.Writer = buf
 
 	create(t, chainName)
 	defer kill(t, chainName)
@@ -166,7 +166,7 @@ func TestCatChainContainerConfig(t *testing.T) {
 	defer tests.RemoveAllContainers()
 
 	buf := new(bytes.Buffer)
-	config.GlobalConfig.Writer = buf
+	config.Global.Writer = buf
 
 	const chain = "test-cat-cont-config"
 
@@ -189,7 +189,7 @@ func TestCatChainContainerGenesis(t *testing.T) {
 	defer tests.RemoveAllContainers()
 
 	buf := new(bytes.Buffer)
-	config.GlobalConfig.Writer = buf
+	config.Global.Writer = buf
 
 	create(t, chainName)
 	defer kill(t, chainName)
@@ -348,7 +348,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_IPFS)+`"
+image = "`+path.Join(config.Global.DefaultRegistry, config.Global.ImageIPFS)+`"
 data_container = true
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
@@ -369,7 +369,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_IPFS)+`"
+image = "`+path.Join(config.Global.DefaultRegistry, config.Global.ImageIPFS)+`"
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
 	}
@@ -391,7 +391,7 @@ func TestServiceLinkBadChainWithoutChainInDefinition(t *testing.T) {
 	if err := tests.FakeServiceDefinition("fake", `
 [service]
 name = "fake"
-image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_IPFS)+`"
+image = "`+path.Join(config.Global.DefaultRegistry, config.Global.ImageIPFS)+`"
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
 	}
@@ -426,7 +426,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)+`"
+image = "`+path.Join(config.Global.DefaultRegistry, config.Global.ImageKeys)+`"
 data_container = false
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
@@ -475,7 +475,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_IPFS)+`"
+image = "`+path.Join(config.Global.DefaultRegistry, config.Global.ImageIPFS)+`"
 data_container = true
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
@@ -524,7 +524,7 @@ chain = "`+chain+`:fake"
 
 [service]
 name = "fake"
-image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)+`"
+image = "`+path.Join(config.Global.DefaultRegistry, config.Global.ImageKeys)+`"
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
 	}
@@ -572,7 +572,7 @@ chain = "blah-blah:blah"
 
 [service]
 name = "fake"
-image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_IPFS)+`"
+image = "`+path.Join(config.Global.DefaultRegistry, config.Global.ImageKeys)+`"
 `); err != nil {
 		t.Fatalf("can't create a fake service definition: %v", err)
 	}
@@ -606,7 +606,7 @@ chain = "$chain:fake"
 
 [service]
 name = "fake"
-image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)+`"
+image = "`+path.Join(config.Global.DefaultRegistry, config.Global.ImageKeys)+`"
 
 [dependencies]
 services = [ "sham" ]
@@ -619,7 +619,7 @@ chain = "$chain:sham"
 
 [service]
 name = "sham"
-image = "`+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)+`"
+image = "`+path.Join(config.Global.DefaultRegistry, config.Global.ImageKeys)+`"
 data_container = true
 `); err != nil {
 		t.Fatalf("can't create a sham service definition: %v", err)

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -45,7 +45,7 @@ func MakeChain(do *definitions.Do) error {
 	}
 
 	do.Service.Name = do.Name
-	do.Service.Image = path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_CM)
+	do.Service.Image = path.Join(config.Global.DefaultRegistry, config.Global.ImageCM)
 	do.Service.User = "eris"
 	do.Service.AutoData = true
 	do.Service.Links = []string{fmt.Sprintf("%s:%s", util.ServiceContainerName("keys"), "keys")}
@@ -117,7 +117,7 @@ func MakeChain(do *definitions.Do) error {
 		return err
 	}
 
-	io.Copy(config.GlobalConfig.Writer, buf)
+	io.Copy(config.Global.Writer, buf)
 
 	doData.Source = path.Join(ErisContainerRoot, "chains")
 	doData.Destination = ErisRoot
@@ -237,7 +237,7 @@ func CatChain(do *definitions.Do) error {
 		if err != nil {
 			return err
 		}
-		config.GlobalConfig.Writer.Write(cat)
+		config.Global.Writer.Write(cat)
 		return nil
 	default:
 		return fmt.Errorf("unknown cat subcommand %q", do.Type)
@@ -248,7 +248,7 @@ func CatChain(do *definitions.Do) error {
 	buf, err := ExecChain(do)
 
 	if buf != nil {
-		io.Copy(config.GlobalConfig.Writer, buf)
+		io.Copy(config.Global.Writer, buf)
 	}
 
 	return err

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -127,7 +127,7 @@ func testCheckChainDirsExist(chains []string, yes bool, t *testing.T) {
 }
 
 func testCreateNotEris(name string, t *testing.T) string {
-	if err := perform.DockerBuild(customImage, "FROM "+path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_KEYS)); err != nil {
+	if err := perform.DockerBuild(customImage, "FROM "+path.Join(config.Global.DefaultRegistry, config.Global.ImageKeys)); err != nil {
 		t.Fatalf("expected to build a custom image, got %v", err)
 	}
 

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -414,8 +414,8 @@ func ExecChain(cmd *cobra.Command, args []string) {
 	}
 	do.Operations.Terminal = true
 	do.Operations.Args = args
-	config.GlobalConfig.InteractiveWriter = os.Stdout
-	config.GlobalConfig.InteractiveErrorWriter = os.Stderr
+	config.Global.InteractiveWriter = os.Stdout
+	config.Global.InteractiveErrorWriter = os.Stderr
 	_, err := chns.ExecChain(do)
 	IfExit(err)
 }
@@ -449,8 +449,8 @@ func MakeChain(cmd *cobra.Command, args []string) {
 		IfExit(fmt.Errorf("\nThe --account-types and --chain-type flags are incompatible with the --known flag. Please use only one of these."))
 	}
 	if !do.Known {
-		config.GlobalConfig.InteractiveWriter = os.Stdout
-		config.GlobalConfig.InteractiveErrorWriter = os.Stderr
+		config.Global.InteractiveWriter = os.Stdout
+		config.Global.InteractiveErrorWriter = os.Stderr
 		do.Operations.Terminal = true
 	}
 

--- a/cmd/crash_report.go
+++ b/cmd/crash_report.go
@@ -20,7 +20,7 @@ type CrashReport interface {
 // the 'CrashReport' value in the `eris.toml` configuration file) and returns
 // a hook for the Eris logging library.
 func CrashReportHook(dockerVersion string) log.Hook {
-	switch config.GlobalConfig.Config.CrashReport {
+	switch config.Global.CrashReport {
 	case "bugsnag":
 		crashReport = log.NewBugsnagReporter(ConfigureCrashReport(dockerVersion))
 	default:

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -218,8 +218,8 @@ func ExecData(cmd *cobra.Command, args []string) {
 	}
 	do.Operations.Terminal = true
 	do.Operations.Args = args
-	config.GlobalConfig.InteractiveWriter = os.Stdout
-	config.GlobalConfig.InteractiveErrorWriter = os.Stderr
+	config.Global.InteractiveWriter = os.Stdout
+	config.Global.InteractiveErrorWriter = os.Stderr
 	_, err := data.ExecData(do)
 	IfExit(err)
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -283,8 +283,8 @@ func ExecService(cmd *cobra.Command, args []string) {
 	}
 	do.Operations.Terminal = true
 	do.Operations.Args = args
-	config.GlobalConfig.InteractiveWriter = os.Stdout
-	config.GlobalConfig.InteractiveErrorWriter = os.Stderr
+	config.Global.InteractiveWriter = os.Stdout
+	config.Global.InteractiveErrorWriter = os.Stderr
 	_, err := srv.ExecService(do)
 	IfExit(err)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	ver "github.com/eris-ltd/eris-cli/version"
+	"github.com/eris-ltd/common/go/common"
 
 	log "github.com/eris-ltd/eris-logger"
 )
@@ -33,8 +34,8 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-func TestSetGlobalObject1(t *testing.T) {
-	cli, err := SetGlobalObject(os.Stdout, os.Stderr)
+func TestNew1(t *testing.T) {
+	cli, err := New(os.Stdout, os.Stderr)
 	if err != nil {
 		t.Fatalf("expected success, got error %v", err)
 	}
@@ -48,8 +49,8 @@ func TestSetGlobalObject1(t *testing.T) {
 	}
 }
 
-func TestSetGlobalObject2(t *testing.T) {
-	cli, err := SetGlobalObject(os.Stderr, os.Stdout)
+func TestNew2(t *testing.T) {
+	cli, err := New(os.Stderr, os.Stdout)
 	if err != nil {
 		t.Fatalf("expected success, got error %v", err)
 	}
@@ -63,8 +64,8 @@ func TestSetGlobalObject2(t *testing.T) {
 	}
 }
 
-func TestSetGlobalObjectNil(t *testing.T) {
-	cli, err := SetGlobalObject(nil, nil)
+func TestNewNil(t *testing.T) {
+	cli, err := New(nil, nil)
 	if err != nil {
 		t.Fatalf("expected success, got error %v", err)
 	}
@@ -78,10 +79,10 @@ func TestSetGlobalObjectNil(t *testing.T) {
 	}
 }
 
-func TestSetGlobalObjectDefaultConfig(t *testing.T) {
-	ChangeErisDir(configErisDir)
+func TestNewDefaultConfig(t *testing.T) {
+	common.ChangeErisRoot(configErisDir)
 
-	cli, err := SetGlobalObject(os.Stderr, os.Stdout)
+	cli, err := New(os.Stderr, os.Stdout)
 	if err != nil {
 		t.Fatalf("expected success, got error %v", err)
 	}
@@ -91,84 +92,80 @@ func TestSetGlobalObjectDefaultConfig(t *testing.T) {
 		t.Fatalf("expected defaults loaded, got error %v", err)
 	}
 
-	if def, returned := defaults.Get("IpfsHost"), cli.Config.IpfsHost; reflect.DeepEqual(returned, def) != true {
+	if def, returned := defaults.Get("IpfsHost"), cli.IpfsHost; reflect.DeepEqual(returned, def) != true {
 		t.Fatalf("expected default %q, got %q", returned, def)
 	}
 
-	if def, returned := defaults.Get("CompilersHost"), cli.Config.CompilersHost; reflect.DeepEqual(returned, def) != true {
+	if def, returned := defaults.Get("CompilersHost"), cli.CompilersHost; reflect.DeepEqual(returned, def) != true {
 		t.Fatalf("expected default %q, got %q", returned, def)
 	}
 
-	if def, returned := defaults.Get("ERIS_IMG_KEYS"), cli.Config.ERIS_IMG_KEYS; reflect.DeepEqual(returned, def) != true {
+	if def, returned := defaults.Get("ImageKeys"), cli.ImageKeys; reflect.DeepEqual(returned, def) != true {
 		t.Fatalf("expected default %q, got %q", returned, def)
 	}
 
 	log.WithFields(log.Fields{
-		"ipfshost":       cli.Config.IpfsHost,
-		"compilers host": cli.Config.CompilersHost,
-		"host":           cli.Config.DockerHost,
-		"cert path":      cli.Config.DockerCertPath,
-		"crash report":   cli.Config.CrashReport,
-		"verbose":        cli.Config.Verbose,
-		"eris_img_keys":  cli.Config.ERIS_IMG_KEYS,
+		"ipfshost":       cli.IpfsHost,
+		"compilers host": cli.CompilersHost,
+		"host":           cli.DockerHost,
+		"cert path":      cli.DockerCertPath,
+		"crash report":   cli.CrashReport,
+		"verbose":        cli.Verbose,
+		"image keys":  cli.ImageKeys,
 	}).Info("Checking defaults")
 }
 
-func TestSetGlobalObjectCustomConfig(t *testing.T) {
-	placeErisConfig(`
+func TestNewCustomConfig(t *testing.T) {
+	placeSettings(`
 IpfsHost = "foo"
 CompilersHost = "bar"
 DockerHost = "baz"
 DockerCertPath = "qux"
 CrashReport = "quux"
 Verbose = true
-ERIS_IMG_KEYS = "crypto"
-ERIS_IMG_DB = "erisdb"
+ImageKeys = "crypto"
+ImageDB = "erisdb"
 `)
 	defer removeErisDir()
 
-	// [pv]: this is a bit awkward way to reinitialize the config:
-	// SetGlobalConfig, then ChangeErisDir, then again SetGlobalConfig.
-	GlobalConfig = &ErisCli{}
-	ChangeErisDir(configErisDir)
-	cli, err := SetGlobalObject(os.Stderr, os.Stdout)
+	common.ChangeErisRoot(configErisDir)
+	cli, err := New(os.Stderr, os.Stdout)
 	if err != nil {
 		t.Fatalf("expected success, got error %v", err)
 	}
 
-	if custom, returned := "foo", cli.Config.IpfsHost; custom != returned {
+	if custom, returned := "foo", cli.IpfsHost; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := "bar", cli.Config.CompilersHost; custom != returned {
+	if custom, returned := "bar", cli.CompilersHost; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := "baz", cli.Config.DockerHost; custom != returned {
+	if custom, returned := "baz", cli.DockerHost; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := "qux", cli.Config.DockerCertPath; custom != returned {
+	if custom, returned := "qux", cli.DockerCertPath; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := "quux", cli.Config.CrashReport; custom != returned {
+	if custom, returned := "quux", cli.CrashReport; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := true, cli.Config.Verbose; custom != returned {
+	if custom, returned := true, cli.Verbose; custom != returned {
 		t.Fatalf("expected %v, got %v", custom, returned)
 	}
-	if custom, returned := "crypto", cli.Config.ERIS_IMG_KEYS; custom != returned {
+	if custom, returned := "crypto", cli.ImageKeys; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := "erisdb", cli.Config.ERIS_IMG_DB; custom != returned {
+	if custom, returned := "erisdb", cli.ImageDB; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
 }
 
-func TestSetGlobalObjectCustomEmptyConfig(t *testing.T) {
-	placeErisConfig(``)
+func TestNewCustomEmptyConfig(t *testing.T) {
+	placeSettings(``)
 	defer removeErisDir()
 
-	GlobalConfig = &ErisCli{}
-	ChangeErisDir(configErisDir)
-	cli, err := SetGlobalObject(os.Stderr, os.Stdout)
+	common.ChangeErisRoot(configErisDir)
+	cli, err := New(os.Stderr, os.Stdout)
 	if err != nil {
 		t.Fatalf("expected success, got error %v", err)
 	}
@@ -179,65 +176,64 @@ func TestSetGlobalObjectCustomEmptyConfig(t *testing.T) {
 	}
 
 	log.WithFields(log.Fields{
-		"ipfshost":       cli.Config.IpfsHost,
-		"compilers host": cli.Config.CompilersHost,
-		"host":           cli.Config.DockerHost,
-		"cert path":      cli.Config.DockerCertPath,
-		"crash report":   cli.Config.CrashReport,
-		"verbose":        cli.Config.Verbose,
-		"eris_img_keys":  cli.Config.ERIS_IMG_KEYS,
-		"eris_img_db":    cli.Config.ERIS_IMG_DB,
+		"ipfs host":      cli.IpfsHost,
+		"compilers host": cli.CompilersHost,
+		"host":           cli.DockerHost,
+		"cert path":      cli.DockerCertPath,
+		"crash report":   cli.CrashReport,
+		"verbose":        cli.Verbose,
+		"keys image":     cli.ImageKeys,
+		"db image":       cli.ImageDB,
 	}).Info("Checking empty values")
 
 	// With an empty config, the values are used are defaults.
-	if def, returned := defaults.Get("IpfsHost"), cli.Config.IpfsHost; reflect.DeepEqual(returned, def) != true {
+	if def, returned := defaults.Get("IpfsHost"), cli.IpfsHost; reflect.DeepEqual(returned, def) != true {
 		t.Fatalf("expected default %v, got %v", returned, def)
 	}
 
-	if def, returned := defaults.Get("CompilersHost"), cli.Config.CompilersHost; reflect.DeepEqual(returned, def) != true {
+	if def, returned := defaults.Get("CompilersHost"), cli.CompilersHost; reflect.DeepEqual(returned, def) != true {
 		t.Fatalf("expected default %q, got %q", returned, def)
 	}
 
-	if custom, returned := "", cli.Config.DockerHost; custom != returned {
+	if custom, returned := "", cli.DockerHost; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := "", cli.Config.DockerCertPath; custom != returned {
+	if custom, returned := "", cli.DockerCertPath; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := "bugsnag", cli.Config.CrashReport; custom != returned {
+	if custom, returned := "bugsnag", cli.CrashReport; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := false, cli.Config.Verbose; custom != returned {
+	if custom, returned := false, cli.Verbose; custom != returned {
 		t.Fatalf("expected %v, got %v", custom, returned)
 	}
-	if custom, returned := ver.ERIS_IMG_KEYS, cli.Config.ERIS_IMG_KEYS; custom != returned {
+	if custom, returned := ver.ImageKeys, cli.ImageKeys; custom != returned {
 		t.Fatalf("expected %v, got %v", custom, returned)
 	}
-	if custom, returned := ver.ERIS_IMG_DB, cli.Config.ERIS_IMG_DB; custom != returned {
+	if custom, returned := ver.ImageDB, cli.ImageDB; custom != returned {
 		t.Fatalf("expected %v, got %v", custom, returned)
 	}
 }
 
-func TestSetGlobalObjectCustomBadConfig(t *testing.T) {
-	placeErisConfig(`*`)
+func TestNewCustomBadConfig(t *testing.T) {
+	placeSettings(`*`)
 	defer removeErisDir()
 
-	GlobalConfig = &ErisCli{}
-	ChangeErisDir(configErisDir)
-	cli, err := SetGlobalObject(os.Stderr, os.Stdout)
+	common.ChangeErisRoot(configErisDir)
+	cli, err := New(os.Stderr, os.Stdout)
 	if err != nil {
 		t.Fatalf("expected success, got error %v", err)
 	}
 
 	log.WithFields(log.Fields{
-		"ipfshost":       cli.Config.IpfsHost,
-		"compilers host": cli.Config.CompilersHost,
-		"host":           cli.Config.DockerHost,
-		"cert path":      cli.Config.DockerCertPath,
-		"crash report":   cli.Config.CrashReport,
-		"verbose":        cli.Config.Verbose,
-		"eris_img_keys":  cli.Config.ERIS_IMG_KEYS,
-		"eris_img_db":    cli.Config.ERIS_IMG_DB,
+		"ipfshost":       cli.IpfsHost,
+		"compilers host": cli.CompilersHost,
+		"host":           cli.DockerHost,
+		"cert path":      cli.DockerCertPath,
+		"crash report":   cli.CrashReport,
+		"verbose":        cli.Verbose,
+		"keys image":     cli.ImageKeys,
+		"db image":       cli.ImageDB,
 	}).Info("Checking empty values")
 
 	// With an empty config, the values are used are defaults.
@@ -246,30 +242,30 @@ func TestSetGlobalObjectCustomBadConfig(t *testing.T) {
 		t.Fatalf("expected defaults loaded, got error %v", err)
 	}
 
-	if def, returned := defaults.Get("IpfsHost"), cli.Config.IpfsHost; reflect.DeepEqual(returned, def) != true {
+	if def, returned := defaults.Get("IpfsHost"), cli.IpfsHost; reflect.DeepEqual(returned, def) != true {
 		t.Fatalf("expected default %q, got %q", returned, def)
 	}
 
-	if def, returned := defaults.Get("CompilersHost"), cli.Config.CompilersHost; reflect.DeepEqual(returned, def) != true {
+	if def, returned := defaults.Get("CompilersHost"), cli.CompilersHost; reflect.DeepEqual(returned, def) != true {
 		t.Fatalf("expected default %q, got %q", returned, def)
 	}
 
-	if custom, returned := "", cli.Config.DockerHost; custom != returned {
+	if custom, returned := "", cli.DockerHost; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := "", cli.Config.DockerCertPath; custom != returned {
+	if custom, returned := "", cli.DockerCertPath; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := "bugsnag", cli.Config.CrashReport; custom != returned {
+	if custom, returned := "bugsnag", cli.CrashReport; custom != returned {
 		t.Fatalf("expected %q, got %q", custom, returned)
 	}
-	if custom, returned := false, cli.Config.Verbose; custom != returned {
+	if custom, returned := false, cli.Verbose; custom != returned {
 		t.Fatalf("expected %v, got %v", custom, returned)
 	}
-	if def, returned := defaults.Get("ERIS_IMG_KEYS"), cli.Config.ERIS_IMG_KEYS; reflect.DeepEqual(returned, def) != true {
+	if def, returned := defaults.Get("ImageKeys"), cli.ImageKeys; reflect.DeepEqual(returned, def) != true {
 		t.Fatalf("expected default %q, got %q", returned, def)
 	}
-	if def, returned := defaults.Get("ERIS_IMG_DB"), cli.Config.ERIS_IMG_DB; reflect.DeepEqual(returned, def) != true {
+	if def, returned := defaults.Get("ImageDB"), cli.ImageDB; reflect.DeepEqual(returned, def) != true {
 		t.Fatalf("expected default %q, got %q", returned, def)
 	}
 }
@@ -288,25 +284,25 @@ func TestSetDefaults(t *testing.T) {
 		t.Fatalf("expected CompilersHost values set")
 	}
 
-	if _, ok := defaults.Get("ERIS_IMG_KEYS").(string); !ok {
-		t.Fatalf("expected ERIS_IMG_KEYS value set")
+	if _, ok := defaults.Get("ImageKeys").(string); !ok {
+		t.Fatalf("expected ImageKeys value set")
 	}
 }
 
-func TestLoadGlobalConfig(t *testing.T) {
-	placeErisConfig(`
+func TestLoad(t *testing.T) {
+	placeSettings(`
 IpfsHost = "foo"
 CompilersHost = "bar"
 DockerHost = "baz"
 DockerCertPath = "qux"
 CrashReport = "quux"
 Verbose = true
-ERIS_IMG_KEYS = "crypto"
-ERIS_IMG_DB = "erisdb"
+ImageKeys = "crypto"
+ImageDB = "erisdb"
 `)
 	defer removeErisDir()
 
-	config, err := LoadGlobalConfig()
+	config, err := Load()
 	if err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
@@ -329,19 +325,19 @@ ERIS_IMG_DB = "erisdb"
 	if expected, returned := true, config.Get("Verbose"); reflect.DeepEqual(expected, returned) != true {
 		t.Fatalf("expected %v, got %v", expected, returned)
 	}
-	if expected, returned := "crypto", config.Get("ERIS_IMG_KEYS"); reflect.DeepEqual(expected, returned) != true {
+	if expected, returned := "crypto", config.Get("ImageKeys"); reflect.DeepEqual(expected, returned) != true {
 		t.Fatalf("expected %v, got %v", expected, returned)
 	}
-	if expected, returned := "erisdb", config.Get("ERIS_IMG_DB"); reflect.DeepEqual(expected, returned) != true {
+	if expected, returned := "erisdb", config.Get("ImageDB"); reflect.DeepEqual(expected, returned) != true {
 		t.Fatalf("expected %v, got %v", expected, returned)
 	}
 }
 
-func TestLoadGlobalConfigEmpty(t *testing.T) {
-	placeErisConfig(``)
+func TestLoadEmpty(t *testing.T) {
+	placeSettings(``)
 	defer removeErisDir()
 
-	config, err := LoadGlobalConfig()
+	config, err := Load()
 	if err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
@@ -369,20 +365,20 @@ func TestLoadGlobalConfigEmpty(t *testing.T) {
 	if returned := config.Get("Verbose"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
 	}
-	if def, returned := defaults.Get("ERIS_IMG_KEYS"), config.Get("ERIS_IMG_KEYS"); reflect.DeepEqual(returned, def) != true {
+	if def, returned := defaults.Get("ImageKeys"), config.Get("ImageKeys"); reflect.DeepEqual(returned, def) != true {
 		t.Fatalf("expected default %q, got %q", returned, def)
 	}
-	if def, returned := defaults.Get("ERIS_IMG_DB"), config.Get("ERIS_IMG_DB"); reflect.DeepEqual(returned, def) != true {
+	if def, returned := defaults.Get("ImageDB"), config.Get("ImageDB"); reflect.DeepEqual(returned, def) != true {
 		t.Fatalf("expected default %q, got %q", returned, def)
 	}
 }
 
-func TestLoadGlobalConfigBad(t *testing.T) {
-	placeErisConfig(`*`)
+func TestLoadBad(t *testing.T) {
+	placeSettings(`*`)
 	defer removeErisDir()
 
 	// With bad config, load defaults.
-	config, err := LoadGlobalConfig()
+	config, err := Load()
 	if err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
@@ -410,28 +406,28 @@ func TestLoadGlobalConfigBad(t *testing.T) {
 	if returned := config.Get("Verbose"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
 	}
-	if def, returned := defaults.Get("ERIS_IMG_KEYS"), config.Get("ERIS_IMG_KEYS"); reflect.DeepEqual(returned, def) != true {
+	if def, returned := defaults.Get("ImageKeys"), config.Get("ImageKeys"); reflect.DeepEqual(returned, def) != true {
 		t.Fatalf("expected default %q, got %q", returned, def)
 	}
-	if def, returned := defaults.Get("ERIS_IMG_DB"), config.Get("ERIS_IMG_DB"); reflect.DeepEqual(returned, def) != true {
+	if def, returned := defaults.Get("ImageDB"), config.Get("ImageDB"); reflect.DeepEqual(returned, def) != true {
 		t.Fatalf("expected default %q, got %q", returned, def)
 	}
 }
 
-func TestLoadViperConfig(t *testing.T) {
-	placeErisConfig(`
+func TestLoadViper(t *testing.T) {
+	placeSettings(`
 IpfsHost = "foo"
 CompilersHost = "bar"
 DockerHost = "baz"
 DockerCertPath = "qux"
 CrashReport = "quux"
 Verbose = true
-ERIS_IMG_KEYS = "crypto"
-ERIS_IMG_DB = "erisdb"
+ImageKeys = "crypto"
+ImageDB = "erisdb"
 `)
 	defer removeErisDir()
 
-	config, err := LoadViperConfig(configErisDir, "eris")
+	config, err := LoadViper(configErisDir, "eris")
 	if err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
@@ -454,19 +450,19 @@ ERIS_IMG_DB = "erisdb"
 	if expected, returned := true, config.Get("Verbose"); reflect.DeepEqual(expected, returned) != true {
 		t.Fatalf("expected %v, got %v", expected, returned)
 	}
-	if expected, returned := "crypto", config.Get("ERIS_IMG_KEYS"); reflect.DeepEqual(expected, returned) != true {
+	if expected, returned := "crypto", config.Get("ImageKeys"); reflect.DeepEqual(expected, returned) != true {
 		t.Fatalf("expected %v, got %v", expected, returned)
 	}
-	if expected, returned := "erisdb", config.Get("ERIS_IMG_DB"); reflect.DeepEqual(expected, returned) != true {
+	if expected, returned := "erisdb", config.Get("ImageDB"); reflect.DeepEqual(expected, returned) != true {
 		t.Fatalf("expected %v, got %v", expected, returned)
 	}
 }
 
-func TestLoadViperConfigEmpty(t *testing.T) {
-	placeErisConfig(``)
+func TestLoadViperEmpty(t *testing.T) {
+	placeSettings(``)
 	defer removeErisDir()
 
-	config, err := LoadViperConfig(configErisDir, "eris")
+	config, err := LoadViper(configErisDir, "eris")
 	if err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
@@ -489,88 +485,35 @@ func TestLoadViperConfigEmpty(t *testing.T) {
 	if returned := config.Get("Verbose"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
 	}
-	if returned := config.Get("ERIS_IMG_KEYS"); returned != nil {
+	if returned := config.Get("ImageKeys"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
 	}
-	if returned := config.Get("ERIS_IMG_DB"); returned != nil {
+	if returned := config.Get("ImageDB"); returned != nil {
 		t.Fatalf("expected nil, got %q", returned)
 	}
 }
 
-func TestLoadViperConfigBad(t *testing.T) {
-	placeErisConfig(`*`)
+func TestLoadViperBad(t *testing.T) {
+	placeSettings(`*`)
 	defer removeErisDir()
 
-	_, err := LoadViperConfig(configErisDir, "eris")
+	_, err := LoadViper(configErisDir, "eris")
 	if err == nil {
 		t.Fatalf("expected failure, got nil")
 	}
 }
 
-func TestLoadViperConfigNonExistent1(t *testing.T) {
-	_, err := LoadViperConfig(configErisDir, "eris")
+func TestLoadViperNonExistent1(t *testing.T) {
+	_, err := LoadViper(configErisDir, "eris")
 	if err == nil {
 		t.Fatalf("expected failure, got nil")
 	}
 }
 
-func TestLoadViperConfigNonExistent2(t *testing.T) {
-	_, err := LoadViperConfig(configErisDir, "12345")
+func TestLoadViperNonExistent2(t *testing.T) {
+	_, err := LoadViper(configErisDir, "12345")
 	if err == nil {
 		t.Fatalf("expected failure, got nil")
-	}
-}
-
-func TestGetConfigValueUninitialized1(t *testing.T) {
-	GlobalConfig = nil
-
-	if returned := GetConfigValue("IpfsHost"); returned != "" {
-		t.Fatalf("expected empty value, got %v", returned)
-	}
-}
-
-func TestGetConfigValueUninitialized2(t *testing.T) {
-	GlobalConfig = &ErisCli{}
-	GlobalConfig.Config = nil
-
-	if returned := GetConfigValue("IpfsHost"); returned != "" {
-		t.Fatalf("expected empty value, got %v", returned)
-	}
-}
-
-func TestGetConfigValue(t *testing.T) {
-	var err error
-	GlobalConfig, err = SetGlobalObject(os.Stdout, os.Stderr)
-	if err != nil {
-		t.Fatalf("expected success, got %v", err)
-	}
-
-	if returned := GetConfigValue("IpfsHost"); returned == "" {
-		t.Fatal("expected value returned, got empty string")
-	}
-	if returned := GetConfigValue("CompilersHost"); returned == "" {
-		t.Fatal("expected value returned, got empty string")
-	}
-	if returned := GetConfigValue("DockerHost"); returned != "" {
-		t.Fatalf("expected empty string returned, got %v", returned)
-	}
-	if returned := GetConfigValue("DockerCertPath"); returned != "" {
-		t.Fatalf("expected empty string returned, got %v", returned)
-	}
-	if returned := GetConfigValue("ERIS_IMG_KEYS"); returned == "" {
-		t.Fatal("expected value returned, got empty string")
-	}
-}
-
-func TestGetConfigValueBad(t *testing.T) {
-	var err error
-	GlobalConfig, err = SetGlobalObject(os.Stdout, os.Stderr)
-	if err != nil {
-		t.Fatalf("expected success, got %v", err)
-	}
-
-	if returned := GetConfigValue("bad value"); returned != "" {
-		t.Fatalf("expected empty string returned, got %v", returned)
 	}
 }
 
@@ -581,18 +524,18 @@ func TestGitConfigUser(t *testing.T) {
 	}
 }
 
-func TestSaveGlobalConfig(t *testing.T) {
+func TestSave(t *testing.T) {
 	os.MkdirAll(configErisDir, 0755)
 	defer removeErisDir()
 
-	config := &ErisConfig{
+	settings := &Settings{
 		IpfsHost:       "foo",
 		CompilersHost:  "bar",
 		DockerHost:     "baz",
 		DockerCertPath: "qux",
 		Verbose:        true,
 	}
-	if err := SaveGlobalConfig(config); err != nil {
+	if err := Save(settings); err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
 
@@ -613,64 +556,34 @@ Verbose = true
 	}
 }
 
-func TestSaveGlobalConfigNotExistentDir(t *testing.T) {
-	GlobalConfig = &ErisCli{}
-	ChangeErisDir("/non/existent/dir")
-	_, err := SetGlobalObject(os.Stderr, os.Stdout)
+func TestSaveNotExistentDir(t *testing.T) {
+	common.ChangeErisRoot("/non/existent/dir")
+	_, err := New(os.Stderr, os.Stdout)
 	if err != nil {
 		t.Fatalf("expected success, got error %v", err)
 	}
 
-	config := &ErisConfig{
+	settings := &Settings{
 		IpfsHost:       "foo",
 		CompilersHost:  "bar",
 		DockerHost:     "baz",
 		DockerCertPath: "qux",
 		Verbose:        true,
-		ERIS_IMG_KEYS:  "crypto",
-		ERIS_IMG_DB:    "erisdb",
+		ImageKeys:  "crypto",
+		ImageDB:    "erisdb",
 	}
-	if err := SaveGlobalConfig(config); err == nil {
+	if err := Save(settings); err == nil {
 		t.Fatal("expected failure, got nil")
 	}
 }
 
-func TestSaveGlobalConfigNil(t *testing.T) {
-	if err := SaveGlobalConfig(nil); err == nil {
+func TestSaveNil(t *testing.T) {
+	if err := Save(nil); err == nil {
 		t.Fatal("expected failure, got nil")
 	}
 }
 
-func TestChangeErisDirNonInitialized(t *testing.T) {
-	GlobalConfig = nil
-	ChangeErisDir(configErisDir)
-
-	if GlobalConfig != nil {
-		t.Fatal("didn't expect global config to become initialized")
-	}
-}
-
-func TestChangeErisDir(t *testing.T) {
-	GlobalConfig = &ErisCli{}
-	ChangeErisDir(configErisDir)
-
-	if GlobalConfig.ErisDir != configErisDir {
-		t.Fatalf("expected config directory to change, got %v", GlobalConfig.ErisDir)
-	}
-}
-
-func TestChangeErisDirCI(t *testing.T) {
-	GlobalConfig = &ErisCli{}
-
-	os.Setenv("TESTING", "true")
-	ChangeErisDir(configErisDir)
-
-	if GlobalConfig.ErisDir != "" {
-		t.Fatalf("expected config directory not changed in CI, got %v", GlobalConfig.ErisDir)
-	}
-}
-
-func placeErisConfig(definition string) {
+func placeSettings(definition string) {
 	os.MkdirAll(configErisDir, 0755)
 	fakeDefinitionFile(configErisDir, "eris", definition)
 }

--- a/definitions/apps.go
+++ b/definitions/apps.go
@@ -29,7 +29,7 @@ func AllAppTypes() map[string]*AppType {
 func EPMApp() *AppType {
 	app := BlankAppType()
 	app.Name = "epm"
-	app.BaseImage = path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_PM)
+	app.BaseImage = path.Join(version.DefaultRegistry, version.ImagePM)
 	app.EntryPoint = "epm --chain chain:46657 --sign keys:4767"
 	app.DeployCmd = ""
 	app.TestCmd = ""

--- a/files/handle.go
+++ b/files/handle.go
@@ -96,7 +96,7 @@ func exportDirectory(do *definitions.Do) (*bytes.Buffer, error) {
 	}
 
 	ip := new(bytes.Buffer)
-	config.GlobalConfig.Writer = ip
+	config.Global.Writer = ip
 
 	do.Operations.Interactive = false
 	do.Operations.PublishAllPorts = true
@@ -121,7 +121,7 @@ func importDirectory(do *definitions.Do) (*bytes.Buffer, error) {
 	hash := do.Hash
 
 	ip := new(bytes.Buffer)
-	config.GlobalConfig.Writer = ip
+	config.Global.Writer = ip
 
 	do.Name = "ipfs"
 	do.Operations.Interactive = false

--- a/initialize/default_ipfs.go
+++ b/initialize/default_ipfs.go
@@ -33,7 +33,7 @@ This eris service is all but essential as part of the eris tool. The [eris files
 status = "alpha"
 
 [service]
-image = "` + path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_IPFS) + fmt.Sprintf(`"
+image = "` + path.Join(version.DefaultRegistry, version.ImageIPFS) + fmt.Sprintf(`"
 data_container = true
 ports = ["4001:4001", "5001:5001", "%s:%s"]
 user = "root"

--- a/initialize/default_keys.go
+++ b/initialize/default_keys.go
@@ -27,7 +27,7 @@ This service is usually linked to a chain and/or an application. Its functionali
 status = "unfit for production"
 
 [service]
-image = "` + path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_KEYS) + `"
+image = "` + path.Join(version.DefaultRegistry, version.ImageKeys) + `"
 data_container = true
 exec_host = "ERIS_KEYS_HOST"
 #restart = "always"

--- a/initialize/init.go
+++ b/initialize/init.go
@@ -21,7 +21,7 @@ func Initialize(do *definitions.Do) error {
 	}
 
 	if !newDir { //new ErisRoot won't have either...can skip
-		if err := overwriteImageConfigs(); err != nil {
+		if err := overwriteErisToml(); err != nil {
 			return err
 		}
 		if err := checkIfCanOverwrite(do.Yes); err != nil {
@@ -203,17 +203,17 @@ on local host machines. If you already have the images, they'll be updated.
 	return nil
 }
 
-func overwriteImageConfigs() error {
-	config.GlobalConfig.Config.ERIS_REG_DEF = ver.ERIS_REG_DEF
-	config.GlobalConfig.Config.ERIS_REG_BAK = ver.ERIS_REG_BAK
-	config.GlobalConfig.Config.ERIS_IMG_DATA = ver.ERIS_IMG_DATA
-	config.GlobalConfig.Config.ERIS_IMG_KEYS = ver.ERIS_IMG_KEYS
-	config.GlobalConfig.Config.ERIS_IMG_DB = ver.ERIS_IMG_DB
-	config.GlobalConfig.Config.ERIS_IMG_PM = ver.ERIS_IMG_PM
-	config.GlobalConfig.Config.ERIS_IMG_CM = ver.ERIS_IMG_CM
-	config.GlobalConfig.Config.ERIS_IMG_IPFS = ver.ERIS_IMG_IPFS
+func overwriteErisToml() error {
+	config.Global.DefaultRegistry = ver.DefaultRegistry
+	config.Global.BackupRegistry = ver.BackupRegistry
+	config.Global.ImageData = ver.ImageData
+	config.Global.ImageKeys = ver.ImageKeys
+	config.Global.ImageDB = ver.ImageDB
+	config.Global.ImagePM = ver.ImagePM
+	config.Global.ImageCM = ver.ImageCM
+	config.Global.ImageIPFS = ver.ImageIPFS
 
-	if err := config.SaveGlobalConfig(config.GlobalConfig.Config); err != nil {
+	if err := config.Save(&config.Global.Settings); err != nil {
 		return err
 	}
 	return nil

--- a/initialize/initialize_test.go
+++ b/initialize/initialize_test.go
@@ -174,17 +174,13 @@ func toadServerUp() bool {
 }
 
 func testsInit() error {
+	common.ChangeErisRoot(erisDir)
+	
 	var err error
-	config.GlobalConfig, err = config.SetGlobalObject(os.Stdout, os.Stderr)
+	config.Global, err = config.New(os.Stdout, os.Stderr)
 	if err != nil {
 		ifExit(fmt.Errorf("TRAGIC. Could not set global config.\n"))
 	}
-
-	// common is initialized on import so
-	// we have to manually override these
-	// variables to ensure that the tests
-	// run correctly.
-	config.ChangeErisDir(erisDir)
 
 	util.DockerConnect(false, "eris")
 

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -89,9 +89,9 @@ func dropChainDefaults(dir, from string) error {
 	}
 
 	//move things to where they ought to be
-	confiG := filepath.Join(dir, "config.toml")
+	config := filepath.Join(dir, "config.toml")
 	configDef := filepath.Join(chnDir, "config.toml")
-	if err := os.Rename(confiG, configDef); err != nil {
+	if err := os.Rename(config, configDef); err != nil {
 		return err
 	}
 
@@ -105,12 +105,12 @@ func dropChainDefaults(dir, from string) error {
 
 func pullDefaultImages() error {
 	images := []string{
-		config.GlobalConfig.Config.ERIS_IMG_DATA,
-		config.GlobalConfig.Config.ERIS_IMG_KEYS,
-		config.GlobalConfig.Config.ERIS_IMG_IPFS,
-		config.GlobalConfig.Config.ERIS_IMG_DB,
-		config.GlobalConfig.Config.ERIS_IMG_PM,
-		config.GlobalConfig.Config.ERIS_IMG_CM,
+		config.Global.ImageData,
+		config.Global.ImageKeys,
+		config.Global.ImageIPFS,
+		config.Global.ImageDB,
+		config.Global.ImagePM,
+		config.Global.ImageCM,
 	}
 
 	// Spacer.
@@ -134,12 +134,12 @@ func pullDefaultImages() error {
 			tag = nameSplit[2]
 		}
 		image = nameSplit[0]
-		img := path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, image)
+		img := path.Join(config.Global.DefaultRegistry, image)
 
 		r, w := io.Pipe()
 		opts := docker.PullImageOptions{
 			Repository:    img,
-			Registry:      config.GlobalConfig.Config.ERIS_REG_DEF,
+			Registry:      config.Global.DefaultRegistry,
 			Tag:           tag,
 			OutputStream:  w,
 			RawJSONStream: true,
@@ -159,7 +159,7 @@ func pullDefaultImages() error {
 
 			if err := util.DockerClient.PullImage(opts, auth); err != nil {
 				opts.Repository = image
-				opts.Registry = ver.ERIS_REG_BAK //not in global config...(also, won't even work unless we build & push updated images to dockerhub in addition to quay (which we should do)
+				opts.Registry = ver.BackupRegistry //not in global config...(also, won't even work unless we build & push updated images to dockerhub in addition to quay (which we should do)
 				if err := util.DockerClient.PullImage(opts, auth); err != nil {
 					ch <- util.DockerError(err)
 				}

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -57,7 +57,7 @@ func TestGetPubKey(t *testing.T) {
 	doPub.Address = testsGenAKey()
 
 	pub := new(bytes.Buffer)
-	config.GlobalConfig.Writer = pub
+	config.Global.Writer = pub
 	if err := GetPubKey(doPub); err != nil {
 		t.Fatalf("error getting pubkey: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestGetPubKey(t *testing.T) {
 	pubkey := util.TrimString(pub.String())
 
 	key := new(bytes.Buffer)
-	config.GlobalConfig.Writer = key
+	config.Global.Writer = key
 	doKey := def.NowDo()
 	doKey.Address = doPub.Address
 	if err := ConvertKey(doKey); err != nil {
@@ -331,7 +331,7 @@ func testListKeys(typ string) []string {
 //returns an addr for tests
 func testsGenAKey() string {
 	addr := new(bytes.Buffer)
-	config.GlobalConfig.Writer = addr
+	config.Global.Writer = addr
 	doGen := def.NowDo()
 	tests.IfExit(GenerateKey(doGen))
 

--- a/keys/writers.go
+++ b/keys/writers.go
@@ -27,7 +27,7 @@ func GenerateKey(do *definitions.Do) error {
 		return err
 	}
 
-	io.Copy(config.GlobalConfig.Writer, buf)
+	io.Copy(config.Global.Writer, buf)
 
 	return nil
 }
@@ -43,7 +43,7 @@ func GetPubKey(do *definitions.Do) error {
 		return err
 	}
 
-	io.Copy(config.GlobalConfig.Writer, buf)
+	io.Copy(config.Global.Writer, buf)
 
 	return nil
 }
@@ -141,7 +141,7 @@ func ConvertKey(do *definitions.Do) error {
 		return err
 	}
 
-	io.Copy(config.GlobalConfig.Writer, buf)
+	io.Copy(config.Global.Writer, buf)
 
 	return nil
 }

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -39,7 +39,7 @@ func LoadChainDefinition(chainName string) (*definitions.Chain, error) {
 	}
 
 	//definition, err := config.LoadViperConfig(filepath.Join(common.ChainsPath), chainName)
-	definition, err := config.LoadViperConfig(filepath.Join(common.ChainsPath, chainName), chainName)
+	definition, err := config.LoadViper(filepath.Join(common.ChainsPath, chainName), chainName)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func ChainsAsAService(chainName string) (*definitions.ServiceDefinition, error) 
 
 	setChainDefaults(chain)
 	chain.Service.Name = chain.Name
-	chain.Service.Image = path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_DB)
+	chain.Service.Image = path.Join(config.Global.DefaultRegistry, config.Global.ImageDB)
 	chain.Service.AutoData = true
 	chain.Service.Command = ErisChainStart
 
@@ -151,7 +151,7 @@ func MarshalChainDefinition(definition *viper.Viper, chain *definitions.Chain) e
 }
 
 func setChainDefaults(chain *definitions.Chain) error {
-	cfg, err := config.LoadViperConfig(filepath.Join(common.ChainsPath), "default")
+	cfg, err := config.LoadViper(filepath.Join(common.ChainsPath), "default")
 	if err != nil {
 		return err
 	}

--- a/loaders/loaders_test.go
+++ b/loaders/loaders_test.go
@@ -364,7 +364,7 @@ image          = "test image"
 		{`Service.Name`, s.Service.Name, name},
 		{`Service.AutoData`, s.Service.AutoData, true},
 		// [pv]: not "test image", but erisdb image. A bug?
-		{`Service.Image`, s.Service.Image, path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_DB)},
+		{`Service.Image`, s.Service.Image, path.Join(config.Global.DefaultRegistry, config.Global.ImageDB)},
 		{`Service.Environment`, s.Service.Environment, []string{"CHAIN_ID=" + name}},
 	} {
 		if !reflect.DeepEqual(entry.a, entry.b) {

--- a/loaders/pkgs.go
+++ b/loaders/pkgs.go
@@ -62,7 +62,7 @@ func LoadPackage(path, chainName string) (*definitions.Package, error) {
 
 // read the config file into viper
 func loadPackage(path string) (*viper.Viper, error) {
-	return config.LoadViperConfig(path, "package")
+	return config.LoadViper(path, "package")
 }
 
 // DefaultPackage creates a package definition structure

--- a/loaders/services.go
+++ b/loaders/services.go
@@ -134,7 +134,7 @@ func connectToAService(srv *definitions.Service, ops *definitions.Operation, typ
 }
 
 func loadServiceDefinition(servName string) (*viper.Viper, error) {
-	return config.LoadViperConfig(filepath.Join(common.ServicesPath), servName)
+	return config.LoadViper(filepath.Join(common.ServicesPath), servName)
 }
 
 func checkImage(srv *definitions.Service) error {

--- a/perform/perform.go
+++ b/perform/perform.go
@@ -113,7 +113,7 @@ func DockerRunData(ops *def.Operation, service *def.Service) (result []byte, err
 	}
 
 	// Return the logs as a byte slice, if possible.
-	reader, ok := config.GlobalConfig.Writer.(*bytes.Buffer)
+	reader, ok := config.Global.Writer.(*bytes.Buffer)
 	if ok {
 		return reader.Bytes(), nil
 	}
@@ -155,14 +155,14 @@ func DockerExecData(ops *def.Operation, service *def.Service) (buf *bytes.Buffer
 	}()
 
 	// Save writer values for later and restore on exit.
-	stdout, stderr := config.GlobalConfig.Writer, config.GlobalConfig.ErrorWriter
+	stdout, stderr := config.Global.Writer, config.Global.ErrorWriter
 	defer func() {
-		config.GlobalConfig.Writer, config.GlobalConfig.ErrorWriter = stdout, stderr
+		config.Global.Writer, config.Global.ErrorWriter = stdout, stderr
 	}()
 
 	buf = new(bytes.Buffer)
-	config.GlobalConfig.Writer = buf
-	config.GlobalConfig.ErrorWriter = buf
+	config.Global.Writer = buf
+	config.Global.ErrorWriter = buf
 
 	// Start the container.
 	log.WithField("=>", opts.Name).Info("Executing interactive data container")
@@ -303,14 +303,14 @@ func DockerExecService(srv *def.Service, ops *def.Operation) (buf *bytes.Buffer,
 	}()
 
 	// Save writer values for later and restore on exit.
-	stdout, stderr := config.GlobalConfig.Writer, config.GlobalConfig.ErrorWriter
+	stdout, stderr := config.Global.Writer, config.Global.ErrorWriter
 	defer func() {
-		config.GlobalConfig.Writer, config.GlobalConfig.ErrorWriter = stdout, stderr
+		config.Global.Writer, config.Global.ErrorWriter = stdout, stderr
 	}()
 
 	buf = new(bytes.Buffer)
-	config.GlobalConfig.Writer = buf
-	config.GlobalConfig.ErrorWriter = buf
+	config.Global.Writer = buf
+	config.Global.ErrorWriter = buf
 
 	// Start the container.
 	log.WithFields(log.Fields{
@@ -830,8 +830,8 @@ func startInteractiveContainer(opts docker.CreateContainerOptions, terminal bool
 func attachContainer(id string, terminal bool, attached chan struct{}) (docker.CloseWaiter, error) {
 	opts := docker.AttachToContainerOptions{
 		Container:    id,
-		OutputStream: io.MultiWriter(config.GlobalConfig.Writer, config.GlobalConfig.InteractiveWriter),
-		ErrorStream:  io.MultiWriter(config.GlobalConfig.ErrorWriter, config.GlobalConfig.InteractiveErrorWriter),
+		OutputStream: io.MultiWriter(config.Global.Writer, config.Global.InteractiveWriter),
+		ErrorStream:  io.MultiWriter(config.Global.ErrorWriter, config.Global.InteractiveErrorWriter),
 		Logs:         false,
 		Stream:       true,
 		Stdout:       true,
@@ -872,9 +872,9 @@ func logsContainer(id string, follow bool, tail string) error {
 	var writer io.Writer
 	var eWriter io.Writer
 
-	if config.GlobalConfig != nil {
-		writer = config.GlobalConfig.Writer
-		eWriter = config.GlobalConfig.ErrorWriter
+	if config.Global != nil {
+		writer = config.Global.Writer
+		eWriter = config.Global.ErrorWriter
 	} else {
 		writer = os.Stdout
 		eWriter = os.Stderr
@@ -1076,7 +1076,7 @@ func configureVolumesFromContainer(ops *def.Operation, service *def.Service) doc
 	opts := docker.CreateContainerOptions{
 		Name: util.UniqueName("interactive"),
 		Config: &docker.Config{
-			Image:           path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_DATA),
+			Image:           path.Join(config.Global.DefaultRegistry, config.Global.ImageData),
 			User:            "root",
 			WorkingDir:      dirs.ErisContainerRoot,
 			AttachStdout:    true,
@@ -1122,7 +1122,7 @@ func configureDataContainer(srv *def.Service, ops *def.Operation, mainContOpts *
 	//   that base image will not be present. in such cases use
 	//   the base eris data container.
 	if srv.Image == "" {
-		srv.Image = path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_DATA)
+		srv.Image = path.Join(config.Global.DefaultRegistry, config.Global.ImageData)
 	}
 
 	// Manipulate labels locally.

--- a/pkgs/operate.go
+++ b/pkgs/operate.go
@@ -155,7 +155,7 @@ func BootServicesAndChain(do *definitions.Do, pkg *definitions.Package) error {
 //
 func DefinePkgActionService(do *definitions.Do, pkg *definitions.Package) error {
 	do.Service.Name = pkg.Name + "_tmp_" + do.Name
-	do.Service.Image = path.Join(config.GlobalConfig.Config.ERIS_REG_DEF, config.GlobalConfig.Config.ERIS_IMG_PM)
+	do.Service.Image = path.Join(config.Global.DefaultRegistry, config.Global.ImagePM)
 	do.Service.AutoData = true
 	do.Service.EntryPoint = fmt.Sprintf("epm --chain chain:%s --sign keys:%s", do.ChainPort, do.KeysPort)
 	do.Service.WorkDir = path.Join(common.ErisContainerRoot, "apps", filepath.Base(do.Path))
@@ -206,7 +206,7 @@ func PerformAppActionService(do *definitions.Do, pkg *definitions.Package) error
 	}
 
 	// copy output to global writer. [csk note] this is a bit weird cause no output until the whole thing has finished...
-	io.Copy(config.GlobalConfig.Writer, buf)
+	io.Copy(config.Global.Writer, buf)
 
 	log.Info("Finished performing action")
 	return nil

--- a/pkgs/packages_test.go
+++ b/pkgs/packages_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -181,55 +180,6 @@ func TestKnownChainBoots(t *testing.T) {
 		t.Fatalf("expected data container to exist")
 	}
 
-	//doMake.Rm = true
-	//doMake.RmD = true
-	//if err := chains.StopChain(doMake); err != nil {
-	//	t.Fatalf("unexpected error removing chain: %v", err)
-	//}
-}
-
-// [zr] deprecate ... ?
-func _TestThrowawayChainBootsAndIsRemoved(t *testing.T) {
-	defer killKeys()
-
-	name := "good"
-	chainName := "temp"
-
-	pkg := loaders.DefaultPackage(name, chainName)
-	doBoot := definitions.NowDo()
-
-	if err := BootServicesAndChain(doBoot, pkg); err != nil {
-		CleanUp(doBoot, pkg)
-		t.Fatalf("error booting chans and services: %v", err)
-	}
-
-	running := util.ErisContainersByType(definitions.TypeChain, true)
-	var thisChain string
-	matcher := regexp.MustCompile(fmt.Sprintf("%s.*", name))
-	for _, chn := range running {
-		if matcher.MatchString(chn.ShortName) {
-			thisChain = chn.ShortName
-		}
-	}
-
-	if thisChain == "" {
-		t.Fatalf("could not find a matching chain running")
-	}
-
-	if !util.Running(definitions.TypeChain, thisChain) {
-		t.Fatalf("expecting chain container to run")
-	}
-	if !util.Exists(definitions.TypeData, thisChain) {
-		t.Fatalf("expected chain data container to exist")
-	}
-
-	CleanUp(doBoot, pkg)
-	if util.Running(definitions.TypeService, thisChain) {
-		t.Fatalf("expected chain stopped")
-	}
-	if util.Exists(definitions.TypeData, thisChain) {
-		t.Fatalf("expected data container does not exist")
-	}
 }
 
 func TestLinkingToServicesAndChains(t *testing.T) {
@@ -283,8 +233,8 @@ func TestLinkingToServicesAndChains(t *testing.T) {
 		t.Fatalf("wrong service name, expected %s got %s", pkg.Name+"_tmp_"+do.Name, do.Service.Name)
 	}
 
-	if do.Service.Image != path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_PM) {
-		t.Fatalf("wrong service image, expected %s got %s", path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_PM), do.Service.Image)
+	if do.Service.Image != path.Join(version.DefaultRegistry, version.ImagePM) {
+		t.Fatalf("wrong service image, expected %s got %s", path.Join(version.DefaultRegistry, version.ImagePM), do.Service.Image)
 	}
 
 	if !do.Service.AutoData {

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/eris-ltd/eris-cli/util"
 	ver "github.com/eris-ltd/eris-cli/version"
 
+	"github.com/eris-ltd/common/go/common"
+
 	log "github.com/eris-ltd/eris-logger"
 )
 
@@ -125,7 +127,7 @@ func TestExecServiceBadCommandLine(t *testing.T) {
 	start(t, servName, true)
 
 	buf := new(bytes.Buffer)
-	config.GlobalConfig.Writer = buf
+	config.Global.Writer = buf
 
 	do := def.NowDo()
 	do.Name = servName
@@ -221,7 +223,7 @@ func TestMakeService(t *testing.T) {
 	do := def.NowDo()
 	servName := "keys"
 	do.Name = servName
-	do.Operations.Args = []string{path.Join(ver.ERIS_REG_DEF, ver.ERIS_IMG_KEYS)}
+	do.Operations.Args = []string{path.Join(ver.DefaultRegistry, ver.ImageKeys)}
 	if err := MakeService(do); err != nil {
 		t.Fatalf("expected a new service to be created, got %v", err)
 	}
@@ -308,7 +310,7 @@ func TestCatService(t *testing.T) {
 		t.Fatalf("expected cat to succeed, got %v", err)
 	}
 
-	if out := tests.FileContents(filepath.Join(config.GlobalConfig.ErisDir, "services", "ipfs.toml")); out != do.Result {
+	if out := tests.FileContents(filepath.Join(common.ErisRoot, "services", "ipfs.toml")); out != do.Result {
 		t.Fatalf("expected local config to be returned %v, got %v", out, do.Result)
 	}
 }

--- a/tests/testing_utils.go
+++ b/tests/testing_utils.go
@@ -31,17 +31,14 @@ const (
 	Quick
 )
 
-func TestsInit(steps int, services ...string) (err error) {
-	// TODO: make a reader/pipe so we can see what is written from tests.
-	config.GlobalConfig, err = config.SetGlobalObject(os.Stdout, os.Stderr)
+func TestsInit(steps int) (err error) {
+	common.ChangeErisRoot(ErisDir)
+	common.InitErisDir()
+
+	config.Global, err = config.New(os.Stdout, os.Stderr)
 	if err != nil {
 		IfExit(fmt.Errorf("TRAGIC. Could not set global config.\n"))
 	}
-
-	// common is initialized on import so we have to manually override
-	// these variables to ensure that the tests run correctly.
-	config.ChangeErisDir(ErisDir)
-	common.InitErisDir()
 
 	// Don't connect to Docker daemon and don't pull default definitions.
 	if steps == Quick {

--- a/tests/testing_utils.go
+++ b/tests/testing_utils.go
@@ -31,7 +31,7 @@ const (
 	Quick
 )
 
-func TestsInit(steps int) (err error) {
+func TestsInit(steps int, services ...string) (err error) {
 	common.ChangeErisRoot(ErisDir)
 	common.InitErisDir()
 
@@ -58,7 +58,7 @@ func TestsInit(steps int) (err error) {
 	do.Pull = false //don't pull imgs
 	do.Yes = true   //over-ride command-line prompts
 	do.Quiet = true
-	do.Source = "rawgit" //use "rawgit" if ts down
+	do.Source = "rawgit"
 	do.ServicesSlice = services
 	if err := ini.Initialize(do); err != nil {
 		IfExit(fmt.Errorf("TRAGIC. Could not initialize the eris dir: %s.\n", err))

--- a/util/containers_test.go
+++ b/util/containers_test.go
@@ -304,7 +304,7 @@ func create(t, name string) error {
 	labels[def.LabelShortName] = name
 	labels[def.LabelType] = t
 
-	keysImage := path.Join(version.ERIS_REG_DEF, version.ERIS_IMG_KEYS)
+	keysImage := path.Join(version.DefaultRegistry, version.ImageKeys)
 	opts := docker.CreateContainerOptions{
 		Name: ContainerName(t, name),
 		Config: &docker.Config{

--- a/util/inspect.go
+++ b/util/inspect.go
@@ -208,7 +208,7 @@ func writeTemplate(container interface{}, toParse string) error {
 		return err
 	}
 
-	if err = tmpl.Execute(config.GlobalConfig.Writer, container); err != nil {
+	if err = tmpl.Execute(config.Global.Writer, container); err != nil {
 		return err
 	}
 

--- a/util/migrate_dirs_test.go
+++ b/util/migrate_dirs_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/eris-ltd/eris-cli/config"
 
+	"github.com/eris-ltd/common/go/common"
 	log "github.com/eris-ltd/eris-logger"
 )
 
@@ -111,10 +112,14 @@ func TestMigrationMoveFile(t *testing.T) {
 }
 
 func testsInit() error {
-	var err error
+	common.ChangeErisRoot(erisDir)
+
 	// TODO: make a reader/pipe so we can see what is written from tests.
-	config.GlobalConfig, err = config.SetGlobalObject(os.Stdout, os.Stderr)
-	ifExit(err)
+	var err error
+	config.Global, err = config.New(os.Stdout, os.Stderr)
+	if err != nil {
+		ifExit(err)
+	}
 
 	if err := os.Mkdir(erisDir, 0777); err != nil {
 		if runtime.GOOS != "windows" {
@@ -122,7 +127,6 @@ func testsInit() error {
 			ifExit(err)
 		}
 	}
-	config.ChangeErisDir(erisDir)
 
 	return nil
 }

--- a/vendor/github.com/eris-ltd/common/go/common/dirs_and_files.go
+++ b/vendor/github.com/eris-ltd/common/go/common/dirs_and_files.go
@@ -130,6 +130,41 @@ func HomeDir() string {
 	}
 }
 
+// ChangeErisRoot points the root of the Eris settings hierarchy
+// to the erisDir location.
+func ChangeErisRoot(erisDir string) {
+	if os.Getenv("TESTING") == "true" {
+		return
+	}
+
+	ErisRoot = erisDir
+
+	// Major directories.
+	ActionsPath = filepath.Join(ErisRoot, "actions")
+	AppsPath = filepath.Join(ErisRoot, "apps")     // previously "dapps"
+	ChainsPath = filepath.Join(ErisRoot, "chains") // previously "blockchains"
+	KeysPath = filepath.Join(ErisRoot, "keys")
+	RemotesPath = filepath.Join(ErisRoot, "remotes")
+	ScratchPath = filepath.Join(ErisRoot, "scratch")
+	ServicesPath = filepath.Join(ErisRoot, "services")
+
+	// Chains Directories
+	DefaultChainPath = filepath.Join(ChainsPath, "default")
+	AccountsTypePath = filepath.Join(ChainsPath, "account-types")
+	ChainTypePath = filepath.Join(ChainsPath, "chain-types")
+
+	// Keys Directories
+	KeysDataPath = filepath.Join(KeysPath, "data")
+	KeyNamesPath = filepath.Join(KeysPath, "names")
+
+	// Scratch Directories (basically eris' cache) (globally coordinated)
+	DataContainersPath = filepath.Join(ScratchPath, "data")
+	LanguagesScratchPath = filepath.Join(ScratchPath, "languages") // previously "~/.eris/languages"
+
+	// Services Directories
+	PersonalServicesPath = filepath.Join(ServicesPath, "global")
+}
+
 func AbsolutePath(Datadir string, filename string) string {
 	if filepath.IsAbs(filename) {
 		return filename

--- a/version/images.go
+++ b/version/images.go
@@ -7,14 +7,14 @@ import (
 )
 
 var (
-	ERIS_REG_DEF = "quay.io"
-	ERIS_REG_BAK = "" //dockerhub
+	DefaultRegistry = "quay.io"
+	BackupRegistry  = ""
 
-	ERIS_IMG_DATA = fmt.Sprintf("eris/data:%s", VERSION)
-	ERIS_IMG_KEYS = fmt.Sprintf("eris/keys:%s", VERSION)
-	ERIS_IMG_DB   = fmt.Sprintf("eris/erisdb:%s", VERSION)
-	ERIS_IMG_PM   = fmt.Sprintf("eris/epm:%s", VERSION)
-	ERIS_IMG_CM   = fmt.Sprintf("eris/eris-cm:%s", VERSION)
-	ERIS_IMG_COMP = fmt.Sprintf("eris/compilers:%s", VERSION)
-	ERIS_IMG_IPFS = "eris/ipfs"
+	ImageData      = fmt.Sprintf("eris/data:%s", VERSION)
+	ImageKeys      = fmt.Sprintf("eris/keys:%s", VERSION)
+	ImageDB        = fmt.Sprintf("eris/erisdb:%s", VERSION)
+	ImagePM        = fmt.Sprintf("eris/epm:%s", VERSION)
+	ImageCM        = fmt.Sprintf("eris/eris-cm:%s", VERSION)
+	ImageIPFS      = "eris/ipfs"
+	ImageCompilers = fmt.Sprintf("eris/compilers:%s", VERSION)
 )

--- a/version/images_arm.go
+++ b/version/images_arm.go
@@ -7,14 +7,14 @@ import (
 const ARCH = "arm"
 
 var (
-	ERIS_REG_DEF = "quay.io"
-	ERIS_REG_BAK = "" //dockerhub
+	DefaultRegistry = "quay.io"
+	BackupRegistry  = ""
 
-	ERIS_IMG_DATA = fmt.Sprintf("eris/data:%s-%s", ARCH, VERSION)
-	ERIS_IMG_KEYS = fmt.Sprintf("eris/keys:%s-%s", ARCH, VERSION)
-	ERIS_IMG_DB   = fmt.Sprintf("eris/erisdb:%s-%s", ARCH, VERSION)
-	ERIS_IMG_PM   = fmt.Sprintf("eris/epm:%s-%s", ARCH, VERSION)
-	ERIS_IMG_CM   = fmt.Sprintf("eris/eris-cm:%s-%s", ARCH, VERSION)
-	ERIS_IMG_COMP = fmt.Sprintf("eris/compilers:%s-%s", ARCH, VERSION)
-	ERIS_IMG_IPFS = fmt.Sprintf("eris/ipfs:%s", ARCH)
+	ImageData      = fmt.Sprintf("eris/data:%s-%s", ARCH, VERSION)
+	ImageKeys      = fmt.Sprintf("eris/keys:%s-%s", ARCH, VERSION)
+	ImageDB        = fmt.Sprintf("eris/erisdb:%s-%s", ARCH, VERSION)
+	ImagePM        = fmt.Sprintf("eris/epm:%s-%s", ARCH, VERSION)
+	ImageCM        = fmt.Sprintf("eris/eris-cm:%s-%s", ARCH, VERSION)
+	ImageCompilers = fmt.Sprintf("eris/compilers:%s-%s", ARCH, VERSION)
+	ImageIPFS      = fmt.Sprintf("eris/ipfs:%s", ARCH)
 )


### PR DESCRIPTION
* Interpolate `ErisConfig` with `ErisCli` struct:
  ```
  config.GlobalConfig.Writer → config.Global.Writer
  config.GlobalConfig.Config.IpfsHost → config.Global.IpfsHost
  ```

* Remove `ErisDir` field and `ChangeErisDir()` function from `config` altogether (move to `common`).
* Rename functions:

  ```
  SetGlobalObject(...) → New(...)
  LoadGlobalConfig(...) → Load(...)
  LoadViperConfig(...) → LoadViper(...)
  SaveGlobalConfig(...) → Save(...)
  GetConfigValue(...) → (dropped)
  ChangeErisDir(...) → common.ChangeErisRoot(...)
  ```
* Rename images handling variables to match `eris.toml` config style (camel case):
  
  ```
  ERIS_REG_DEF → DefaultRegistry
  ERIS_REG_BAK → BackupRegistry
  ERIS_IMG_DATA → ImageData
  ERIS_IMG_KEYS → ImageKeys
  ERIS_IMG_IPFS → ImageIPFS
  ERIS_IMG_DB → ImageDB
  ERIS_IMG_PM → ImagePM
  ERIS_IMG_CM → ImageCM
  ```