### PR TITLE
Check imported directory exists

### DIFF
--- a/chains/manage.go
+++ b/chains/manage.go
@@ -106,8 +106,10 @@ func MakeChain(do *definitions.Do) error {
 	chnPath := filepath.Join(ChainsPath, do.Name)
 	doData.Source = chnPath
 	doData.Destination = path.Join(ErisContainerRoot, "chains", do.Name)
-	if err := data.ImportData(doData); err != nil {
-		return fmt.Errorf("Cannot import chain directory into container: %v", err)
+	if util.DoesDirExist(doData.Source) {
+		if err := data.ImportData(doData); err != nil {
+			return fmt.Errorf("Cannot import chain directory into container: %v", err)
+		}
 	}
 
 	buf, err := perform.DockerExecService(do.Service, do.Operations)

--- a/data/operate.go
+++ b/data/operate.go
@@ -37,6 +37,11 @@ func ImportData(do *definitions.Do) error {
 	}
 	do.Source = AbsolutePath(wd, do.Source)
 
+	// Check the source path exists.
+	if _, err := os.Stat(do.Source); err != nil {
+		return err
+	}
+
 	log.WithFields(log.Fields{
 		"from": do.Source,
 		"to":   do.Destination,

--- a/initialize/init.go
+++ b/initialize/init.go
@@ -107,20 +107,20 @@ func InitDefaults(do *definitions.Do, newDir bool) error {
 
 func checkThenInitErisRoot(force bool) (bool, error) {
 	var newDir bool
-	if force { //for testing only
+	if force {
 		log.Info("Force initializing Eris root directory")
 		if err := common.InitErisDir(); err != nil {
-			return true, fmt.Errorf("Error:\tcould not initialize the eris root directory.\n%s\n", err)
+			return true, fmt.Errorf("Could not initialize Eris root directory: %v", err)
 		}
 		return true, nil
 	}
 	if !util.DoesDirExist(common.ErisRoot) {
 		log.Warn("Eris root directory doesn't exist. The marmots will initialize it for you")
 		if err := common.InitErisDir(); err != nil {
-			return true, fmt.Errorf("Error: couldn't initialize the Eris root directory: %v", err)
+			return true, fmt.Errorf("Could not initialize Eris root directory: %v", err)
 		}
 		newDir = true
-	} else { // ErisRoot exists, prompt for overwrite
+	} else {
 		newDir = false
 	}
 	return newDir, nil

--- a/initialize/initialize_test.go
+++ b/initialize/initialize_test.go
@@ -21,8 +21,6 @@ var servDir = filepath.Join(erisDir, "services")
 var chnDir = filepath.Join(erisDir, "chains")
 var chnDefDir = filepath.Join(chnDir, "default")
 
-// TODO refactor tests
-
 func TestMain(m *testing.M) {
 	log.SetLevel(log.ErrorLevel)
 	// log.SetLevel(log.InfoLevel)
@@ -41,19 +39,21 @@ func TestInitErisRootDir(t *testing.T) {
 		ifExit(err)
 	}
 
-	for _, dir := range common.MajorDirs {
+	for _, dir := range []string{
+		common.AppsPath,
+		common.BundlesPath,
+		common.ChainsPath,
+		common.KeysPath,
+		common.RemotesPath,
+		common.ScratchPath,
+		common.ServicesPath,
+		common.KeysDataPath,
+		common.KeysNamesPath,
+	} {
 		if !util.DoesDirExist(dir) {
 			ifExit(fmt.Errorf("Could not find the %s subdirectory", dir))
 		}
 	}
-}
-
-func TestMigration(t *testing.T) {
-	//already has its own test
-}
-
-func TestPullImages(t *testing.T) {
-	//already tested by virtue of being needed for tool level tests
 }
 
 func TestDropServiceDefaults(t *testing.T) {

--- a/vendor/github.com/eris-ltd/common/go/common/dirs_and_files.go
+++ b/vendor/github.com/eris-ltd/common/go/common/dirs_and_files.go
@@ -45,69 +45,11 @@ var (
 	LllcScratchPath      = filepath.Join(LanguagesScratchPath, "lllc")
 	SolcScratchPath      = filepath.Join(LanguagesScratchPath, "sol")
 	SerpScratchPath      = filepath.Join(LanguagesScratchPath, "ser")
-
-	// Deprecated Directories (remove on 0.12 release)
-	BlockchainsPath = filepath.Join(ErisRoot, "blockchains")
-	DappsPath       = filepath.Join(ErisRoot, "dapps")
-	LanguagesPath   = filepath.Join(ErisRoot, "languages")
 )
 
-var MajorDirs = []string{
-	ErisRoot,
-	AppsPath,
-	BundlesPath,
-	ChainsPath,
-	AccountsTypePath,
-	ChainTypePath,
-	KeysPath,
-	KeysDataPath,
-	KeysNamesPath,
-	RemotesPath,
-	ScratchPath,
-	DataContainersPath,
-	LanguagesScratchPath,
-	LllcScratchPath,
-	SolcScratchPath,
-	SerpScratchPath,
-	ServicesPath,
-}
-
-// ChainsDirs to be used by specific tooling rather than eris-cli level.
-var ChainsDirs = []string{
-	ChainsPath,
-	AccountsTypePath,
-	ChainTypePath,
-}
-
-// KeysDirs to be used by specific tooling rather than eris-cli level.
-var KeysDirs = []string{
-	KeysPath,
-	KeysDataPath,
-	KeysNamesPath,
-}
-
-// ServicesDirs to be used by specific tooling rather than eris-cli level.
-var ServicesDirs = []string{
-	ServicesPath,
-}
-
-// ScratchDirs to be used by specific tooling rather than eris-cli level.
-var ScratchDirs = []string{
-	ScratchPath,
-	DataContainersPath,
-	LanguagesScratchPath,
-	LllcScratchPath,
-	SolcScratchPath,
-	SerpScratchPath,
-}
-
-// DirsToMigrate is used by the `eris update` command to check
+// DirsToMigrate is used by the `eris init` command to check
 // if old dirs exist to migrate them.
-var DirsToMigrate = map[string]string{
-	BlockchainsPath: ChainsPath,
-	DappsPath:       AppsPath,
-	LanguagesPath:   LanguagesScratchPath,
-}
+var DirsToMigrate = map[string]string{}
 
 func HomeDir() string {
 	if runtime.GOOS == "windows" {
@@ -142,6 +84,7 @@ func ChangeErisRoot(erisDir string) {
 	// Chains Directories
 	AccountsTypePath = filepath.Join(ChainsPath, "account-types")
 	ChainTypePath = filepath.Join(ChainsPath, "chain-types")
+	HEAD = filepath.Join(ChainsPath, "HEAD")
 
 	// Keys Directories
 	KeysDataPath = filepath.Join(KeysPath, "data")
@@ -189,16 +132,31 @@ func ResolveErisRoot() string {
 	return eris
 }
 
-// Create the default eris tree
+// InitErisDir creates an Eris directory hierarchy under ErisRoot dir.
 func InitErisDir() (err error) {
-	for _, d := range MajorDirs {
+	for _, d := range []string{
+		ErisRoot,
+		AppsPath,
+		BundlesPath,
+		ChainsPath,
+		AccountsTypePath,
+		ChainTypePath,
+		KeysPath,
+		KeysDataPath,
+		KeysNamesPath,
+		RemotesPath,
+		ScratchPath,
+		DataContainersPath,
+		LanguagesScratchPath,
+		LllcScratchPath,
+		SolcScratchPath,
+		SerpScratchPath,
+		ServicesPath,
+	} {
 		err := InitDataDir(d)
 		if err != nil {
 			return err
 		}
-	}
-	if _, err = os.Stat(HEAD); err != nil {
-		_, err = os.Create(HEAD)
 	}
 	return
 }


### PR DESCRIPTION
* Additional check for `data.ImportData()`.
* `common`: remove `MigrateDirs` and similar directories because they are not updated on `ChangeErisDir()`.
* `common`: update downstream (was out of date).
* Move `~/.eris/chains/HEAD` file creation into the `eris chains checkout` command.
* Fix `eris chains checkout` command to use `util.IsChain()` to determine whether a chain exists.