### PR TITLE
chains make: warn users if no validators created

### DIFF
--- a/chains/make.go
+++ b/chains/make.go
@@ -3,6 +3,8 @@ package chains
 import (
 	"fmt"
 	"path"
+	"strconv"
+	"strings"
 
 	"github.com/eris-ltd/eris-cli/config"
 	"github.com/eris-ltd/eris-cli/definitions"
@@ -34,6 +36,7 @@ import (
 //  do.Debug         - debug output (optional)
 //
 func MakeChain(do *definitions.Do) error {
+
 	doKeys := definitions.NowDo()
 	doKeys.Name = "keys"
 	if err := services.EnsureRunning(doKeys); err != nil {
@@ -89,5 +92,30 @@ func MakeChain(do *definitions.Do) error {
 		}
 	}
 
+	// put at end so users see it after any verbose/debug logs
+	numberOfValidators, err := checkNumberValidators(do.AccountTypes)
+	if err != nil {
+		return err
+	}
+	if numberOfValidators == 0 {
+		log.Warn("WARNING: The chain made did not contain account types (Full/Validator) with validator permissions and will require further modification to run. The marmots recommend making a chain with Full/Validator account types")
+	}
+
 	return nil
+}
+
+func checkNumberValidators(accountTypes []string) (int, error) {
+	var num int = 0
+	var err error
+	for _, accT := range accountTypes {
+		accounts := strings.Split(accT, ":")
+		if accounts[0] == "Full" || accounts[0] == "Validator" {
+			num, err = strconv.Atoi(accounts[1])
+			if err != nil {
+				return -1, err
+			}
+			num += num
+		}
+	}
+	return num, nil
 }

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -373,6 +373,7 @@ func MakeChain(cmd *cobra.Command, args []string) {
 
 	do.Name = args[0]
 
+	// TODO clean up this logic
 	if do.Known && (do.ChainMakeActs == "" || do.ChainMakeVals == "") {
 		cmd.Help()
 		util.IfExit(fmt.Errorf("If you are using the --known flag the --validators *and* the --accounts flags are both required"))
@@ -395,10 +396,7 @@ func MakeChain(cmd *cobra.Command, args []string) {
 	}
 
 	if do.Wizard {
-		// TODO fix
-		config.Global.InteractiveWriter = os.Stdout
-		config.Global.InteractiveErrorWriter = os.Stderr
-		do.Operations.Terminal = true
+		// TODO ... something ... ?
 	} else if len(do.AccountTypes) == 0 && do.ChainType == "" && do.ChainMakeActs == "" && do.ChainMakeVals == "" {
 		// no flags given assume simplechain
 		do.ChainType = "simplechain"

--- a/maker/maker.go
+++ b/maker/maker.go
@@ -268,6 +268,7 @@ func assembleTypesFlags(accountT []*definitions.ErisDBAccountType, do *definitio
 
 			// If the number of account types is missing,
 			// assuming 1.
+			// [zr] this should throw an error ... (bad user input)
 			num int = 1
 		)
 		if len(tmp) > 1 {

--- a/maker/maker.go
+++ b/maker/maker.go
@@ -268,7 +268,6 @@ func assembleTypesFlags(accountT []*definitions.ErisDBAccountType, do *definitio
 
 			// If the number of account types is missing,
 			// assuming 1.
-			// [zr] this should throw an error ... (bad user input)
 			num int = 1
 		)
 		if len(tmp) > 1 {


### PR DESCRIPTION
- closes #1012
- applies only to the `--account-types` flag. If we wanted to get fancy, we could check the `--chain-type` but I think it's safe to assume that users writing their own will know what they're doing.