### PR TITLE
clean: don't remove chain directories by default

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -30,7 +30,7 @@ func addCleanFlags() {
 	Clean.Flags().BoolVarP(&do.Yes, "yes", "y", false, "overrides prompts prior to removing things")
 	Clean.Flags().BoolVarP(&do.All, "all", "a", false, "removes everything, stopping short of uninstalling eris")
 	Clean.Flags().BoolVarP(&do.Containers, "containers", "c", true, "remove all eris containers")
-	Clean.Flags().BoolVarP(&do.ChnDirs, "chains", "", true, "remove latent chain data in "+util.Tilde(ChainsPath))
+	Clean.Flags().BoolVarP(&do.ChnDirs, "chains", "", false, "remove latent chain data in "+util.Tilde(ChainsPath))
 	Clean.Flags().BoolVarP(&do.Scratch, "scratch", "s", true, "remove contents of "+util.Tilde(ScratchPath))
 	Clean.Flags().BoolVarP(&do.RmD, "dir", "", false, "remove the eris home directory in "+util.Tilde(ErisRoot))
 	Clean.Flags().BoolVarP(&do.Images, "images", "i", false, "remove all eris docker images")


### PR DESCRIPTION
- closes #952 
- flips default bool. to remove stale chain directories, use `--chains`
