### PR TITLE
Fix imported keys ownership on `eris chains start` command

### DIFF
--- a/chains/make.go
+++ b/chains/make.go
@@ -12,6 +12,7 @@ import (
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/log"
 	"github.com/eris-ltd/eris-cli/perform"
+	"github.com/eris-ltd/eris-cli/services"
 	"github.com/eris-ltd/eris-cli/util"
 
 	"github.com/eris-ltd/common/go/common"
@@ -34,7 +35,9 @@ import (
 //  do.Debug         - debug output (optional)
 //
 func MakeChain(do *definitions.Do) error {
-	if err := checkKeysRunningOrStart(); err != nil {
+	doKeys := definitions.NowDo()
+	doKeys.Name = "keys"
+	if err := services.EnsureRunning(doKeys); err != nil {
 		return err
 	}
 

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -99,15 +99,9 @@ func ConnectToAChain(srv *definitions.Service, ops *definitions.Operation, name,
 // in the chain structure. Returns config read errors.
 func MarshalChainDefinition(definition *viper.Viper, chain *definitions.ChainDefinition) error {
 	log.Debug("Marshalling chain")
-	chnTemp := definitions.BlankChainDefinition()
 
-	if err := definition.Unmarshal(chnTemp); err != nil {
+	if err := definition.Unmarshal(chain); err != nil {
 		return fmt.Errorf("The marmots coult not read the chain definition: %v", err)
-	}
-
-	util.Merge(chain.Service, chnTemp.Service)
-	if len(chnTemp.Service.Ports) != 0 {
-		chain.Service.Ports = chnTemp.Service.Ports
 	}
 
 	// toml bools don't really marshal well "data_container". It can be

--- a/loaders/loaders_test.go
+++ b/loaders/loaders_test.go
@@ -50,6 +50,9 @@ name           = "random name"
 image          = "test image"
 data_container = true
 ports          = [ "1234" ]
+
+[dependencies]
+services       = [ "keys" ]
 `
 	)
 
@@ -76,6 +79,8 @@ ports          = [ "1234" ]
 		{`Service.AutoData`, d.Service.AutoData, true},
 		{`Service.Image`, d.Service.Image, "test image"},
 		{`Service.Ports`, d.Service.Ports, []string{"1234"}},
+
+		{`Dependencies`, d.Dependencies.Services, []string{"keys"}},
 	} {
 		if !reflect.DeepEqual(entry.a, entry.b) {
 			t.Fatalf("marshalled definition expected %s = %#v, got %#v", entry.name, entry.b, entry.a)

--- a/services/services.go
+++ b/services/services.go
@@ -131,6 +131,9 @@ func ExecService(do *definitions.Do) (buf *bytes.Buffer, err error) {
 	}
 
 	util.Merge(service.Operations, do.Operations)
+	if do.Service.User != "" {
+		service.Service.User = do.Service.User
+	}
 
 	// Get the main service container name, check if it's running.
 	main := util.ServiceContainerName(do.Name)
@@ -264,7 +267,7 @@ func EnsureRunning(do *definitions.Do) error {
 	}
 
 	if !util.IsService(do.Name, true) {
-		log.WithField("=>", do.Name).Warn("Starting service")
+		log.WithField("=>", do.Name).Info("Starting service")
 		do.Operations.Args = []string{do.Name}
 		StartService(do)
 	} else {


### PR DESCRIPTION
* Fix key ownership on `eris chains start` command. Closes #1052.

```
$ eris chains make simplechain
$ eris services rm -xf keys
$ eris chains start simplechain
$ eris services exec keys -- ls -la /home/eris/.eris/keys/data
total 12
drwxr-sr-x 3 eris eris 4096 Nov  1 05:07 .
drwxr-sr-x 4 eris eris 4096 Aug 19 03:53 ..
drwx--S--- 2 eris eris 4096 Nov  1 05:07 9900DE3C16C1D92867FC1D3D6F06386FF8952035

$ eris clean -y
$ eris chains start simplechain
$ eris chains start --force simplechain
$ eris services exec keys -- ls -la /home/eris/.eris/keys/data
total 12
drwxr-sr-x 3 eris eris 4096 Nov  1 05:07 .
drwxr-sr-x 4 eris eris 4096 Aug 19 03:53 ..
drwx--S--- 2 eris eris 4096 Nov  1 05:07 9900DE3C16C1D92867FC1D3D6F06386FF8952035
```
* Fix chain dependencies not loading on `LoadChainDefinition` + test.