### PR TITLE
Update develop branch version.go

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -4,4 +4,4 @@ var COMMIT = "HEAD"
 
 const DOCKER_VER_MIN = "1.8.0"
 const DM_VER_MIN = "0.6.0"
-const VERSION = "0.12.0-rc3"
+const VERSION = "0.12.0-develop"


### PR DESCRIPTION
Suffix develop branch version with '-develop' to avoid pushing to 0.12.0 tag on quay before release.