### PR TITLE
fix chains restart & remove latent code

### DIFF
--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -247,25 +247,6 @@ func TestLogsChain(t *testing.T) {
 	}
 }
 
-func _TestUpdateChain(t *testing.T) {
-	defer testutil.RemoveAllContainers()
-
-	create(t, chainName)
-	defer kill(t, chainName)
-
-	do := def.NowDo()
-	do.Name = chainName
-	do.Pull = false
-	do.Operations.PublishAllPorts = true
-	if err := UpdateChain(do); err != nil {
-		t.Fatalf("expected chain to update, got %v", err)
-	}
-
-	if !util.Running(def.TypeChain, chainName) {
-		t.Fatalf("expecting chain running")
-	}
-}
-
 func TestInspectChain(t *testing.T) {
 	defer testutil.RemoveAllContainers()
 

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -273,27 +273,6 @@ func PortsChain(do *definitions.Do) error {
 	return nil
 }
 
-func UpdateChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name)
-	if err != nil {
-		return err
-	}
-
-	// set the right env vars and command
-	if util.IsChain(chain.Name, true) {
-		chain.Service.Environment = []string{fmt.Sprintf("CHAIN_ID=%s", do.Name)}
-		chain.Service.Environment = append(chain.Service.Environment, do.Env...)
-		chain.Service.Links = append(chain.Service.Links, do.Links...)
-		chain.Service.Command = loaders.ErisChainStart
-	}
-
-	err = perform.DockerRebuild(chain.Service, chain.Operations, do.Pull, do.Timeout)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func RemoveChain(do *definitions.Do) error {
 	chain, err := loaders.LoadChainDefinition(do.Name)
 	if err != nil {

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -250,35 +250,18 @@ var chainsRemove = &cobra.Command{
 	Short: "remove an installed chain",
 	Long: `remove an installed chain
 
-Command will remove the chain's container but will not
-remove the chain definition file.`,
+Command will remove the chain's container but not its 
+local directory or data container unless specified.`,
 	Run: RmChain,
-}
-
-var chainsUpdate = &cobra.Command{
-	Use:   "update NAME",
-	Short: "update an installed chain",
-	Long: `update an installed chain, or install it if it has not been installed
-
-Functionally this command will perform the following sequence:
-
-1. Stop the chain (if it is running).
-2. Remove the container which ran the chain.
-3. Pull the image the container uses from a hub.
-4. Rebuild the container from the updated image.
-5. Restart the chain (if it was previously running).
-
-NOTE: If the chain uses data containers those will not be affected
-by the update command.
-`,
-	Run: UpdateChain,
 }
 
 var chainsRestart = &cobra.Command{
 	Use:   "restart NAME",
-	Short: "restart chain",
-	Long:  `restart chain`,
-	Run:   RestartChain,
+	Short: "restart a chain",
+	Long: `restart a chain
+
+Command will gracefully stop then start a chain.`,
+	Run: RestartChain,
 }
 
 var chainsCat = &cobra.Command{
@@ -335,11 +318,6 @@ func addChainsFlags() {
 	buildFlag(chainsRemove, do, "rm-volumes", "chain")
 	chainsRemove.Flags().BoolVarP(&do.RmHF, "dir", "", false, "remove the chain directory in "+util.Tilde(ChainsPath))
 
-	buildFlag(chainsUpdate, do, "pull", "chain")
-	buildFlag(chainsUpdate, do, "timeout", "chain")
-	buildFlag(chainsUpdate, do, "env", "chain")
-	buildFlag(chainsUpdate, do, "links", "chain")
-
 	buildFlag(chainsStop, do, "rm", "chain")
 	buildFlag(chainsStop, do, "data", "chain")
 	buildFlag(chainsStop, do, "force", "chain")
@@ -354,15 +332,12 @@ func addChainsFlags() {
 }
 
 func StartChain(cmd *cobra.Command, args []string) {
-	// [csk]: if no args should we just start the checkedout chain?
-	// [zr]: yes, eventually
 	IfExit(ArgCheck(1, "ge", cmd, args))
 	do.Name = args[0]
 	IfExit(chns.StartChain(do))
 }
 
 func LogChain(cmd *cobra.Command, args []string) {
-	// [csk]: if no args should we just start the checkedout chain?
 	IfExit(ArgCheck(1, "ge", cmd, args))
 	do.Name = args[0]
 	IfExit(chns.LogsChain(do))
@@ -391,7 +366,6 @@ func ExecChain(cmd *cobra.Command, args []string) {
 }
 
 func StopChain(cmd *cobra.Command, args []string) {
-	// [csk]: if no args should we just start the checkedout chain?
 	IfExit(ArgCheck(1, "ge", cmd, args))
 	do.Name = args[0]
 	IfExit(chns.StopChain(do))
@@ -451,7 +425,6 @@ func CurrentChain(cmd *cobra.Command, args []string) {
 }
 
 func CatChain(cmd *cobra.Command, args []string) {
-	// [csk]: if no args should we just start the checkedout chain?
 	IfExit(ArgCheck(2, "ge", cmd, args))
 	do.Name = args[0]
 	do.Type = args[1]
@@ -466,7 +439,6 @@ func PortsChain(cmd *cobra.Command, args []string) {
 }
 
 func InspectChain(cmd *cobra.Command, args []string) {
-	// [csk]: if no args should we just start the checkedout chain?
 	IfExit(ArgCheck(1, "ge", cmd, args))
 
 	do.Name = args[0]
@@ -500,18 +472,11 @@ func ListChains(cmd *cobra.Command, args []string) {
 	IfExit(list.Containers(def.TypeChain, do.Format, do.Running))
 }
 
-func UpdateChain(cmd *cobra.Command, args []string) {
-	// [csk]: if no args should we just start the checkedout chain?
-	IfExit(ArgCheck(1, "ge", cmd, args))
-	do.Name = args[0]
-	IfExit(chns.UpdateChain(do))
-}
-
 func RestartChain(cmd *cobra.Command, args []string) {
 	IfExit(ArgCheck(1, "ge", cmd, args))
 	do.Name = args[0]
-	do.Pull = false
-	IfExit(chns.UpdateChain(do))
+	IfExit(chns.StopChain(do))
+	IfExit(chns.StartChain(do))
 }
 
 func RmChain(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
- closes #967 
- fixes `chains restart` to simply stop/start gracefully rather than a docker re-build
- removes deprecated `chains update` code

