### PR TITLE
utilize a common docker building paradigm across the stack

### DIFF
--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -223,12 +223,19 @@ func TestChainsNewKeysImported(t *testing.T) {
 		t.Fatalf("expecting to list keys, got %v", err)
 	}
 
-	keysOutString := strings.Fields(strings.TrimSpace(keysOut.String()))[0]
+	keysOutString0 := strings.Fields(strings.TrimSpace(keysOut.String()))[0]
 
-	args := []string{"cat", fmt.Sprintf("/home/eris/.eris/keys/data/%s/%s", keysOutString, keysOutString)}
+	args := []string{"cat", fmt.Sprintf("/home/eris/.eris/keys/data/%s/%s", keysOutString0, keysOutString0)}
 
-	if out := exec(t, chain, args); !strings.Contains(out, keysOutString) {
-		t.Fatalf("expected to find keys in container, got %v", out)
+	keysOut1, err := services.ExecHandler("keys", args)
+	if err != nil {
+		t.Fatalf("expecting to cat keys, got %v", err)
+	}
+
+	keysOutString1 := strings.Fields(strings.TrimSpace(keysOut1.String()))[0]
+
+	if !strings.Contains(keysOutString1, keysOutString0) { // keysOutString0 is the substring (addr only)
+		t.Fatalf("keys do not match, key0: %v, key1: %v", keysOutString0, keysOutString1)
 	}
 }
 

--- a/chains/manage.go
+++ b/chains/manage.go
@@ -229,23 +229,29 @@ func CatChain(do *definitions.Do) error {
 		return fmt.Errorf("a chain name is required")
 	}
 	rootDir := path.Join(ErisContainerRoot, "chains", do.Name)
+
+	doCat := definitions.NowDo()
+	doCat.Name = do.Name
+	doCat.Operations.SkipLink = true
+
 	switch do.Type {
 	case "genesis":
-		do.Operations.Args = []string{"cat", path.Join(rootDir, "genesis.json")}
+		doCat.Operations.Args = []string{"cat", path.Join(rootDir, "genesis.json")}
 	case "config":
-		do.Operations.Args = []string{"cat", path.Join(rootDir, "config.toml")}
+		doCat.Operations.Args = []string{"cat", path.Join(rootDir, "config.toml")}
 	// TODO re-implement with eris-client ... mintinfo was remove from container (and write tests for these cmds)
 	// case "status":
-	//	do.Operations.Args = []string{"mintinfo", "--node-addr", "http://chain:46657", "status"}
+	//	doCat.Operations.Args = []string{"mintinfo", "--node-addr", "http://chain:46657", "status"}
 	// case "validators":
-	//	do.Operations.Args = []string{"mintinfo", "--node-addr", "http://chain:46657", "validators"}
+	//	doCat.Operations.Args = []string{"mintinfo", "--node-addr", "http://chain:46657", "validators"}
 	default:
 		return fmt.Errorf("unknown cat subcommand %q", do.Type)
 	}
-	do.Operations.PublishAllPorts = true
+	// edb docker image is (now) properly formulated with entrypoint && cmd
+	// so the entrypoint must be overwritten.
 	log.WithField("args", do.Operations.Args).Debug("Executing command")
 
-	buf, err := ExecChain(do)
+	buf, err := ExecChain(doCat)
 
 	if buf != nil {
 		io.Copy(config.Global.Writer, buf)

--- a/definitions/apps.go
+++ b/definitions/apps.go
@@ -1,75 +1,75 @@
 package definitions
 
-import (
-	"path"
+// import (
+// 	"path"
 
-	"github.com/eris-ltd/eris-cli/version"
-)
+// 	"github.com/eris-ltd/eris-cli/version"
+// )
 
-// [csk]: TODO: refactor what the hell we're doing here. move away from the restrictive eth app types into the larger area of play.
-// NOTE: this is currently unused.
-type AppType struct {
-	Name       string
-	BaseImage  string
-	DeployCmd  string
-	TestCmd    string
-	EntryPoint string
-	ChainTypes []string
-}
+// // [csk]: TODO: refactor what the hell we're doing here. move away from the restrictive eth app types into the larger area of play.
+// // NOTE: this is currently unused.
+// type AppType struct {
+// 	Name       string
+// 	BaseImage  string
+// 	DeployCmd  string
+// 	TestCmd    string
+// 	EntryPoint string
+// 	ChainTypes []string
+// }
 
-func AllAppTypes() map[string]*AppType {
-	apps := make(map[string]*AppType)
-	apps["epm"] = EPMApp()
-	apps["embark"] = EmbarkApp()
-	apps["sunit"] = SUnitApp()
-	apps["manual"] = GulpApp()
-	return apps
-}
+// func AllAppTypes() map[string]*AppType {
+// 	apps := make(map[string]*AppType)
+// 	apps["eris-pm"] = EPMApp()
+// 	apps["embark"] = EmbarkApp()
+// 	apps["sunit"] = SUnitApp()
+// 	apps["manual"] = GulpApp()
+// 	return apps
+// }
 
-func EPMApp() *AppType {
-	app := BlankAppType()
-	app.Name = "epm"
-	app.BaseImage = path.Join(version.DefaultRegistry, version.ImagePM)
-	app.EntryPoint = "epm --chain tcp://chain:46657 --sign http://keys:4767"
-	app.DeployCmd = ""
-	app.TestCmd = ""
-	app.ChainTypes = []string{"mint"}
-	return app
-}
+// func EPMApp() *AppType {
+// 	app := BlankAppType()
+// 	app.Name = "eris-pm"
+// 	app.BaseImage = path.Join(version.DefaultRegistry, version.ImagePM)
+// 	app.EntryPoint = "eris-pm --chain tcp://chain:46657 --sign http://keys:4767"
+// 	app.DeployCmd = ""
+// 	app.TestCmd = ""
+// 	app.ChainTypes = []string{"mint"}
+// 	return app
+// }
 
-func EmbarkApp() *AppType {
-	app := BlankAppType()
-	app.Name = "embark"
-	app.BaseImage = "quay.io/eris/embark_base"
-	app.EntryPoint = "embark"
-	app.DeployCmd = "deploy" // +blockchainname
-	app.TestCmd = "spec"
-	app.ChainTypes = []string{"eth"}
-	return app
-}
+// func EmbarkApp() *AppType {
+// 	app := BlankAppType()
+// 	app.Name = "embark"
+// 	app.BaseImage = "quay.io/eris/embark_base"
+// 	app.EntryPoint = "embark"
+// 	app.DeployCmd = "deploy" // +blockchainname
+// 	app.TestCmd = "spec"
+// 	app.ChainTypes = []string{"eth"}
+// 	return app
+// }
 
-func SUnitApp() *AppType {
-	app := BlankAppType()
-	app.Name = "sunit"
-	app.BaseImage = "quay.io/eris/sunit_base"
-	app.EntryPoint = "sunit"
-	app.DeployCmd = "nil" // n/a
-	app.TestCmd = "--coverage"
-	app.ChainTypes = []string{"mint"}
-	return app
-}
+// func SUnitApp() *AppType {
+// 	app := BlankAppType()
+// 	app.Name = "sunit"
+// 	app.BaseImage = "quay.io/eris/sunit_base"
+// 	app.EntryPoint = "sunit"
+// 	app.DeployCmd = "nil" // n/a
+// 	app.TestCmd = "--coverage"
+// 	app.ChainTypes = []string{"mint"}
+// 	return app
+// }
 
-func GulpApp() *AppType {
-	app := BlankAppType()
-	app.Name = "manual"
-	app.BaseImage = "quay.io/eris/gulp"
-	app.EntryPoint = "gulp"
-	app.DeployCmd = "" //+TASK
-	app.TestCmd = ""   //+TASK
-	app.ChainTypes = []string{"eth", "mint"}
-	return app
-}
+// func GulpApp() *AppType {
+// 	app := BlankAppType()
+// 	app.Name = "manual"
+// 	app.BaseImage = "quay.io/eris/gulp"
+// 	app.EntryPoint = "gulp"
+// 	app.DeployCmd = "" //+TASK
+// 	app.TestCmd = ""   //+TASK
+// 	app.ChainTypes = []string{"eth", "mint"}
+// 	return app
+// }
 
-func BlankAppType() *AppType {
-	return &AppType{}
-}
+// func BlankAppType() *AppType {
+// 	return &AppType{}
+// }

--- a/definitions/pkg.go
+++ b/definitions/pkg.go
@@ -21,9 +21,9 @@ type Package struct {
 	// Dependencies to be booted before the package is ran
 	Dependencies *Dependencies `mapstructure:"dependencies" json:"dependencies" yaml:"dependencies" toml:"dependencies"`
 
-	Maintainer        *Maintainer `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
-	Location          *Location   `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
-	AppType           *AppType    `json:"app_type,omitempty" yaml:"app_type,omitempty" toml:"app_type,omitempty"`
+	Maintainer *Maintainer `json:"maintainer,omitempty" yaml:"maintainer,omitempty" toml:"maintainer,omitempty"`
+	Location   *Location   `json:"location,omitempty" yaml:"location,omitempty" toml:"location,omitempty"`
+	// AppType           *AppType    `json:"app_type,omitempty" yaml:"app_type,omitempty" toml:"app_type,omitempty"`
 	Chain             *Chain
 	Srvs              []*Service
 	Operations        *Operation
@@ -42,7 +42,7 @@ func BlankPackage() *Package {
 		Dependencies: &Dependencies{},
 		Location:     BlankLocation(),
 		Operations:   BlankOperation(),
-		AppType:      BlankAppType(),
-		Chain:        BlankChain(),
+		// AppType:      BlankAppType(),
+		Chain: BlankChain(),
 	}
 }

--- a/docs/examples/how_to_make_a_service.md
+++ b/docs/examples/how_to_make_a_service.md
@@ -243,13 +243,7 @@ The output of that command should look something like this:
 ```irc
 REPOSITORY            TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
 idiservice            latest              cbe1ec579e9b        3 minutes ago       666.5 MB
-quay.io/eris/erisdb   0.11.0              f771905fcd3b        2 days ago          995.2 MB
-quay.io/eris/ipfs     latest              6e8658f9aa86        2 days ago          785.9 MB
-quay.io/eris/data     latest              11a6ba126b53        2 days ago          726.9 MB
-quay.io/eris/base     latest              53137e76ae59        2 days ago          726.9 MB
-quay.io/eris/epm      0.11.0              d7ba8273bad3        4 days ago          739.4 MB
 node                  4-onbuild           9e1063b1a9cd        11 days ago         642.6 MB
-quay.io/eris/keys     latest              7db20d196c40        11 days ago         756.7 MB
 ```
 
 Note in the above, the `REPOSITORY` field and the `TAG` field. When we build docker images, they will generally default to a `latest` in the tag field. This is what can be analogized to our "master" branch. Docker generally thinks more in terms of "channels" than in fixed versions for many of the images produced within the docker ecosystem. In other words, generally docker image maintainers treat their images like Chrome "channels" rather than Git "branches".

--- a/initialize/writers.go
+++ b/initialize/writers.go
@@ -52,9 +52,10 @@ func pullDefaultImages(images []string) error {
 			"data",
 			"keys",
 			"ipfs",
-			"erisdb",
-			"epm",
-			"eris-cm",
+			"db",
+			"cm",
+			"pm",
+			"compilers",
 		}
 	}
 
@@ -64,15 +65,10 @@ func pullDefaultImages(images []string) error {
 		"data":      config.Global.ImageData,
 		"keys":      config.Global.ImageKeys,
 		"ipfs":      config.Global.ImageIPFS,
-		"erisdb":    config.Global.ImageDB,
-		"eris-cm":   config.Global.ImageCM,
-		"epm":       config.Global.ImagePM,
+		"db":        config.Global.ImageDB,
+		"cm":        config.Global.ImageCM,
+		"pm":        config.Global.ImagePM,
 		"compilers": config.Global.ImageCompilers,
-
-		// Aliases.
-		"db": config.Global.ImageDB,
-		"cm": config.Global.ImageCM,
-		"pm": config.Global.ImagePM,
 	}
 
 	for i, image := range images {

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -17,13 +17,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Standard package commands.
-// TODO remove (consult w/ ben)
-const (
-	ErisChainStart = "run"
-	ErisChainNew   = "new"
-)
-
 // LoadChainDefinition finds the path to the chains config.toml by reading
 // from CONFIG_PATH (written in func setupChain()), and returns a chain
 // structure set accordingly, along with any errors
@@ -80,7 +73,6 @@ func ChainsAsAService(chainName string) (*definitions.ServiceDefinition, error) 
 	chain.Service.Name = chain.Name
 	chain.Service.Image = path.Join(config.Global.DefaultRegistry, config.Global.ImageDB)
 	chain.Service.AutoData = true
-	chain.Service.Command = ErisChainStart
 
 	s := &definitions.ServiceDefinition{
 		Name:         chain.Name,

--- a/perform/perform.go
+++ b/perform/perform.go
@@ -1054,7 +1054,7 @@ func configureServiceContainer(srv *def.Service, ops *def.Operation) docker.Crea
 
 			opts.Config.ExposedPorts[docker.Port(exposed)] = struct{}{}
 
-			opts.HostConfig.PortBindings[docker.Port(exposed)] = []docker.PortBinding{docker.PortBinding{
+			opts.HostConfig.PortBindings[docker.Port(exposed)] = []docker.PortBinding{{
 				HostPort: published,
 				HostIP:   ip,
 			}}

--- a/pkgs/pkgs.go
+++ b/pkgs/pkgs.go
@@ -154,7 +154,7 @@ func DefinePkgActionService(do *definitions.Do, pkg *definitions.Package) error 
 	do.Service.Name = pkg.Name + "_tmp_" + do.Name
 	do.Service.Image = path.Join(config.Global.DefaultRegistry, config.Global.ImagePM)
 	do.Service.AutoData = true
-	do.Service.EntryPoint = fmt.Sprintf("epm --chain tcp://chain:%s --sign http://keys:%s", do.ChainPort, do.KeysPort)
+	do.Service.EntryPoint = fmt.Sprintf("eris-pm --chain tcp://chain:%s --sign http://keys:%s", do.ChainPort, do.KeysPort)
 	do.Service.WorkDir = path.Join(common.ErisContainerRoot, "apps", filepath.Base(do.Path))
 	do.Service.User = "eris"
 

--- a/version/images.go
+++ b/version/images.go
@@ -12,9 +12,9 @@ var (
 
 	ImageData      = fmt.Sprintf("eris/data:%s", VERSION)
 	ImageKeys      = fmt.Sprintf("eris/keys:%s", VERSION)
-	ImageDB        = fmt.Sprintf("eris/erisdb:%s", VERSION)
-	ImagePM        = fmt.Sprintf("eris/epm:%s", VERSION)
-	ImageCM        = fmt.Sprintf("eris/eris-cm:%s", VERSION)
+	ImageDB        = fmt.Sprintf("eris/db:%s", VERSION)
+	ImagePM        = fmt.Sprintf("eris/pm:%s", VERSION)
+	ImageCM        = fmt.Sprintf("eris/cm:%s", VERSION)
 	ImageIPFS      = "eris/ipfs"
 	ImageCompilers = fmt.Sprintf("eris/compilers:%s", VERSION)
 )

--- a/version/images_arm.go
+++ b/version/images_arm.go
@@ -12,9 +12,9 @@ var (
 
 	ImageData      = fmt.Sprintf("eris/data:%s-%s", ARCH, VERSION)
 	ImageKeys      = fmt.Sprintf("eris/keys:%s-%s", ARCH, VERSION)
-	ImageDB        = fmt.Sprintf("eris/erisdb:%s-%s", ARCH, VERSION)
-	ImagePM        = fmt.Sprintf("eris/epm:%s-%s", ARCH, VERSION)
-	ImageCM        = fmt.Sprintf("eris/eris-cm:%s-%s", ARCH, VERSION)
+	ImageDB        = fmt.Sprintf("eris/db:%s-%s", ARCH, VERSION)
+	ImagePM        = fmt.Sprintf("eris/pm:%s-%s", ARCH, VERSION)
+	ImageCM        = fmt.Sprintf("eris/cm:%s-%s", ARCH, VERSION)
 	ImageCompilers = fmt.Sprintf("eris/compilers:%s-%s", ARCH, VERSION)
 	ImageIPFS      = fmt.Sprintf("eris/ipfs:%s", ARCH)
 )


### PR DESCRIPTION
this PR accompanies branch names from the rest of the stack:
- https://github.com/eris-ltd/eris-cm/pull/56
- https://github.com/eris-ltd/eris-pm/pull/238
- https://github.com/eris-ltd/eris-db/pull/318

stack conventions for docker images have updated slightly. this PR reflects the CLI side of those changes.

Changes:

* better booting of chain (harmonized against db's new boot path; using only the binary without the start script... cc @benjaminbollen @silasdavis ; see also https://github.com/eris-ltd/eris-db/issues/317 )
* apps definitions have been commented out (they should be removed shortly) (dead code)
* renaming of images per stack convention
* change epm binary to eris-pm per stack convention

**N.B.** -- rest of stack should be green on develop with the accompanying PR's *before* this is merged.