### PR TITLE
add [--save] flag to [eris keys gen]

### DIFF
--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -27,30 +27,25 @@ func buildKeysCommand() {
 	Keys.AddCommand(keysPub)
 	Keys.AddCommand(keysExport)
 	Keys.AddCommand(keysImport)
-	Keys.AddCommand(keysConvert)
 	Keys.AddCommand(keysList)
 	addKeysFlags()
 }
 
 var keysGen = &cobra.Command{
 	Use:   "gen",
-	Short: "generates an unsafe key using the keys container",
-	Long: `generates a key using the keys container
+	Short: "generates an unsafe key in the keys container",
+	Long: `generates an unsafe key in the keys container
 
-Key is saved in keys data container and can be exported to host
-with the [eris keys export] command.
-
-Command is equivalent to [eris services exec keys "eris-keys gen --no-pass"]`,
+Key is created in keys data container and can be exported to host
+by using the [--save] flag or by running [eris keys export ADDR].`,
 	Run: GenerateKey,
 }
 
 var keysPub = &cobra.Command{
 	Use:   "pub ADDR",
 	Short: "returns a machine readable pubkey given an address",
-	Long: `returns a machine readable pubkey given an address
-
-Command is equivalent to [eris services exec keys "eris-keys pub --addr ADDR"]`,
-	Run: GetPubKey,
+	Long:  `returns a machine readable pubkey given an address`,
+	Run:   GetPubKey,
 }
 
 var keysExport = &cobra.Command{
@@ -59,9 +54,7 @@ var keysExport = &cobra.Command{
 	Long: `export a key from container to host
 
 Takes a key from /home/eris/.eris/keys/data/ADDR/ADDR in the keys container
-and copies it to $HOME/user/.eris/keys/data/ADDR/ADDR on the host.
-
-Optionally specify host destination with --dest.`,
+and copies it to $HOME/user/.eris/keys/data/ADDR/ADDR on the host.`,
 	Run: ExportKey,
 }
 
@@ -74,17 +67,6 @@ Takes a key from $HOME/user/.eris/keys/data/ADDR/ADDR
 on the host and copies it to /home/eris/.eris/keys/data/ADDR/ADDR
 in the keys container.`,
 	Run: ImportKey,
-}
-
-var keysConvert = &cobra.Command{
-	Use:   "convert ADDR",
-	Short: "convert and eris-keys key to Tendermint key",
-	Long: `convert and eris-keys key to Tendermint key
-
-Command is equivalent to [eris services exec keys "mintkey mint ADDR"]
-
-Usually will be piped into $HOME/.eris/chains/newChain/priv_validator.json`,
-	Run: ConvertKey,
 }
 
 var keysList = &cobra.Command{
@@ -100,6 +82,10 @@ Latter flag is equivalent to:
 }
 
 func addKeysFlags() {
+	// [zr] eventually we'll want to flip (both?) these bools. definitely the latter, probably the former
+	keysGen.Flags().BoolVarP(&do.Save, "save", "", false, "export the key to host following creation")
+	//keysGen.Flags().BoolVarP(&do.Password, "passwd", "", false, "require a password prompt to generate the key")
+
 	keysExport.Flags().StringVarP(&do.Address, "addr", "", "", "address of key to export")
 	keysExport.Flags().BoolVarP(&do.All, "all", "", false, "export all keys. do not provide any arguments")
 
@@ -113,6 +99,10 @@ func addKeysFlags() {
 
 func GenerateKey(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(0, "eq", cmd, args))
+
+	// TODO implement once we move to using keys client exclusively
+	// if do.Password {}
+
 	IfExit(keys.GenerateKey(do))
 }
 
@@ -140,12 +130,6 @@ func ImportKey(cmd *cobra.Command, args []string) {
 		do.Address = strings.TrimSpace(args[0])
 	}
 	IfExit(keys.ImportKey(do))
-}
-
-func ConvertKey(cmd *cobra.Command, args []string) {
-	IfExit(ArgCheck(1, "eq", cmd, args))
-	do.Address = strings.TrimSpace(args[0])
-	IfExit(keys.ConvertKey(do))
 }
 
 func ListKeys(cmd *cobra.Command, args []string) {

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -24,7 +24,6 @@ See https://docs.erisindustries.com/documentation/eris-keys/ for more info.`,
 
 func buildKeysCommand() {
 	Keys.AddCommand(keysGen)
-	Keys.AddCommand(keysPub)
 	Keys.AddCommand(keysExport)
 	Keys.AddCommand(keysImport)
 	Keys.AddCommand(keysList)
@@ -39,13 +38,6 @@ var keysGen = &cobra.Command{
 Key is created in keys data container and can be exported to host
 by using the [--save] flag or by running [eris keys export ADDR].`,
 	Run: GenerateKey,
-}
-
-var keysPub = &cobra.Command{
-	Use:   "pub ADDR",
-	Short: "returns a machine readable pubkey given an address",
-	Long:  `returns a machine readable pubkey given an address`,
-	Run:   GetPubKey,
 }
 
 var keysExport = &cobra.Command{
@@ -104,12 +96,6 @@ func GenerateKey(cmd *cobra.Command, args []string) {
 	// if do.Password {}
 
 	IfExit(keys.GenerateKey(do))
-}
-
-func GetPubKey(cmd *cobra.Command, args []string) {
-	IfExit(ArgCheck(1, "eq", cmd, args))
-	do.Address = strings.TrimSpace(args[0])
-	IfExit(keys.GetPubKey(do))
 }
 
 func ExportKey(cmd *cobra.Command, args []string) {

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -27,6 +27,8 @@ type Do struct {
 	Overwrite     bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Dump          bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	LocalCompiler bool     `mapstructure:"," json:"," yaml:"," toml:","`
+	Save          bool     `mapstructure:"," json:"," yaml:"," toml:","`
+	Password      bool     `mapstructure:"," json:"," yaml:"," toml:","`
 	Lines         int      `mapstructure:"," json:"," yaml:"," toml:","` // XXX: for tail and logs
 	Timeout       uint     `mapstructure:"," json:"," yaml:"," toml:","`
 	N             uint     `mapstructure:"," json:"," yaml:"," toml:","`

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -46,36 +45,6 @@ func TestGenerateKey(t *testing.T) {
 
 	if address != output[0] {
 		t.Fatalf("Expected (%s), got (%s)", address, output[0])
-	}
-}
-
-func TestGetPubKey(t *testing.T) {
-	testStartKeys(t)
-	defer testKillService(t, "keys", true)
-
-	doPub := def.NowDo()
-	doPub.Address = testsGenAKey()
-
-	pub := new(bytes.Buffer)
-	config.Global.Writer = pub
-	if err := GetPubKey(doPub); err != nil {
-		t.Fatalf("error getting pubkey: %v", err)
-	}
-
-	pubkey := util.TrimString(pub.String())
-
-	key := new(bytes.Buffer)
-	config.Global.Writer = key
-	doKey := def.NowDo()
-	doKey.Address = doPub.Address
-	if err := ConvertKey(doKey); err != nil {
-		t.Fatalf("error converting key: %v", err)
-	}
-
-	converted := regexp.MustCompile(`"pub_key":\[1,"([^"]+)"\]`).FindStringSubmatch(key.String())[1]
-
-	if converted != pubkey {
-		t.Fatalf("Expected (%s), got (%s)", pubkey, converted)
 	}
 }
 
@@ -241,10 +210,6 @@ func TestImportKeySingle(t *testing.T) {
 	if keyOnHost != keyInCont {
 		t.Fatalf("Expected (%s), got (%s)", keyOnHost, keyInCont)
 	}
-}
-
-func TestConvertKey(t *testing.T) {
-	// tested in TestGetPubKey
 }
 
 func TestListKeyContainer(t *testing.T) {

--- a/keys/writers.go
+++ b/keys/writers.go
@@ -49,22 +49,6 @@ func GenerateKey(do *definitions.Do) error {
 	return nil
 }
 
-func GetPubKey(do *definitions.Do) error {
-	do.Name = "keys"
-	if err := srv.EnsureRunning(do); err != nil {
-		return err
-	}
-
-	buf, err := srv.ExecHandler(do.Name, []string{"eris-keys", "pub", "--addr", do.Address})
-	if err != nil {
-		return err
-	}
-
-	io.Copy(config.Global.Writer, buf)
-
-	return nil
-}
-
 func ExportKey(do *definitions.Do) error {
 	do.Name = "keys"
 	if err := srv.EnsureRunning(do); err != nil {


### PR DESCRIPTION
- closes #794 (`--pass` deferred FTTB)
- `eris keys gen --save` will generate a key in the keys container and export it to the host. This is equivalent to running:
```
eris keys gen
eris keys export ADDR
```
- **deprecation notice:** `eris keys pub` is removed