### PR TITLE
update IPFS and compilers URLs to monax.io

### DIFF
--- a/cmd/pkgs.go
+++ b/cmd/pkgs.go
@@ -83,5 +83,5 @@ func formCompilers() string {
 	maj, _ := strconv.Atoi(verSplit[0])
 	min, _ := strconv.Atoi(verSplit[1])
 	pat, _ := strconv.Atoi(verSplit[2])
-	return fmt.Sprintf("https://compilers.eris.industries:1%01d%02d%01d", maj, min, pat)
+	return fmt.Sprintf("https://compilers.monax.io:1%01d%02d%01d", maj, min, pat)
 }

--- a/cmd/pkgs_arm.go
+++ b/cmd/pkgs_arm.go
@@ -115,5 +115,5 @@ func formCompilers() string {
 	maj, _ := strconv.Atoi(verSplit[0])
 	min, _ := strconv.Atoi(verSplit[1])
 	pat, _ := strconv.Atoi(verSplit[2])
-	return fmt.Sprintf("https://compilers.eris.industries:1%01d%02d%01d", maj, min, pat)
+	return fmt.Sprintf("https://compilers.monax.io:1%01d%02d%01d", maj, min, pat)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -136,7 +136,7 @@ func SetDefaults() (*viper.Viper, error) {
 	config.SetDefault("ImagesPullTimeout", "15m")
 
 	// Compiler defaults.
-	config.SetDefault("CompilersHost", "https://compilers.eris.industries")
+	config.SetDefault("CompilersHost", "https://compilers.monax.io")
 	config.SetDefault("CompilersPort", "1"+strings.Replace(strings.Split(ver.VERSION, "-")[0], ".", "", -1))
 
 	// Image defaults.

--- a/vendor/github.com/eris-ltd/common/go/ipfs/url_handler.go
+++ b/vendor/github.com/eris-ltd/common/go/ipfs/url_handler.go
@@ -27,8 +27,7 @@ func IPFSBaseAPIUrl() string {
 
 func SexyUrl() string {
 	//TODO load balancer (when one isn't enough)
-	// also hosts toadserver (for init) at port 11113
-	return "http://ipfs.erisbootstrap.sexy"
+	return "http://ipfs.monax.io"
 }
 
 func IPFSUrl() string {


### PR DESCRIPTION
- s/eris.industries/monax.io in compilers & ipfs URLs
- closes #956, #957 
- related to https://github.com/eris-ltd/common/pull/85
