### PR TITLE
chains make: seeds-ip flag to populate config.toml

### DIFF
--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -288,7 +288,7 @@ func addChainsFlags() {
 	chainsMake.PersistentFlags().StringVarP(&do.ChainMakeActs, "accounts", "", "", "comma separated list of the accounts.csv files you would like to utilize (requires --known flag)")
 	chainsMake.PersistentFlags().StringVarP(&do.ChainMakeVals, "validators", "", "", "comma separated list of the validators.csv files you would like to utilize (requires --known flag)")
 	chainsMake.PersistentFlags().BoolVarP(&do.Wizard, "wizard", "w", false, "summon the interactive chain making wizard")
-	chainsMake.PersistentFlags().StringSliceVarP(&do.SeedsIP, "seeds-ip", "", []string{}, "set the seed IP:PORT for the root node. all other nodes will attempt to join at this IP") // [zr] limited to only one IP for the time being.
+	chainsMake.PersistentFlags().StringSliceVarP(&do.SeedsIP, "seeds-ip", "", []string{}, "set a list of seeds (e.g. IP:PORT,IP:PORT) for peers to join the chain")
 
 	chainsNew.PersistentFlags().StringVarP(&do.Path, "dir", "", "", "a directory whose contents should be copied into the chain's main dir")
 	buildFlag(chainsNew, do, "publish", "chain")
@@ -373,11 +373,6 @@ func MakeChain(cmd *cobra.Command, args []string) {
 	util.IfExit(ArgCheck(1, "eq", cmd, args))
 
 	do.Name = args[0]
-
-	// maybe we want to expose this in the chain-type files <=> marmont
-	if len(do.SeedsIP) > 1 {
-		util.IfExit(fmt.Errorf("Only one IP:PORT can be provided for the time being"))
-	}
 
 	// TODO clean up this logic
 	if do.Known && (do.ChainMakeActs == "" || do.ChainMakeVals == "") {

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -288,6 +288,7 @@ func addChainsFlags() {
 	chainsMake.PersistentFlags().StringVarP(&do.ChainMakeActs, "accounts", "", "", "comma separated list of the accounts.csv files you would like to utilize (requires --known flag)")
 	chainsMake.PersistentFlags().StringVarP(&do.ChainMakeVals, "validators", "", "", "comma separated list of the validators.csv files you would like to utilize (requires --known flag)")
 	chainsMake.PersistentFlags().BoolVarP(&do.Wizard, "wizard", "w", false, "summon the interactive chain making wizard")
+	chainsMake.PersistentFlags().StringSliceVarP(&do.SeedsIP, "seeds-ip", "", []string{}, "set the seed IP:PORT for the root node. all other nodes will attempt to join at this IP") // [zr] limited to only one IP for the time being.
 
 	chainsNew.PersistentFlags().StringVarP(&do.Path, "dir", "", "", "a directory whose contents should be copied into the chain's main dir")
 	buildFlag(chainsNew, do, "publish", "chain")
@@ -372,6 +373,11 @@ func MakeChain(cmd *cobra.Command, args []string) {
 	util.IfExit(ArgCheck(1, "eq", cmd, args))
 
 	do.Name = args[0]
+
+	// maybe we want to expose this in the chain-type files <=> marmont
+	if len(do.SeedsIP) > 1 {
+		util.IfExit(fmt.Errorf("Only one IP:PORT can be provided for the time being"))
+	}
 
 	// TODO clean up this logic
 	if do.Known && (do.ChainMakeActs == "" || do.ChainMakeVals == "") {

--- a/definitions/do.go
+++ b/definitions/do.go
@@ -63,6 +63,7 @@ type Do struct {
 	DefaultAmount string   `mapstructure:"," json:"," yaml:"," toml:","`
 	ChainMakeActs string   `mapstructure:"," json:"," yaml:"," toml:","`
 	ChainMakeVals string   `mapstructure:"," json:"," yaml:"," toml:","`
+	SeedsIP       []string `mapstructure:"," json:"," yaml:"," toml:","`
 	ServicesSlice []string `mapstructure:"," json:"," yaml:"," toml:","`
 	ImagesSlice   []string `mapstructure:"," json:"," yaml:"," toml:","`
 	ConfigOpts    []string `mapstructure:"," json:"," yaml:"," toml:","`

--- a/maker/erisdb_chains.go
+++ b/maker/erisdb_chains.go
@@ -1,12 +1,14 @@
 package maker
 
 import (
+	"strings"
+
 	"github.com/eris-ltd/eris-cli/definitions"
 	"github.com/eris-ltd/eris-cli/log"
 	"github.com/eris-ltd/eris-cli/util"
 )
 
-func MakeErisDBChain(name string, accounts []*definitions.ErisDBAccount, chainImageName string,
+func MakeErisDBChain(name string, seeds []string, accounts []*definitions.ErisDBAccount, chainImageName string,
 	useDataContainer bool, exportedPorts []string, containerEntrypoint string) error {
 	genesis := definitions.BlankGenesis()
 	genesis.ChainID = name
@@ -36,9 +38,10 @@ func MakeErisDBChain(name string, accounts []*definitions.ErisDBAccount, chainIm
 		// TODO: [ben] we can expose seeds to be written into the configuration file
 		// here, but currently not used and we'll overwrite the configuration file
 		// with flag or environment variable in eris-db container
-		// [zr] to be implemented in #1007
-		if err := util.WriteConfigurationFile(genesis.ChainID, account.Name, "", chainImageName,
-			useDataContainer, exportedPorts, containerEntrypoint); err != nil {
+		theSeeds := strings.Join(seeds, ",") // format for config file (if len>1)
+		if err := util.WriteConfigurationFile(genesis.ChainID, account.Name, theSeeds,
+			len(accounts) == 1, chainImageName, useDataContainer, exportedPorts,
+			containerEntrypoint); err != nil {
 			return err
 		}
 	}

--- a/maker/maker.go
+++ b/maker/maker.go
@@ -105,7 +105,7 @@ func maker(do *definitions.Do, consensus_type string, accountTypes []*definition
 		return err
 	}
 
-	return MakeErisDBChain(do.Name, do.Accounts, do.ChainImageName,
+	return MakeErisDBChain(do.Name, do.SeedsIP, do.Accounts, do.ChainImageName,
 		do.UseDataContainer, do.ExportedPorts, do.ContainerEntrypoint)
 }
 


### PR DESCRIPTION
- closes #1007, replaces https://github.com/eris-ltd/eris-cm/pull/52
- `eris chains make someChain --seeds-ip-145.65.2.14:46656` will populate the `config.toml`; works on complex chains as well
- limited to one IP:PORT pending discussion.
- in the future, we may want to expose this functionality in the chain-type definition files.

