### PR TITLE
chains make default: add more chain-types other than simplechain

### DIFF
--- a/definitions/chain_types.go
+++ b/definitions/chain_types.go
@@ -5,9 +5,9 @@ type ChainType struct {
 	AccountTypes map[string]int `mapstructure:"account_types" json:"account_types" yaml:"account_types" toml:"account_types"`
 
 	// currently unused
-	ConsensusEngine    map[string]string `mapstructure:"consensus" json:"consensus" yaml:"consensus" toml:"consensus"`
-	ApplicationManager map[string]string `mapstructure:"manager" json:"manager" yaml:"manager" toml:"manager"`
-	Messenger          map[string]string `mapstructure:"messenger" json:"messenger" yaml:"messenger" toml:"messenger"`
+	ConsensusEngine    map[string]string `mapstructure:"tendermint" json:"tendermint" yaml:"tendermint" toml:"tendermint"`
+	ApplicationManager map[string]string `mapstructure:"erismint" json:"erismint" yaml:"erismint" toml:"erismint"`
+	Messenger          map[string]string `mapstructure:"servers" json:"servers" yaml:"servers" toml:"servers"`
 }
 
 func BlankChainType() *ChainType {

--- a/initialize/default_account_types.go
+++ b/initialize/default_account_types.go
@@ -2,35 +2,6 @@ package initialize
 
 // TODO [zr] use templates
 
-func defaultSimpleChainType() string {
-	return `
-# This is a TOML config file.
-# For more information, see https://github.com/toml-lang/toml
-
-name = "simplechain"
-
-definition = """
-A simple chain type will build a single node chain. This chain type is useful
-for quick and easy prototyping. It should not be used for anything more than
-the most simple prototyping as it only has one node and the keys to that node
-could get lost or compromised and the chain would thereafter become useless.
-"""
-
-[account_types]
-Full = 1
-Developer = 0
-Participant = 0
-Root = 0
-Validator = 0
-
-[messenger]
-
-[manager]
-
-[consensus]
-`
-}
-
 func defaultDeveloperAccountType() string {
 	return `
 # This is a TOML config file.

--- a/initialize/default_chain_types.go
+++ b/initialize/default_chain_types.go
@@ -1,0 +1,134 @@
+package initialize
+
+func defaultSimpleChainType() string {
+	return `
+# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+name = "simplechain"
+
+definition = """
+A simple chain type will build a single node chain. This chain type is useful
+for quick and easy prototyping. It should not be used for anything more than
+the most simple prototyping as it only has one node and the keys to that node
+could get lost or compromised and the chain would thereafter become useless.
+"""
+
+[account_types]
+Full = 1
+Developer = 0
+Participant = 0
+Root = 0
+Validator = 0
+
+[messenger]
+
+[manager]
+
+[consensus]
+`
+}
+
+func defaultAdminChainType() string {
+	return `
+# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+name = "adminchain"
+
+definition = """
+An adminchain type has settings for prototyping a larger chain from a sysadmin point of view. With four Validator and three Full account_types, at minimum of five nodes must be up for consensus to happen.
+"""
+
+[account_types]
+Full = 3
+Developer = 1
+Participant = 1
+Root = 1
+Validator = 4
+
+[messenger]
+
+[manager]
+
+[consensus]
+`
+}
+
+func defaultDemoChainType() string {
+	return `
+# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+name = "demochain"
+
+definition = """
+A demochain type has one node for setting up a simplechain but comes with additional Developer and Participant accounts for demonstrating a typical application. Use for prototyping only.
+"""
+
+[account_types]
+Full = 1
+Developer = 5
+Participant = 5
+Root = 0
+Validator = 0
+
+[messenger]
+
+[manager]
+
+[consensus]
+`
+}
+
+func defaultGoChainType() string {
+	return `
+# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+name = "gochain"
+
+definition = """
+A gochain type will build a three node chain. It is a quick andeasy way to get started with a multi-validator chain. The Full account_type includes validator and deploy permissions, allowing for experimentation with setting up a chain and halting it by taking down a single node. Use for prototyping only.
+"""
+
+[account_types]
+Full = 3
+Developer = 0
+Participant = 0
+Root = 0
+Validator = 0
+
+[messenger]
+
+[manager]
+
+[consensus]
+`
+}
+
+func defaultSprawlChainType() string {
+	return `
+# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+name = "sprawlchain"
+
+definition = """
+A sprawlchain type has a little bit of everything. Modify as necessary for your ecosystem application. Will tolerate three nodes down.
+"""
+
+[account_types]
+Full = 5
+Developer = 10
+Participant = 20 
+Root = 3
+Validator = 5
+
+[messenger]
+
+[manager]
+
+[consensus]
+`
+}

--- a/initialize/default_chain_types.go
+++ b/initialize/default_chain_types.go
@@ -21,11 +21,11 @@ Participant = 0
 Root = 0
 Validator = 0
 
-[messenger]
+[servers]
 
-[manager]
+[erismint]
 
-[consensus]
+[tendermint]
 `
 }
 
@@ -37,7 +37,7 @@ func defaultAdminChainType() string {
 name = "adminchain"
 
 definition = """
-An adminchain type has settings for prototyping a larger chain from a sysadmin point of view. With four Validator and three Full account_types, at minimum of five nodes must be up for consensus to happen.
+An adminchain type has settings for prototyping a larger chain from a sysadmin point of view. With four Validator and three Full account_types, at minimum of five nodes must be up for consensus to happen. This account combination is what we use to test long running chains on our CI system.
 """
 
 [account_types]
@@ -47,11 +47,11 @@ Participant = 1
 Root = 1
 Validator = 4
 
-[messenger]
+[servers]
 
-[manager]
+[erismint]
 
-[consensus]
+[tendermint]
 `
 }
 
@@ -63,21 +63,21 @@ func defaultDemoChainType() string {
 name = "demochain"
 
 definition = """
-A demochain type has one node for setting up a simplechain but comes with additional Developer and Participant accounts for demonstrating a typical application. Use for prototyping only.
+A demo chain is useful for setting up proof of concept demonstration chains. It is a quick and easy way to have multi-validator, multi-developer, multi-participant chains set up for your application. This chain will tolerate 2 validators becoming byzantine or going off-line while still moving forward. You should utilize 7 different cloud instances and deploy one of the validator chain directories to each.
 """
 
 [account_types]
-Full = 1
+Full = 0
 Developer = 5
-Participant = 5
-Root = 0
-Validator = 0
+Participant = 20
+Root = 3
+Validator = 7
 
-[messenger]
+[servers]
 
-[manager]
+[erismint]
 
-[consensus]
+[tendermint]
 `
 }
 
@@ -89,21 +89,21 @@ func defaultGoChainType() string {
 name = "gochain"
 
 definition = """
-A gochain type will build a three node chain. It is a quick andeasy way to get started with a multi-validator chain. The Full account_type includes validator and deploy permissions, allowing for experimentation with setting up a chain and halting it by taking down a single node. Use for prototyping only.
+A gochain type will build a three node chain. It is a quick and easy way to get started with a multi-validator chain. The Full account_type includes validator and deploy permissions, allowing for experimentation with setting up a chain and halting it by taking down a single node. This Full account should be deployed on your local machine and cloud nodes should have only Validator accounts. Use for prototyping only.
 """
 
 [account_types]
-Full = 3
+Full = 1
 Developer = 0
 Participant = 0
 Root = 0
-Validator = 0
+Validator = 2
 
-[messenger]
+[servers]
 
-[manager]
+[erismint]
 
-[consensus]
+[tendermint]
 `
 }
 
@@ -115,20 +115,20 @@ func defaultSprawlChainType() string {
 name = "sprawlchain"
 
 definition = """
-A sprawlchain type has a little bit of everything. Modify as necessary for your ecosystem application. Will tolerate three nodes down.
+A sprawlchain type has a little bit of everything. Modify as necessary for your ecosystem application. Will tolerate three nodes down. As with other chains, Validator accounts ought to go on cloud. No Full accounts are provided since these are prefered for quick development only.
 """
 
 [account_types]
-Full = 5
+Full = 0
 Developer = 10
 Participant = 20 
 Root = 3
-Validator = 5
+Validator = 10
 
-[messenger]
+[servers]
 
-[manager]
+[erismint]
 
-[consensus]
+[tendermint]
 `
 }

--- a/initialize/initialize.go
+++ b/initialize/initialize.go
@@ -141,6 +141,18 @@ func dropAccountAndChainTypeDefaults() error {
 	if err := writeDefaultFile(config.ChainTypePath, "simplechain.toml", defaultSimpleChainType); err != nil {
 		return err
 	}
+	if err := writeDefaultFile(config.ChainTypePath, "adminchain.toml", defaultAdminChainType); err != nil {
+		return err
+	}
+	if err := writeDefaultFile(config.ChainTypePath, "demochain.toml", defaultDemoChainType); err != nil {
+		return err
+	}
+	if err := writeDefaultFile(config.ChainTypePath, "gochain.toml", defaultGoChainType); err != nil {
+		return err
+	}
+	if err := writeDefaultFile(config.ChainTypePath, "sprawlchain.toml", defaultSprawlChainType); err != nil {
+		return err
+	}
 
 	// account-types
 	if err := writeDefaultFile(config.AccountsTypePath, "developer.toml", defaultDeveloperAccountType); err != nil {


### PR DESCRIPTION
- closes #931 and replaces https://github.com/eris-ltd/eris-cm/pull/66
- adds several `*.toml` files in `~/.eris/chain/chain-types` for consumption by the `eris chains make --chain-type` flag
- these will become templates in #1003 