### PR TITLE
Check for presence of `services` directory in `~/.eris`

### DIFF
--- a/initialize/init.go
+++ b/initialize/init.go
@@ -114,7 +114,7 @@ func checkThenInitErisRoot(force bool) (bool, error) {
 		}
 		return true, nil
 	}
-	if !util.DoesDirExist(common.ErisRoot) {
+	if !util.DoesDirExist(common.ErisRoot) || !util.DoesDirExist(common.ServicesPath) {
 		log.Warn("Eris root directory doesn't exist. The marmots will initialize it for you")
 		if err := common.InitErisDir(); err != nil {
 			return true, fmt.Errorf("Could not initialize Eris root directory: %v", err)


### PR DESCRIPTION
* Check for presence of `services` directory in `~/.eris` root to determine its emptiness. 
* Fixes #971