### PR TITLE
Handle Cobra failing results for bad arguments

### DIFF
--- a/cmd/eris.go
+++ b/cmd/eris.go
@@ -108,7 +108,7 @@ func Execute() {
 	InitializeConfig()
 	AddGlobalFlags()
 	AddCommands()
-	ErisCmd.Execute()
+	IfExit(ErisCmd.Execute())
 }
 
 // Define the commands


### PR DESCRIPTION
* Return exit code 1 if Cobra library can't parse command line arguments.
* Closes #905.