### PR TITLE
Fix `chains make --known` command not writing `genesis.json`

### DIFF
--- a/chains/make.go
+++ b/chains/make.go
@@ -44,6 +44,7 @@ func MakeChain(do *definitions.Do) error {
 	do.Service.User = "eris"
 	do.Service.AutoData = true
 	do.Service.Links = []string{fmt.Sprintf("%s:%s", util.ServiceContainerName("keys"), "keys")}
+	do.Service.DNS = []string{"8.8.8.8", "8.8.4.4"}
 	do.Service.Environment = []string{
 		fmt.Sprintf("ERIS_KEYS_PATH=http://keys:%d", 4767), // note, needs to be made aware of keys port...
 		fmt.Sprintf("ERIS_CHAINMANAGER_ACCOUNTTYPES=%s", strings.Join(do.AccountTypes, ",")),

--- a/perform/perform.go
+++ b/perform/perform.go
@@ -890,8 +890,6 @@ func logsContainer(id string, follow bool, tail string) error {
 		Since:        0,
 		Timestamps:   false,
 		Tail:         tail,
-
-		RawTerminal: true, // Usually true when the container contains a TTY.
 	}
 
 	if err := util.DockerClient.Logs(opts); err != nil {

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -77,7 +77,7 @@ func TestRunDataSimple(t *testing.T) {
 		t.Fatalf("expected data container created, got %v", err)
 	}
 
-	ops.Args = strings.Fields("uptime")
+	ops.Args = strings.Fields("bash -c true")
 	if _, err := DockerRunData(ops, nil); err != nil {
 		t.Fatalf("expected data successfully run, got %v", err)
 	}


### PR DESCRIPTION
* Fix `chains make --known` command not writing the `genesis.json` file in the chain directory. Fixes #1039.
* Explicitly set container DNS servers. Fixes #762.
* Fix spurious characters on `logs` commands. 