### PR TITLE
Don't use `config.toml` on any command but `chains start`

### DIFF
--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -301,8 +301,12 @@ data_container = true
 
 	do := definitions.NowDo()
 	do.Operations.Args = []string{"fake"}
-	if err := services.StartService(do); err == nil {
-		t.Fatalf("expect start service to fail, got nil")
+	// [pv]: chain specification is ignored if do.ChainName is not set.
+	if err := services.StartService(do); err != nil {
+		t.Fatalf("expect service to start, got %v", err)
+	}
+	if !util.Running(definitions.TypeService, "fake") {
+		t.Fatalf("expecting fake service running")
 	}
 }
 
@@ -345,17 +349,8 @@ image = "`+path.Join(config.Global.DefaultRegistry, config.Global.ImageIPFS)+`"
 	do.Operations.Args = []string{"fake"}
 	do.ChainName = "non-existent-chain"
 
-	// [pv]: is this a bug? the service which doesn't have a
-	// "chain" in its definition file doesn't care about linking at all.
-	if err := services.StartService(do); err != nil {
-		t.Fatalf("expect service to start, got %v", err)
-	}
-
-	if !util.Running(definitions.TypeService, "fake") {
-		t.Fatalf("expecting fake service running")
-	}
-	if util.Exists(definitions.TypeData, "fake") {
-		t.Fatalf("expecting fake data container doesn't exist")
+	if err := services.StartService(do); err == nil {
+		t.Fatalf("expect service start to fail")
 	}
 }
 

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -121,7 +121,7 @@ func testCheckChainDirsExist(chains []string, yes bool, t *testing.T) {
 			if util.DoesDirExist(filepath.Join(common.ChainsPath, chn)) {
 				t.Fatalf("chain directory exists when it shouldn't")
 			}
-			_, err := loaders.LoadChainDefinition(chn)
+			_, err := loaders.LoadChainDefinition(chn, filepath.Join(common.ChainsPath, chn, "config.toml"))
 			if err == nil {
 				t.Fatalf("no error loading chain def that shouldn't exist")
 			}

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -303,6 +303,7 @@ func addChainsFlags() {
 	buildFlag(chainsStart, do, "ports", "chain")
 	buildFlag(chainsStart, do, "env", "chain")
 	buildFlag(chainsStart, do, "links", "chain")
+	chainsStart.PersistentFlags().BoolVarP(&do.Force, "force", "f", false, "force reinitialize the chain")
 	chainsStart.PersistentFlags().BoolVarP(&do.Logrotate, "logrotate", "z", false, "turn on logrotate as a dependency to handle long output")
 
 	buildFlag(chainsLogs, do, "follow", "chain")

--- a/services/services.go
+++ b/services/services.go
@@ -58,9 +58,11 @@ func StartService(do *definitions.Do) (err error) {
 		// Spacer.
 		log.Debug()
 	}
-	services, err = BuildChainGroup(do.ChainName, services)
-	if err != nil {
-		return err
+	if do.ChainName != "" {
+		services, err = BuildChainGroup(do.ChainName, services)
+		if err != nil {
+			return err
+		}
 	}
 	log.Debug("Checking services after build chain")
 	for _, s := range services {
@@ -206,6 +208,9 @@ func StartGroup(group []*definitions.ServiceDefinition) error {
 // Service defs which don't specify a chain or $chain won't connect to a chain.
 // NOTE: chains have to be started before services that depend on them.
 func BuildChainGroup(chainName string, services []*definitions.ServiceDefinition) (servicesAndChains []*definitions.ServiceDefinition, err error) {
+	if !util.IsChain(chainName, true) {
+		return nil, fmt.Errorf("Dependent chain %v is not running", chainName)
+	}
 	var chains = make(map[string]*definitions.ServiceDefinition)
 	for _, srv := range services {
 		if srv.Chain != "" {

--- a/util/migrate_dirs.go
+++ b/util/migrate_dirs.go
@@ -141,14 +141,3 @@ func checkFileNamesAndMigrate(depDir, newDir string) error {
 	}
 	return nil
 }
-
-func DoesDirExist(dir string) bool {
-	f, err := os.Stat(dir)
-	if err != nil {
-		return false
-	}
-	if !f.IsDir() {
-		return false
-	}
-	return true
-}

--- a/util/paths.go
+++ b/util/paths.go
@@ -231,3 +231,25 @@ func Tilde(path string) string {
 	}
 	return path
 }
+
+// DoesDirExist returns true if the directory exists and readable,
+// otherwise false.
+func DoesDirExist(dir string) bool {
+	f, err := os.Stat(dir)
+	if err != nil {
+		return false
+	}
+	if !f.IsDir() {
+		return false
+	}
+	return true
+}
+
+// DoesFileExist returns true if the file exists and readable,
+// otherwise false.
+func DoesFileExist(file string) bool {
+	if _, err := os.Stat(file); err != nil {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
* Allow specifying arbitrary directories for `eris chains start --init-dir` command. Closes #991.
* Omitted `--init-dir` flag for the `eris chains start` command equals `$ERIS/chains/CHAIN_NAME`.
* Extra checks for starting services with dependent chains to avoid spurious Docker errors (dependent chains should be running).