### PR TITLE
Remove duplicate output when running `cm` image interactively

### DIFF
--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -448,7 +448,7 @@ func MakeChain(cmd *cobra.Command, args []string) {
 		cmd.Help()
 		IfExit(fmt.Errorf("\nThe --account-types and --chain-type flags are incompatible with the --known flag. Please use only one of these."))
 	}
-	if !do.Known {
+	if !do.Known && len(do.AccountTypes) == 0 && do.ChainType == "" {
 		config.Global.InteractiveWriter = os.Stdout
 		config.Global.InteractiveErrorWriter = os.Stderr
 		do.Operations.Terminal = true


### PR DESCRIPTION
* Fix the interactive condition when turning the interactive writers on or off.
* Fixes #865.