### PR TITLE
version compilers definition file; fixes #972

### DIFF
--- a/initialize/default_compilers.go
+++ b/initialize/default_compilers.go
@@ -1,0 +1,44 @@
+package initialize
+
+import (
+	"path"
+
+	"github.com/eris-ltd/eris-cli/version"
+)
+
+func defServiceCompilers() string {
+	return `
+# For more information on configurations, see the services specification:
+# https://monax.io/docs/documentation/cli/latest/specifications/services_specification/
+
+# These fields marshal roughly into the [docker run] command, see:
+# https://docs.docker.com/engine/reference/run/
+
+# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+name           = "compilers"
+description = """
+Monax's Solidity Compiler Server.
+
+This eris service compiles smart contract languages.
+"""
+
+status = "beta"
+
+[service]
+image          = "` + path.Join(version.DefaultRegistry, version.ImageCompilers) + `"
+data_container = true
+ports          = [  ]
+volumes        = [  ]
+environment    = [  ]
+
+[maintainer]
+name = "Monax Industries"
+email = "support@monax.io"
+
+[location]
+repository = "https://github.com/eris-ltd/eris-compilers"
+website = "https://monax.io/docs/documentation/compilers"
+`
+}

--- a/initialize/default_keys.go
+++ b/initialize/default_keys.go
@@ -31,9 +31,12 @@ image = "` + path.Join(version.DefaultRegistry, version.ImageKeys) + `"
 data_container = true
 exec_host = "ERIS_KEYS_HOST"
 
+[maintainer]
+name = "Monax Industries"
+email = "support@monax.io"
+
 [location]
-dockerfile = "https://github.com/eris-ltd/eris-keys/blob/master/Dockerfile"
 repository = "https://github.com/eris-ltd/eris-keys"
-website = "https://monax.io/docs/documentation/keys/"
+website = "https://monax.io/docs/documentation/keys"
 `
 }

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -32,6 +32,8 @@ func dropServiceDefaults(dir string, services []string) error {
 			err = writeDefaultFile(common.ServicesPath, "keys.toml", defServiceKeys)
 		case "ipfs":
 			err = writeDefaultFile(common.ServicesPath, "ipfs.toml", defServiceIPFS)
+		case "compilers":
+			err = writeDefaultFile(common.ServicesPath, "compilers.toml", defServiceCompilers)
 		default:
 			err = drops([]string{service}, "services", dir)
 		}
@@ -85,7 +87,7 @@ func pullDefaultImages(images []string) error {
 	// Spacer.
 	log.Warn()
 
-	log.Warn("Pulling default Docker images from "+config.Global.DefaultRegistry)
+	log.Warn("Pulling default Docker images from " + config.Global.DefaultRegistry)
 	for i, image := range images {
 		log.WithField("image", image).Warnf("Pulling image %d out of %d", i+1, len(images))
 


### PR DESCRIPTION
Changes:

* treats compilers service definition same way that keys are treated. 

This is a fine short-term measure. However, we should be reconciling this init writing pipeline and use go templates along with default structs rather than handling it like strings as we currently do.